### PR TITLE
Add feasibility wizard UI and custom router

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,114 +1,136 @@
-import { useState, useEffect } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { Link } from './router'
 
 interface HealthStatus {
-  status: string;
-  service: string;
+  status: string
+  service: string
 }
 
 function App() {
-  const [healthStatus, setHealthStatus] = useState<HealthStatus | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [healthStatus, setHealthStatus] = useState<HealthStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
-  const rawBaseUrl = import.meta.env.VITE_API_BASE_URL ?? '/';
-  const resolvedBaseUrl = React.useMemo<URL | null>(() => {
+  const rawBaseUrl = import.meta.env.VITE_API_BASE_URL ?? '/'
+  const resolvedBaseUrl = useMemo<URL | null>(() => {
     if (typeof window === 'undefined') {
-      return null;
+      return null
     }
 
     try {
-      return new URL(rawBaseUrl, window.location.origin);
+      return new URL(rawBaseUrl, window.location.origin)
     } catch (err) {
-      console.error('Invalid VITE_API_BASE_URL, falling back to window.location.origin', err);
-      return new URL(window.location.origin);
+      console.error('Invalid VITE_API_BASE_URL, falling back to window.location.origin', err)
+      return new URL(window.location.origin)
     }
-  }, [rawBaseUrl]);
+  }, [rawBaseUrl])
 
-  const buildApiUrl = React.useCallback(
+  const buildApiUrl = useCallback(
     (path: string) => {
       if (!resolvedBaseUrl) {
-        return path;
+        return path
       }
 
-      return new URL(path, resolvedBaseUrl).toString();
+      return new URL(path, resolvedBaseUrl).toString()
     },
-    [resolvedBaseUrl]
-  );
+    [resolvedBaseUrl],
+  )
 
   useEffect(() => {
     const checkHealth = async () => {
       try {
-        const response = await fetch(buildApiUrl('health'));
+        const response = await fetch(buildApiUrl('health'))
         if (response.ok) {
-          const data = await response.json();
-          setHealthStatus(data);
+          const data = await response.json()
+          setHealthStatus(data)
         } else {
-          setError('Backend not responding');
+          setError('Backend not responding')
         }
       } catch (err) {
-        setError('Cannot connect to backend');
+        setError('Cannot connect to backend')
       } finally {
-        setLoading(false);
+        setLoading(false)
       }
-    };
+    }
 
-    checkHealth();
-  }, [buildApiUrl]);
+    checkHealth()
+  }, [buildApiUrl])
 
   return (
-    <div style={{ 
-      padding: '40px', 
-      fontFamily: 'Arial, sans-serif',
-      maxWidth: '800px',
-      margin: '0 auto'
-    }}>
-      <h1 style={{ color: '#2563eb', marginBottom: '20px' }}>
-        🏗️ Building Compliance Platform
-      </h1>
-      
-      <div style={{ 
-        background: '#f8fafc', 
-        padding: '20px', 
-        borderRadius: '8px',
-        marginBottom: '20px'
-      }}>
-        <h2>System Status</h2>
-        {loading && <p>Checking backend connection...</p>}
-        {error && <p style={{ color: 'red' }}>❌ {error}</p>}
+    <div className="app-shell">
+      <header className="app-shell__header">
+        <h1>Optimal Build Studio</h1>
+        <p>
+          Explore automated compliance insights, land intelligence and feasibility analysis for
+          Singapore developments.
+        </p>
+      </header>
+
+      <nav className="app-shell__nav">
+        <Link className="app-shell__nav-link" to="/feasibility">
+          Launch feasibility wizard
+        </Link>
+        <a
+          className="app-shell__nav-link"
+          href={buildApiUrl('docs')}
+          target="_blank"
+          rel="noreferrer"
+        >
+          View API reference
+        </a>
+      </nav>
+
+      <section className="app-shell__section">
+        <h2>System status</h2>
+        {loading && <p>Checking backend connection…</p>}
+        {error && <p style={{ color: '#b91c1c' }}>❌ {error}</p>}
         {healthStatus && (
-          <p style={{ color: 'green' }}>
+          <p style={{ color: '#15803d' }}>
             ✅ Backend Status: {healthStatus.status} ({healthStatus.service})
           </p>
         )}
-      </div>
+      </section>
 
-      <div style={{ 
-        background: '#f0f9ff', 
-        padding: '20px', 
-        borderRadius: '8px',
-        marginBottom: '20px'
-      }}>
-        <h2>Quick Links</h2>
+      <section className="app-shell__section">
+        <h2>Quick links</h2>
         <ul>
-          <li><a href={buildApiUrl('health')} target="_blank" rel="noreferrer">Backend Health Check</a></li>
-          <li><a href={buildApiUrl('docs')} target="_blank" rel="noreferrer">API Documentation</a></li>
-          <li><a href={buildApiUrl('api/v1/test')} target="_blank" rel="noreferrer">API Test Endpoint</a></li>
+          <li>
+            <a href={buildApiUrl('health')} target="_blank" rel="noreferrer">
+              Backend health check
+            </a>
+          </li>
+          <li>
+            <a href={buildApiUrl('docs')} target="_blank" rel="noreferrer">
+              API documentation
+            </a>
+          </li>
+          <li>
+            <a href={buildApiUrl('api/v1/test')} target="_blank" rel="noreferrer">
+              API test endpoint
+            </a>
+          </li>
         </ul>
-      </div>
+      </section>
 
-      <div style={{ 
-        background: '#fefce8', 
-        padding: '20px', 
-        borderRadius: '8px'
-      }}>
-        <h2>Next Steps</h2>
+      <section className="app-shell__section">
+        <h2>Why start here?</h2>
+        <ul>
+          <li>Capture project basics once and reuse across compliance workflows.</li>
+          <li>Review cross-agency rules synthesised from the knowledge platform.</li>
+          <li>Generate buildability insights with clear next steps for the team.</li>
+        </ul>
+      </section>
+
+      <section className="app-shell__section">
+        <h2>Next steps</h2>
         <ol>
-          <li>✅ Frontend and Backend are connected</li>
-          <li>🔄 Add database integration</li>
-          <li>🔄 Implement buildable analysis</li>
-          <li>🔄 Add Singapore building codes</li>
+          <li>✅ Frontend and backend are connected.</li>
+          <li>🔄 Add database integration.</li>
+          <li>🔄 Implement buildable analysis.</li>
+          <li>🔄 Add Singapore building codes.</li>
         </ol>
-      </div>
+      </section>
     </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,3 +35,367 @@ a:hover {
 h1, h2, h3 {
   line-height: 1.1;
 }
+
+.app-shell {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.app-shell__header h1 {
+  margin-bottom: 0.5rem;
+  font-size: 2.5rem;
+}
+
+.app-shell__nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.app-shell__nav-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  background-color: #2563eb;
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.app-shell__nav-link + .app-shell__nav-link {
+  background-color: #0f172a;
+}
+
+.app-shell__section ul {
+  padding-left: 1.25rem;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.feasibility-wizard {
+  max-width: 1024px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.feasibility-wizard__header h1 {
+  margin-bottom: 0.5rem;
+  font-size: 2.25rem;
+}
+
+.feasibility-wizard__header p {
+  margin: 0 0 1.5rem;
+  max-width: 720px;
+}
+
+.feasibility-wizard__error {
+  background-color: #fee2e2;
+  color: #b91c1c;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+}
+
+.feasibility-progress {
+  display: flex;
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.feasibility-progress__item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background-color: #e2e8f0;
+  color: #1f2937;
+}
+
+.feasibility-progress__item--active {
+  background-color: #2563eb;
+  color: #ffffff;
+}
+
+.feasibility-progress__item--done {
+  background-color: #0f172a;
+  color: #ffffff;
+}
+
+.feasibility-progress__index {
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.feasibility-step {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.feasibility-step__heading {
+  margin: 0;
+}
+
+.feasibility-step__intro {
+  margin: 0;
+  color: #475569;
+}
+
+.feasibility-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  background-color: #f8fafc;
+  padding: 1.75rem;
+  border-radius: 1rem;
+}
+
+.feasibility-form__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.feasibility-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.feasibility-form__field label {
+  font-weight: 600;
+}
+
+.feasibility-form__field input,
+.feasibility-form__field select {
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid #cbd5f5;
+  font-size: 1rem;
+}
+
+.feasibility-form__field input:focus,
+.feasibility-form__field select:focus {
+  outline: 2px solid #2563eb;
+  border-color: #2563eb;
+}
+
+.feasibility-form__error {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #b91c1c;
+}
+
+.feasibility-form__submit {
+  align-self: flex-start;
+  padding: 0.85rem 1.75rem;
+  border-radius: 0.75rem;
+  border: none;
+  background-color: #2563eb;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.feasibility-panel {
+  background-color: #f1f5f9;
+  border-radius: 1rem;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.feasibility-panel__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .feasibility-panel__header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+}
+
+.feasibility-panel__title {
+  margin: 0;
+}
+
+.feasibility-panel__subtitle {
+  margin: 0;
+  color: #475569;
+}
+
+.feasibility-panel__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.feasibility-panel__metric-label {
+  display: block;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.feasibility-panel__metric-value {
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.feasibility-panel__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.feasibility-panel__error {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.feasibility-rules {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.feasibility-rules__item {
+  border-radius: 0.75rem;
+  background-color: #ffffff;
+  padding: 1.25rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.feasibility-rules__item label {
+  display: flex;
+  gap: 1rem;
+  cursor: pointer;
+}
+
+.feasibility-rules__item input {
+  margin-top: 0.25rem;
+}
+
+.feasibility-rules__meta {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.feasibility-rules__title {
+  margin: 0.35rem 0 0.25rem;
+  font-weight: 600;
+}
+
+.feasibility-rules__description,
+.feasibility-rules__requirement {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.feasibility-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+}
+
+.feasibility-actions__primary,
+.feasibility-actions__secondary {
+  padding: 0.85rem 1.75rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+}
+
+.feasibility-actions__primary {
+  background-color: #2563eb;
+  color: #ffffff;
+}
+
+.feasibility-actions__primary:disabled {
+  background-color: #93c5fd;
+  cursor: not-allowed;
+}
+
+.feasibility-actions__secondary {
+  background-color: #e2e8f0;
+  color: #0f172a;
+}
+
+.feasibility-results {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.feasibility-results th,
+.feasibility-results td {
+  padding: 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.feasibility-results__title {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.feasibility-results__requirement {
+  margin: 0;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.feasibility-results__status {
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-weight: 600;
+}
+
+.feasibility-results__status--pass {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.feasibility-results__status--fail {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.feasibility-results__status--warning {
+  background-color: #fef9c3;
+  color: #92400e;
+}
+
+.feasibility-recommendations {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,23 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { createBrowserRouter, RouterProvider } from './router'
 import App from './App'
+import FeasibilityWizard from './modules/feasibility/FeasibilityWizard'
 import './index.css'
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+  },
+  {
+    path: '/feasibility',
+    element: <FeasibilityWizard />,
+  },
+])
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </React.StrictMode>,
 )

--- a/frontend/src/modules/feasibility/FeasibilityWizard.tsx
+++ b/frontend/src/modules/feasibility/FeasibilityWizard.tsx
@@ -1,0 +1,232 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import {
+  FeasibilityAssessmentRequest,
+  FeasibilityAssessmentResponse,
+  FeasibilityRulesResponse,
+  FeasibilityRule,
+  NewFeasibilityProjectInput,
+} from './types'
+import { fetchFeasibilityRules, submitFeasibilityAssessment } from './api'
+import Step1NewProject from './Step1NewProject'
+import Step2Rules from './Step2Rules'
+import Step3Buildable from './Step3Buildable'
+
+const steps = ['Project details', 'Compliance scope', 'Buildability results']
+
+function extractErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+  return 'Something went wrong. Please try again.'
+}
+
+export function FeasibilityWizard() {
+  const [currentStep, setCurrentStep] = useState(0)
+  const [project, setProject] = useState<NewFeasibilityProjectInput | null>(null)
+  const [selectedRuleIds, setSelectedRuleIds] = useState<string[]>([])
+  const [assessment, setAssessment] = useState<FeasibilityAssessmentResponse | null>(null)
+  const [assessmentError, setAssessmentError] = useState<string | null>(null)
+  const [rulesData, setRulesData] = useState<FeasibilityRulesResponse | null>(null)
+  const [isRulesLoading, setIsRulesLoading] = useState(false)
+  const [rulesError, setRulesError] = useState<string | null>(null)
+  const [isAssessmentLoading, setIsAssessmentLoading] = useState(false)
+
+  useEffect(() => {
+    if (!project) {
+      setRulesData(null)
+      return
+    }
+
+    let cancelled = false
+    setIsRulesLoading(true)
+    setRulesError(null)
+
+    fetchFeasibilityRules(project)
+      .then((data) => {
+        if (cancelled) {
+          return
+        }
+        setRulesData(data)
+      })
+      .catch((error: unknown) => {
+        if (cancelled) {
+          return
+        }
+        setRulesError(extractErrorMessage(error))
+        setRulesData(null)
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsRulesLoading(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [project])
+
+  useEffect(() => {
+    if (rulesData && selectedRuleIds.length === 0) {
+      const { recommendedRuleIds, rules } = rulesData
+      const defaults =
+        recommendedRuleIds.length > 0
+          ? recommendedRuleIds
+          : rules
+              .filter((rule: FeasibilityRule) => rule.defaultSelected)
+              .map((rule: FeasibilityRule) => rule.id)
+
+      if (defaults.length > 0) {
+        setSelectedRuleIds(defaults)
+      }
+    }
+  }, [rulesData, selectedRuleIds.length])
+
+  const handleProjectSubmit = useCallback((values: NewFeasibilityProjectInput) => {
+    setProject(values)
+    setSelectedRuleIds([])
+    setAssessment(null)
+    setAssessmentError(null)
+    setCurrentStep(1)
+  }, [])
+
+  const handleRunAssessment = useCallback(() => {
+    if (!project) {
+      return
+    }
+
+    setAssessmentError(null)
+    setIsAssessmentLoading(true)
+    setAssessment(null)
+    setCurrentStep(2)
+
+    const payload: FeasibilityAssessmentRequest = {
+      project,
+      selectedRuleIds,
+    }
+
+    submitFeasibilityAssessment(payload)
+      .then((response) => {
+        setAssessment(response)
+      })
+      .catch((error: unknown) => {
+        setAssessmentError(extractErrorMessage(error))
+        setCurrentStep(1)
+      })
+      .finally(() => {
+        setIsAssessmentLoading(false)
+      })
+  }, [project, selectedRuleIds])
+
+  const handleRestart = useCallback(() => {
+    setProject(null)
+    setSelectedRuleIds([])
+    setAssessment(null)
+    setAssessmentError(null)
+    setCurrentStep(0)
+    setRulesData(null)
+    setRulesError(null)
+  }, [])
+
+  const stepIndicator = useMemo(() => {
+    return (
+      <ol className="feasibility-progress">
+        {steps.map((label, index) => {
+          const isActive = index === currentStep
+          const isCompleted = index < currentStep
+          return (
+            <li
+              key={label}
+              className={`feasibility-progress__item${
+                isActive ? ' feasibility-progress__item--active' : ''
+              }${isCompleted ? ' feasibility-progress__item--done' : ''}`}
+            >
+              <span className="feasibility-progress__index">{index + 1}</span>
+              <span>{label}</span>
+            </li>
+          )
+        })}
+      </ol>
+    )
+  }, [currentStep])
+
+  const renderStep = () => {
+    switch (currentStep) {
+      case 0:
+        return (
+          <Step1NewProject
+            onSubmit={handleProjectSubmit}
+            defaultValues={project ?? undefined}
+            isSubmitting={isRulesLoading && Boolean(project)}
+          />
+        )
+      case 1:
+        if (!project) {
+          return null
+        }
+        return (
+          <Step2Rules
+            project={project}
+            rules={rulesData?.rules ?? []}
+            summary={rulesData?.summary}
+            isLoading={isRulesLoading}
+            error={rulesError}
+            selectedRuleIds={selectedRuleIds}
+            onSelectionChange={setSelectedRuleIds}
+            onBack={() => setCurrentStep(0)}
+            onContinue={handleRunAssessment}
+            isEvaluating={isAssessmentLoading}
+          />
+        )
+      case 2:
+        if (!assessment) {
+          return (
+            <Step3Buildable
+              assessment={{
+                projectId: project?.name ?? 'pending',
+                summary: {
+                  maxPermissibleGfaSqm: project?.targetGrossFloorAreaSqm ?? 0,
+                  estimatedAchievableGfaSqm: project?.targetGrossFloorAreaSqm ?? 0,
+                  estimatedUnitCount: 0,
+                  siteCoveragePercent: 0,
+                  remarks: 'Preparing assessment…',
+                },
+                rules: [],
+                recommendations: [],
+              }}
+              onBack={() => setCurrentStep(1)}
+              onRestart={handleRestart}
+              isLoading
+            />
+          )
+        }
+        return (
+          <Step3Buildable
+            assessment={assessment}
+            onBack={() => setCurrentStep(1)}
+            onRestart={handleRestart}
+            isLoading={isAssessmentLoading && !assessment}
+          />
+        )
+      default:
+        return null
+    }
+  }
+
+  return (
+    <div className="feasibility-wizard">
+      <header className="feasibility-wizard__header">
+        <h1>Feasibility assessment</h1>
+        <p>Evaluate plot potential, identify binding regulations and generate next steps for compliance.</p>
+        {stepIndicator}
+      </header>
+
+      {assessmentError && <p className="feasibility-wizard__error">{assessmentError}</p>}
+
+      <main>{renderStep()}</main>
+    </div>
+  )
+}
+
+export default FeasibilityWizard

--- a/frontend/src/modules/feasibility/Step1NewProject.stories.tsx
+++ b/frontend/src/modules/feasibility/Step1NewProject.stories.tsx
@@ -1,0 +1,24 @@
+import Step1NewProject from './Step1NewProject'
+import type { NewFeasibilityProjectInput } from './types'
+
+const meta = {
+  title: 'Feasibility/Step 1 · New project',
+  component: Step1NewProject,
+}
+
+export default meta
+
+const sampleProject: NewFeasibilityProjectInput = {
+  name: 'Riverfront Residences',
+  siteAddress: '123 Serangoon Ave 3',
+  siteAreaSqm: 4125,
+  landUse: 'residential',
+  targetGrossFloorAreaSqm: 13800,
+  buildingHeightMeters: 80,
+}
+
+export const Default = () => (
+  <div style={{ maxWidth: 720 }}>
+    <Step1NewProject defaultValues={sampleProject} onSubmit={console.log} />
+  </div>
+)

--- a/frontend/src/modules/feasibility/Step1NewProject.tsx
+++ b/frontend/src/modules/feasibility/Step1NewProject.tsx
@@ -1,0 +1,252 @@
+import type { ChangeEvent, FormEvent } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+
+import { landUseOptions, LandUseType, NewFeasibilityProjectInput } from './types'
+
+type Step1FieldKey =
+  | 'name'
+  | 'siteAddress'
+  | 'siteAreaSqm'
+  | 'landUse'
+  | 'targetGrossFloorAreaSqm'
+  | 'buildingHeightMeters'
+
+export interface Step1FormValues {
+  name: string
+  siteAddress: string
+  siteAreaSqm: string
+  landUse: LandUseType | ''
+  targetGrossFloorAreaSqm: string
+  buildingHeightMeters: string
+}
+
+type Step1FormErrors = Partial<Record<Step1FieldKey, string>>
+
+const initialFormState: Step1FormValues = {
+  name: '',
+  siteAddress: '',
+  siteAreaSqm: '',
+  landUse: '',
+  targetGrossFloorAreaSqm: '',
+  buildingHeightMeters: '',
+}
+
+function formatDefaultValues(defaultValues?: NewFeasibilityProjectInput): Step1FormValues {
+  if (!defaultValues) {
+    return initialFormState
+  }
+
+  return {
+    name: defaultValues.name ?? '',
+    siteAddress: defaultValues.siteAddress ?? '',
+    siteAreaSqm:
+      defaultValues.siteAreaSqm !== undefined ? String(defaultValues.siteAreaSqm) : '',
+    landUse: defaultValues.landUse ?? '',
+    targetGrossFloorAreaSqm:
+      defaultValues.targetGrossFloorAreaSqm !== undefined
+        ? String(defaultValues.targetGrossFloorAreaSqm)
+        : '',
+    buildingHeightMeters:
+      defaultValues.buildingHeightMeters !== undefined
+        ? String(defaultValues.buildingHeightMeters)
+        : '',
+  }
+}
+
+interface Step1NewProjectProps {
+  defaultValues?: NewFeasibilityProjectInput
+  onSubmit: (values: NewFeasibilityProjectInput) => void
+  isSubmitting?: boolean
+}
+
+export function Step1NewProject({
+  defaultValues,
+  onSubmit,
+  isSubmitting = false,
+}: Step1NewProjectProps) {
+  const [values, setValues] = useState<Step1FormValues>(() => formatDefaultValues(defaultValues))
+  const [errors, setErrors] = useState<Step1FormErrors>({})
+
+  useEffect(() => {
+    setValues(formatDefaultValues(defaultValues))
+    setErrors({})
+  }, [defaultValues])
+
+  const description = useMemo(
+    () =>
+      `Capture the essential site information that powers compliance lookups. ` +
+      `This data will be used to determine zoning, plot ratio and envelope controls before fetching applicable rules.`,
+    [],
+  )
+
+  const handleFieldChange = (field: Step1FieldKey) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+      const { value } = event.target
+      setValues((previous) => ({ ...previous, [field]: value }))
+      setErrors((previous) => ({ ...previous, [field]: undefined }))
+    }
+
+  const validateForm = (): Step1FormErrors | null => {
+    const nextErrors: Step1FormErrors = {}
+
+    if (!values.name.trim()) {
+      nextErrors.name = 'Project name is required'
+    }
+
+    if (!values.siteAddress.trim()) {
+      nextErrors.siteAddress = 'Site address is required'
+    }
+
+    const siteArea = Number.parseFloat(values.siteAreaSqm)
+    if (!values.siteAreaSqm.trim()) {
+      nextErrors.siteAreaSqm = 'Site area is required'
+    } else if (!Number.isFinite(siteArea) || siteArea <= 0) {
+      nextErrors.siteAreaSqm = 'Site area must be greater than zero'
+    }
+
+    if (!values.landUse) {
+      nextErrors.landUse = 'Select a land use to continue'
+    }
+
+    if (values.targetGrossFloorAreaSqm.trim()) {
+      const targetGfa = Number.parseFloat(values.targetGrossFloorAreaSqm)
+      if (!Number.isFinite(targetGfa) || targetGfa <= 0) {
+        nextErrors.targetGrossFloorAreaSqm = 'Target GFA must be greater than zero'
+      }
+    }
+
+    if (values.buildingHeightMeters.trim()) {
+      const height = Number.parseFloat(values.buildingHeightMeters)
+      if (!Number.isFinite(height) || height <= 0) {
+        nextErrors.buildingHeightMeters = 'Height must be greater than zero'
+      }
+    }
+
+    return Object.keys(nextErrors).length > 0 ? nextErrors : null
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const validationErrors = validateForm()
+    if (validationErrors) {
+      setErrors(validationErrors)
+      return
+    }
+
+    const siteArea = Number.parseFloat(values.siteAreaSqm)
+    const payload: NewFeasibilityProjectInput = {
+      name: values.name.trim(),
+      siteAddress: values.siteAddress.trim(),
+      siteAreaSqm: siteArea,
+      landUse: values.landUse as LandUseType,
+    }
+
+    if (values.targetGrossFloorAreaSqm.trim()) {
+      payload.targetGrossFloorAreaSqm = Number.parseFloat(values.targetGrossFloorAreaSqm)
+    }
+
+    if (values.buildingHeightMeters.trim()) {
+      payload.buildingHeightMeters = Number.parseFloat(values.buildingHeightMeters)
+    }
+
+    onSubmit(payload)
+  }
+
+  return (
+    <div className="feasibility-step">
+      <h2 className="feasibility-step__heading">Step 1 · New project details</h2>
+      <p className="feasibility-step__intro">{description}</p>
+
+      <form className="feasibility-form" onSubmit={handleSubmit} noValidate>
+        <div className="feasibility-form__field">
+          <label htmlFor="name">Project name</label>
+          <input
+            id="name"
+            type="text"
+            value={values.name}
+            onChange={handleFieldChange('name')}
+            placeholder="e.g. Riverfront Residences"
+          />
+          {errors.name && <p className="feasibility-form__error">{errors.name}</p>}
+        </div>
+
+        <div className="feasibility-form__field">
+          <label htmlFor="siteAddress">Site address</label>
+          <input
+            id="siteAddress"
+            type="text"
+            value={values.siteAddress}
+            onChange={handleFieldChange('siteAddress')}
+            placeholder="e.g. 123 Serangoon Ave 3"
+          />
+          {errors.siteAddress && <p className="feasibility-form__error">{errors.siteAddress}</p>}
+        </div>
+
+        <div className="feasibility-form__field">
+          <label htmlFor="siteAreaSqm">Site area (sqm)</label>
+          <input
+            id="siteAreaSqm"
+            type="number"
+            step="0.01"
+            value={values.siteAreaSqm}
+            onChange={handleFieldChange('siteAreaSqm')}
+            placeholder="e.g. 4250"
+          />
+          {errors.siteAreaSqm && <p className="feasibility-form__error">{errors.siteAreaSqm}</p>}
+        </div>
+
+        <div className="feasibility-form__field">
+          <label htmlFor="landUse">Land use</label>
+          <select id="landUse" value={values.landUse} onChange={handleFieldChange('landUse')}>
+            <option value="">Select a land use</option>
+            {landUseOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          {errors.landUse && <p className="feasibility-form__error">{errors.landUse}</p>}
+        </div>
+
+        <div className="feasibility-form__grid">
+          <div className="feasibility-form__field">
+            <label htmlFor="targetGrossFloorAreaSqm">Target GFA (sqm)</label>
+            <input
+              id="targetGrossFloorAreaSqm"
+              type="number"
+              step="0.01"
+              value={values.targetGrossFloorAreaSqm}
+              onChange={handleFieldChange('targetGrossFloorAreaSqm')}
+              placeholder="Optional"
+            />
+            {errors.targetGrossFloorAreaSqm && (
+              <p className="feasibility-form__error">{errors.targetGrossFloorAreaSqm}</p>
+            )}
+          </div>
+
+          <div className="feasibility-form__field">
+            <label htmlFor="buildingHeightMeters">Target height (m)</label>
+            <input
+              id="buildingHeightMeters"
+              type="number"
+              step="0.1"
+              value={values.buildingHeightMeters}
+              onChange={handleFieldChange('buildingHeightMeters')}
+              placeholder="Optional"
+            />
+            {errors.buildingHeightMeters && (
+              <p className="feasibility-form__error">{errors.buildingHeightMeters}</p>
+            )}
+          </div>
+        </div>
+
+        <button className="feasibility-form__submit" type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Saving…' : 'Continue to rules'}
+        </button>
+      </form>
+    </div>
+  )
+}
+
+export default Step1NewProject

--- a/frontend/src/modules/feasibility/Step2Rules.stories.tsx
+++ b/frontend/src/modules/feasibility/Step2Rules.stories.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react'
+
+import Step2Rules from './Step2Rules'
+import type { FeasibilityRule, NewFeasibilityProjectInput } from './types'
+
+const meta = {
+  title: 'Feasibility/Step 2 · Rules',
+  component: Step2Rules,
+}
+
+export default meta
+
+const project: NewFeasibilityProjectInput = {
+  name: 'Riverfront Residences',
+  siteAddress: '123 Serangoon Ave 3',
+  siteAreaSqm: 4125,
+  landUse: 'residential',
+  targetGrossFloorAreaSqm: 13800,
+  buildingHeightMeters: 80,
+}
+
+const rules: FeasibilityRule[] = [
+  {
+    id: 'ura-plot-ratio',
+    title: 'Plot ratio within URA master plan envelope',
+    description: 'Maximum gross plot ratio permitted for the planning area.',
+    authority: 'URA',
+    topic: 'zoning',
+    parameterKey: 'planning.gross_plot_ratio',
+    operator: '<=',
+    value: '3.5',
+    severity: 'critical',
+    defaultSelected: true,
+  },
+  {
+    id: 'bca-site-coverage',
+    title: 'Site coverage for residential developments',
+    description: 'Site coverage must not exceed prescribed limits.',
+    authority: 'BCA',
+    topic: 'envelope',
+    parameterKey: 'envelope.site_coverage_percent',
+    operator: '<=',
+    value: '45',
+    unit: '%',
+    severity: 'important',
+    defaultSelected: true,
+  },
+  {
+    id: 'scdf-access',
+    title: 'Fire appliance access road width',
+    description: 'Primary fire engine access roads must satisfy minimum width requirements.',
+    authority: 'SCDF',
+    topic: 'fire safety',
+    parameterKey: 'fire.access.road_width_m',
+    operator: '>=',
+    value: '4.5',
+    unit: 'm',
+    severity: 'critical',
+    defaultSelected: true,
+  },
+]
+
+export const Default = () => {
+  const [selected, setSelected] = useState(() => rules.map((rule) => rule.id))
+
+  return (
+    <div style={{ maxWidth: 960 }}>
+      <Step2Rules
+        project={project}
+        rules={rules}
+        summary={{
+          complianceFocus: 'Envelope controls and critical access provisions',
+          notes: 'Auto-selected based on residential land use profile',
+        }}
+        isLoading={false}
+        error={null}
+        selectedRuleIds={selected}
+        onSelectionChange={setSelected}
+        onBack={() => undefined}
+        onContinue={() => undefined}
+      />
+    </div>
+  )
+}

--- a/frontend/src/modules/feasibility/Step2Rules.tsx
+++ b/frontend/src/modules/feasibility/Step2Rules.tsx
@@ -1,0 +1,164 @@
+import { useMemo } from 'react'
+
+import {
+  FeasibilityRule,
+  FeasibilityRulesSummary,
+  NewFeasibilityProjectInput,
+} from './types'
+
+interface Step2RulesProps {
+  project: NewFeasibilityProjectInput
+  rules: FeasibilityRule[]
+  summary?: FeasibilityRulesSummary
+  isLoading: boolean
+  error?: string | null
+  selectedRuleIds: string[]
+  onSelectionChange: (ids: string[]) => void
+  onBack: () => void
+  onContinue: () => void
+  isEvaluating?: boolean
+}
+
+function formatNumber(value: number | undefined) {
+  if (value === undefined || Number.isNaN(value)) {
+    return '—'
+  }
+
+  return value.toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+  })
+}
+
+export function Step2Rules({
+  project,
+  rules,
+  summary,
+  isLoading,
+  error,
+  selectedRuleIds,
+  onSelectionChange,
+  onBack,
+  onContinue,
+  isEvaluating = false,
+}: Step2RulesProps) {
+  const recommendationText = useMemo(() => {
+    if (!summary) {
+      return null
+    }
+
+    return `${summary.complianceFocus}${summary.notes ? ` · ${summary.notes}` : ''}`
+  }, [summary])
+
+  const toggleRule = (ruleId: string) => {
+    if (selectedRuleIds.includes(ruleId)) {
+      onSelectionChange(selectedRuleIds.filter((id) => id !== ruleId))
+    } else {
+      onSelectionChange([...selectedRuleIds, ruleId])
+    }
+  }
+
+  const selectedRulesSet = useMemo(() => new Set(selectedRuleIds), [selectedRuleIds])
+
+  return (
+    <div className="feasibility-step">
+      <h2 className="feasibility-step__heading">Step 2 · Review suggested rules</h2>
+      <p className="feasibility-step__intro">
+        We analysed the project details and surfaced the most relevant codes across agencies.
+        You can adjust the scope before running the compliance engine.
+      </p>
+
+      <section className="feasibility-panel">
+        <header className="feasibility-panel__header">
+          <div>
+            <h3 className="feasibility-panel__title">Project summary</h3>
+            <p className="feasibility-panel__subtitle">
+              {recommendationText ?? 'Provide a quick confirmation before running the checks.'}
+            </p>
+          </div>
+          <div className="feasibility-panel__metrics">
+            <div>
+              <span className="feasibility-panel__metric-label">Site area</span>
+              <span className="feasibility-panel__metric-value">
+                {formatNumber(project.siteAreaSqm)} m²
+              </span>
+            </div>
+            <div>
+              <span className="feasibility-panel__metric-label">Land use</span>
+              <span className="feasibility-panel__metric-value">{project.landUse}</span>
+            </div>
+            <div>
+              <span className="feasibility-panel__metric-label">Target GFA</span>
+              <span className="feasibility-panel__metric-value">
+                {formatNumber(project.targetGrossFloorAreaSqm)} m²
+              </span>
+            </div>
+            <div>
+              <span className="feasibility-panel__metric-label">Target height</span>
+              <span className="feasibility-panel__metric-value">
+                {formatNumber(project.buildingHeightMeters)} m
+              </span>
+            </div>
+          </div>
+        </header>
+
+        <div className="feasibility-panel__content">
+          {isLoading && <p>Loading recommended rules…</p>}
+          {error && <p className="feasibility-panel__error">{error}</p>}
+          {!isLoading && !error && rules.length === 0 && (
+            <p>No rules were found for this project configuration.</p>
+          )}
+
+          {!isLoading && !error && rules.length > 0 && (
+            <ul className="feasibility-rules">
+              {rules.map((rule) => {
+                const isSelected = selectedRulesSet.has(rule.id)
+                return (
+                  <li
+                    key={rule.id}
+                    className={`feasibility-rules__item feasibility-rules__item--${rule.severity}`}
+                  >
+                    <label>
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={() => toggleRule(rule.id)}
+                      />
+                      <div>
+                        <div className="feasibility-rules__meta">
+                          <span className="feasibility-rules__authority">{rule.authority}</span>
+                          <span className="feasibility-rules__topic">{rule.topic}</span>
+                        </div>
+                        <p className="feasibility-rules__title">{rule.title}</p>
+                        <p className="feasibility-rules__description">{rule.description}</p>
+                        <p className="feasibility-rules__requirement">
+                          Requirement: {rule.parameterKey} {rule.operator} {rule.value}
+                          {rule.unit ? ` ${rule.unit}` : ''}
+                        </p>
+                      </div>
+                    </label>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      </section>
+
+      <div className="feasibility-actions">
+        <button type="button" className="feasibility-actions__secondary" onClick={onBack}>
+          Back
+        </button>
+        <button
+          type="button"
+          className="feasibility-actions__primary"
+          onClick={onContinue}
+          disabled={selectedRuleIds.length === 0 || isEvaluating || isLoading}
+        >
+          {isEvaluating ? 'Running assessment…' : 'Run buildability checks'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default Step2Rules

--- a/frontend/src/modules/feasibility/Step3Buildable.stories.tsx
+++ b/frontend/src/modules/feasibility/Step3Buildable.stories.tsx
@@ -1,0 +1,62 @@
+import Step3Buildable from './Step3Buildable'
+import type { FeasibilityAssessmentResponse } from './types'
+
+const meta = {
+  title: 'Feasibility/Step 3 · Buildability',
+  component: Step3Buildable,
+}
+
+export default meta
+
+const assessment: FeasibilityAssessmentResponse = {
+  projectId: 'project-Riverfront Residences',
+  summary: {
+    maxPermissibleGfaSqm: 14438,
+    estimatedAchievableGfaSqm: 11839,
+    estimatedUnitCount: 140,
+    siteCoveragePercent: 38.5,
+    remarks: 'Envelope complies with current zoning allowances.',
+  },
+  rules: [
+    {
+      id: 'ura-plot-ratio',
+      title: 'Plot ratio within URA master plan envelope',
+      description:
+        'Maximum gross plot ratio permitted for the planning area according to the 2025 URA plan.',
+      authority: 'URA',
+      topic: 'zoning',
+      parameterKey: 'planning.gross_plot_ratio',
+      operator: '<=',
+      value: '3.5',
+      severity: 'critical',
+      defaultSelected: true,
+      status: 'pass',
+      notes: 'Design meets required plot ratio.',
+    },
+    {
+      id: 'scdf-access',
+      title: 'Fire appliance access road width',
+      description: 'Primary fire engine access roads must satisfy minimum width requirements.',
+      authority: 'SCDF',
+      topic: 'fire safety',
+      parameterKey: 'fire.access.road_width_m',
+      operator: '>=',
+      value: '4.5',
+      unit: 'm',
+      severity: 'critical',
+      defaultSelected: true,
+      status: 'warning',
+      notes: 'Review secondary access – marginal clearance observed.',
+    },
+  ],
+  recommendations: [
+    'Coordinate with the fire consultant to confirm appliance access turning radii.',
+    'Prepare submission pack with the generated feasibility summary for management review.',
+  ],
+}
+
+export const Default = () => (
+  <div style={{ maxWidth: 960 }}>
+    <Step3Buildable assessment={assessment} onBack={() => undefined} onRestart={() => undefined} />
+  </div>
+)

--- a/frontend/src/modules/feasibility/Step3Buildable.tsx
+++ b/frontend/src/modules/feasibility/Step3Buildable.tsx
@@ -1,0 +1,161 @@
+import { useMemo } from 'react'
+
+import { FeasibilityAssessmentResponse } from './types'
+
+interface Step3BuildableProps {
+  assessment: FeasibilityAssessmentResponse
+  onBack: () => void
+  onRestart: () => void
+  isLoading?: boolean
+}
+
+const statusLabels = {
+  pass: 'Pass',
+  fail: 'Fail',
+  warning: 'Review',
+} as const
+
+export function Step3Buildable({
+  assessment,
+  onBack,
+  onRestart,
+  isLoading = false,
+}: Step3BuildableProps) {
+  const { summary, rules, recommendations } = assessment
+
+  const siteEfficiency = useMemo(() => {
+    if (!summary.maxPermissibleGfaSqm) {
+      return '—'
+    }
+
+    const ratio = summary.estimatedAchievableGfaSqm / summary.maxPermissibleGfaSqm
+    if (!Number.isFinite(ratio)) {
+      return '—'
+    }
+
+    return `${Math.round(ratio * 100)}% of permissible GFA utilised`
+  }, [summary])
+
+  return (
+    <div className="feasibility-step">
+      <h2 className="feasibility-step__heading">Step 3 · Buildability outlook</h2>
+      <p className="feasibility-step__intro">
+        {isLoading
+          ? 'Finalising the analysis…'
+          : 'This snapshot summarises the achievable massing and highlights rules that require attention.'}
+      </p>
+
+      <section className="feasibility-panel">
+        <header className="feasibility-panel__header">
+          <div>
+            <h3 className="feasibility-panel__title">Envelope summary</h3>
+            <p className="feasibility-panel__subtitle">{summary.remarks ?? siteEfficiency}</p>
+          </div>
+          <div className="feasibility-panel__metrics">
+            <div>
+              <span className="feasibility-panel__metric-label">Max permissible GFA</span>
+              <span className="feasibility-panel__metric-value">
+                {summary.maxPermissibleGfaSqm.toLocaleString()} m²
+              </span>
+            </div>
+            <div>
+              <span className="feasibility-panel__metric-label">Estimated achievable GFA</span>
+              <span className="feasibility-panel__metric-value">
+                {summary.estimatedAchievableGfaSqm.toLocaleString()} m²
+              </span>
+            </div>
+            <div>
+              <span className="feasibility-panel__metric-label">Estimated units</span>
+              <span className="feasibility-panel__metric-value">
+                {summary.estimatedUnitCount.toLocaleString()}
+              </span>
+            </div>
+            <div>
+              <span className="feasibility-panel__metric-label">Site coverage</span>
+              <span className="feasibility-panel__metric-value">
+                {summary.siteCoveragePercent.toFixed(1)}%
+              </span>
+            </div>
+          </div>
+        </header>
+
+        <div className="feasibility-panel__content">
+          {rules.length === 0 ? (
+            <p>All tracked rules passed – consider expanding the scope to include more topics.</p>
+          ) : (
+            <table className="feasibility-results">
+              <thead>
+                <tr>
+                  <th scope="col">Rule</th>
+                  <th scope="col">Agency</th>
+                  <th scope="col">Status</th>
+                  <th scope="col">Notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rules.map((rule) => (
+                  <tr
+                    key={rule.id}
+                    className={`feasibility-results__row feasibility-results__row--${rule.status}`}
+                  >
+                    <td>
+                      <p className="feasibility-results__title">{rule.title}</p>
+                      <p className="feasibility-results__requirement">
+                        {rule.parameterKey} {rule.operator} {rule.value}
+                        {rule.unit ? ` ${rule.unit}` : ''}
+                      </p>
+                    </td>
+                    <td>
+                      <span>{rule.authority}</span>
+                    </td>
+                    <td>
+                      <span
+                        className={`feasibility-results__status feasibility-results__status--${rule.status}`}
+                      >
+                        {statusLabels[rule.status]}
+                      </span>
+                    </td>
+                    <td>
+                      <span>{rule.notes ?? rule.actualValue ?? '—'}</span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </section>
+
+      {recommendations.length > 0 && (
+        <section className="feasibility-panel">
+          <header className="feasibility-panel__header">
+            <div>
+              <h3 className="feasibility-panel__title">Next steps</h3>
+              <p className="feasibility-panel__subtitle">
+                Prioritised guidance to resolve outstanding compliance gaps.
+              </p>
+            </div>
+          </header>
+          <div className="feasibility-panel__content">
+            <ol className="feasibility-recommendations">
+              {recommendations.map((item, index) => (
+                <li key={index}>{item}</li>
+              ))}
+            </ol>
+          </div>
+        </section>
+      )}
+
+      <div className="feasibility-actions">
+        <button type="button" className="feasibility-actions__secondary" onClick={onBack}>
+          Back to rules
+        </button>
+        <button type="button" className="feasibility-actions__primary" onClick={onRestart}>
+          Start a new assessment
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default Step3Buildable

--- a/frontend/src/modules/feasibility/api.ts
+++ b/frontend/src/modules/feasibility/api.ts
@@ -1,0 +1,161 @@
+import {
+  FeasibilityAssessmentRequest,
+  FeasibilityAssessmentResponse,
+  FeasibilityRule,
+  FeasibilityRulesResponse,
+  NewFeasibilityProjectInput,
+  RuleAssessmentResult,
+} from './types'
+
+const baseRules: FeasibilityRule[] = [
+  {
+    id: 'ura-plot-ratio',
+    title: 'Plot ratio within URA master plan envelope',
+    description:
+      'Maximum gross plot ratio permitted for the planning area according to the 2025 URA master plan.',
+    authority: 'URA',
+    topic: 'zoning',
+    parameterKey: 'planning.gross_plot_ratio',
+    operator: '<=',
+    value: '3.5',
+    severity: 'critical',
+    defaultSelected: true,
+  },
+  {
+    id: 'bca-site-coverage',
+    title: 'Site coverage for residential developments',
+    description:
+      'Site coverage must not exceed the prescribed limit to maintain environmental quality.',
+    authority: 'BCA',
+    topic: 'envelope',
+    parameterKey: 'envelope.site_coverage_percent',
+    operator: '<=',
+    value: '45',
+    unit: '%',
+    severity: 'important',
+    defaultSelected: true,
+  },
+  {
+    id: 'scdf-access',
+    title: 'Fire appliance access road width',
+    description: 'Primary fire engine access roads must satisfy minimum width requirements.',
+    authority: 'SCDF',
+    topic: 'fire safety',
+    parameterKey: 'fire.access.road_width_m',
+    operator: '>=',
+    value: '4.5',
+    unit: 'm',
+    severity: 'critical',
+    defaultSelected: true,
+  },
+  {
+    id: 'nea-bin-centre',
+    title: 'Provision of bin centre',
+    description: 'Residential developments above 40 units must provide an on-site bin centre.',
+    authority: 'NEA',
+    topic: 'environmental health',
+    parameterKey: 'operations.bin_centre_required',
+    operator: '=',
+    value: 'true',
+    severity: 'informational',
+  },
+]
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+function buildRulesResponse(project: NewFeasibilityProjectInput): FeasibilityRulesResponse {
+  return {
+    projectId: `project-${project.name || 'draft'}`,
+    rules: baseRules,
+    recommendedRuleIds: baseRules.filter((rule) => rule.defaultSelected).map((rule) => rule.id),
+    summary: {
+      complianceFocus: 'Envelope controls and critical access provisions',
+      notes: `Auto-selected based on ${project.landUse} land use profile`,
+    },
+  }
+}
+
+function calculateSummary(
+  project: NewFeasibilityProjectInput,
+  selectedRules: RuleAssessmentResult[],
+): FeasibilityAssessmentResponse['summary'] {
+  const maxPlotRatio = 3.5
+  const maxGfa = Math.round(project.siteAreaSqm * maxPlotRatio)
+  const achievableFactor = selectedRules.some((rule) => rule.status === 'fail') ? 0.65 : 0.82
+  const achievableGfa = Math.round(maxGfa * achievableFactor)
+  const averageUnitSize = project.landUse === 'residential' ? 85 : 120
+  const estimatedUnits = Math.max(1, Math.round(achievableGfa / averageUnitSize))
+  const coverageLimit = 45
+
+  return {
+    maxPermissibleGfaSqm: maxGfa,
+    estimatedAchievableGfaSqm: achievableGfa,
+    estimatedUnitCount: estimatedUnits,
+    siteCoveragePercent: Math.min(coverageLimit, (achievableFactor * 100) / 2),
+    remarks:
+      selectedRules.every((rule) => rule.status === 'pass')
+        ? 'All checked parameters comply with the default envelope.'
+        : 'Certain parameters require design revisions before proceeding.',
+  }
+}
+
+function buildAssessmentResponse(
+  payload: FeasibilityAssessmentRequest,
+): FeasibilityAssessmentResponse {
+  const { project, selectedRuleIds } = payload
+  const selected = baseRules.filter((rule) => selectedRuleIds.includes(rule.id))
+
+  const results: RuleAssessmentResult[] = selected.map((rule, index) => {
+    const status = index % 3 === 0 ? 'warning' : index % 2 === 0 ? 'pass' : 'fail'
+    const actualValue = rule.parameterKey.includes('plot_ratio')
+      ? project.targetGrossFloorAreaSqm
+        ? (project.targetGrossFloorAreaSqm / project.siteAreaSqm).toFixed(2)
+        : undefined
+      : undefined
+
+    return {
+      ...rule,
+      status,
+      actualValue,
+      notes:
+        status === 'fail'
+          ? 'Adjust design parameters or consult the respective authority.'
+          : status === 'warning'
+            ? 'Consider alternative layouts to increase compliance buffer.'
+            : undefined,
+    }
+  })
+
+  const recommendations = [
+    'Share the feasibility snapshot with the wider design team to align on constraints.',
+  ]
+
+  if (results.some((rule) => rule.status === 'fail')) {
+    recommendations.push('Schedule a coordination call with URA/BCA to clarify envelope outcomes.')
+  }
+
+  if (results.some((rule) => rule.status === 'warning')) {
+    recommendations.push('Investigate design options to improve fire access compliance buffers.')
+  }
+
+  return {
+    projectId: `project-${project.name || 'draft'}`,
+    summary: calculateSummary(project, results),
+    rules: results,
+    recommendations,
+  }
+}
+
+export async function fetchFeasibilityRules(
+  project: NewFeasibilityProjectInput,
+): Promise<FeasibilityRulesResponse> {
+  await delay(200)
+  return buildRulesResponse(project)
+}
+
+export async function submitFeasibilityAssessment(
+  payload: FeasibilityAssessmentRequest,
+): Promise<FeasibilityAssessmentResponse> {
+  await delay(350)
+  return buildAssessmentResponse(payload)
+}

--- a/frontend/src/modules/feasibility/types.ts
+++ b/frontend/src/modules/feasibility/types.ts
@@ -1,0 +1,74 @@
+export const landUseOptions = [
+  { value: 'residential', label: 'Residential' },
+  { value: 'commercial', label: 'Commercial' },
+  { value: 'mixed_use', label: 'Mixed Use' },
+  { value: 'industrial', label: 'Industrial' },
+  { value: 'institutional', label: 'Institutional' },
+] as const
+
+export type LandUseType = (typeof landUseOptions)[number]['value']
+
+export interface NewFeasibilityProjectInput {
+  name: string
+  siteAddress: string
+  siteAreaSqm: number
+  landUse: LandUseType
+  targetGrossFloorAreaSqm?: number
+  buildingHeightMeters?: number
+}
+
+export type FeasibilityRuleSeverity = 'critical' | 'important' | 'informational'
+
+export interface FeasibilityRule {
+  id: string
+  title: string
+  description: string
+  authority: string
+  topic: string
+  parameterKey: string
+  operator: string
+  value: string
+  unit?: string
+  severity: FeasibilityRuleSeverity
+  defaultSelected?: boolean
+}
+
+export interface FeasibilityRulesSummary {
+  complianceFocus: string
+  notes?: string
+}
+
+export interface FeasibilityRulesResponse {
+  projectId: string
+  rules: FeasibilityRule[]
+  recommendedRuleIds: string[]
+  summary: FeasibilityRulesSummary
+}
+
+export interface FeasibilityAssessmentRequest {
+  project: NewFeasibilityProjectInput
+  selectedRuleIds: string[]
+}
+
+export type RuleAssessmentStatus = 'pass' | 'fail' | 'warning'
+
+export interface RuleAssessmentResult extends FeasibilityRule {
+  status: RuleAssessmentStatus
+  actualValue?: string
+  notes?: string
+}
+
+export interface BuildableAreaSummary {
+  maxPermissibleGfaSqm: number
+  estimatedAchievableGfaSqm: number
+  estimatedUnitCount: number
+  siteCoveragePercent: number
+  remarks?: string
+}
+
+export interface FeasibilityAssessmentResponse {
+  projectId: string
+  summary: BuildableAreaSummary
+  rules: RuleAssessmentResult[]
+  recommendations: string[]
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,0 +1,122 @@
+/* eslint-disable react-refresh/only-export-components */
+import type { AnchorHTMLAttributes, MouseEventHandler, ReactNode } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+
+interface RouteDefinition {
+  path: string
+  element: ReactNode
+}
+
+interface RouterInstance {
+  routes: RouteDefinition[]
+}
+
+interface RouterContextValue {
+  path: string
+  navigate: (to: string) => void
+}
+
+const RouterContext = createContext<RouterContextValue | null>(null)
+
+const getInitialPath = () => {
+  if (typeof window === 'undefined') {
+    return '/'
+  }
+  return window.location.pathname || '/'
+}
+
+export function createBrowserRouter(routes: RouteDefinition[]): RouterInstance {
+  return { routes }
+}
+
+interface RouterProviderProps {
+  router: RouterInstance
+}
+
+export function RouterProvider({ router }: RouterProviderProps) {
+  const [path, setPath] = useState<string>(() => getInitialPath())
+  const routesRef = useRef(router.routes)
+  routesRef.current = router.routes
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const handlePopState = () => {
+      setPath(window.location.pathname || '/')
+    }
+
+    window.addEventListener('popstate', handlePopState)
+    return () => window.removeEventListener('popstate', handlePopState)
+  }, [])
+
+  const navigate = useCallback((to: string) => {
+    if (typeof window !== 'undefined') {
+      window.history.pushState({}, '', to)
+    }
+    setPath(to)
+  }, [])
+
+  const activeElement = useMemo(() => {
+    const exactMatch = routesRef.current.find((route) => route.path === path)
+    if (exactMatch) {
+      return exactMatch.element
+    }
+
+    return routesRef.current.find((route) => route.path === '/')?.element ?? null
+  }, [path])
+
+  const contextValue = useMemo<RouterContextValue>(() => ({ path, navigate }), [path, navigate])
+
+  return <RouterContext.Provider value={contextValue}>{activeElement}</RouterContext.Provider>
+}
+
+interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  to: string
+  children: ReactNode
+}
+
+export function Link({ to, children, onClick, ...rest }: LinkProps) {
+  const context = useContext(RouterContext)
+
+  const handleClick: MouseEventHandler<HTMLAnchorElement> = useCallback(
+    (event) => {
+      if (onClick) {
+        onClick(event)
+      }
+
+      if (event.defaultPrevented) {
+        return
+      }
+
+      event.preventDefault()
+      if (context) {
+        context.navigate(to)
+      }
+    },
+    [context, onClick, to],
+  )
+
+  return (
+    <a href={to} onClick={handleClick} {...rest}>
+      {children}
+    </a>
+  )
+}
+
+export function useRouterPath() {
+  const context = useContext(RouterContext)
+  if (!context) {
+    return getInitialPath()
+  }
+  return context.path
+}


### PR DESCRIPTION
## Summary
- refresh the landing page with navigation, quick links, and backend health messaging while preserving environment-aware API URLs
- add a lightweight client router and wire the app entry point to serve the new feasibility workflow route
- implement the multi-step feasibility wizard with mock API helpers, reusable step components, and supporting styles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfee51afac8320b7edf1ef6aba4b84