### PR TITLE
Fix Singapore address validation fallback and add tests

### DIFF
--- a/backend/app/utils/validators.py
+++ b/backend/app/utils/validators.py
@@ -42,8 +42,8 @@ def validate_singapore_address(address: str) -> bool:
     for pattern in patterns:
         if re.search(pattern, address):
             return True
-    
-    return True
+
+    return False
 
 
 def validate_postal_code(postal_code: str) -> bool:

--- a/backend/tests/test_utils/test_validators.py
+++ b/backend/tests/test_utils/test_validators.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+BACKEND_ROOT = str(Path(__file__).resolve().parents[2])
+
+if BACKEND_ROOT not in sys.path:
+    sys.path.append(BACKEND_ROOT)
+
+from app.utils.validators import validate_singapore_address
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "Not an address",
+        "123 Fake Street",
+        "",  # Already handled by length check
+        "     ",
+    ],
+)
+def test_validate_singapore_address_rejects_invalid_inputs(address: str) -> None:
+    assert validate_singapore_address(address) is False
+
+
+def test_validate_singapore_address_accepts_valid_input() -> None:
+    assert (
+        validate_singapore_address(
+            "10 ANSON ROAD #10-01 INTERNATIONAL PLAZA SINGAPORE 079903"
+        )
+        is True
+    )


### PR DESCRIPTION
## Summary
- ensure `validate_singapore_address` returns `False` when none of the known patterns match
- add unit tests covering invalid address inputs and a valid Singapore address

## Testing
- pytest --override-ini addopts="" tests/test_utils/test_validators.py

------
https://chatgpt.com/codex/tasks/task_e_68cfe5a4bd608320a13796bfe8cb8798