### PR TITLE
Expose SQLAlchemy Base from models package

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,8 @@
+"""Model package exports."""
+
+from .base import Base  # noqa: F401
+
+# Import model modules so their metadata is registered with SQLAlchemy.
+from . import rkp  # noqa: F401  pylint: disable=unused-import
+
+__all__ = ["Base"]


### PR DESCRIPTION
## Summary
- import Base into the models package so `from app.models import Base` works
- ensure the RKP model module is imported so its metadata is registered with SQLAlchemy

## Testing
- PYTHONPATH=$(pwd) alembic upgrade head --sql

------
https://chatgpt.com/codex/tasks/task_e_68cfe5a327d883208a7d87bd8fd4d6a0