### PR TITLE
Use official Prometheus client and refresh metrics

### DIFF
--- a/backend/app/utils/_prometheus_stub.py
+++ b/backend/app/utils/_prometheus_stub.py
@@ -1,13 +1,22 @@
-"""Minimal Prometheus client stubs for offline testing."""
+"""Fallback Prometheus client for offline testing.
+
+This module exposes a very small subset of the `prometheus_client` interface.
+It mirrors the behaviour relied upon in the test-suite so that our code can be
+validated without the third-party dependency installed.  When the real
+``prometheus_client`` package is available it should take precedence and this
+stub will remain unused.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable, Tuple
+from typing import Dict, Iterable, Iterator, Tuple
 
 
 @dataclass
 class _ValueHolder:
+    """Container for numeric metric values."""
+
     value: float = 0.0
 
     def get(self) -> float:
@@ -15,17 +24,30 @@ class _ValueHolder:
 
 
 class CollectorRegistry:
-    """Simple registry to track metric instances."""
+    """Simplified collector registry."""
 
     def __init__(self, auto_describe: bool = True) -> None:
         self.auto_describe = auto_describe
-        self._metrics: list[_MetricBase] = []
+        self._collectors: Dict[str, _MetricBase] = {}
 
     def register(self, metric: "_MetricBase") -> None:
-        self._metrics.append(metric)
+        self._collectors[metric._name] = metric
+
+    def collect(self) -> Iterable["_MetricBase"]:
+        return self._collectors.values()
+
+    def get_sample_value(
+        self, name: str, labels: Dict[str, str] | None = None
+    ) -> float | None:
+        metric = self._collectors.get(name)
+        if metric is None:
+            return None
+        return metric.get_sample_value(labels or {})
 
 
 class _MetricBase:
+    _type: str = "gauge"
+
     def __init__(
         self,
         name: str,
@@ -36,7 +58,7 @@ class _MetricBase:
         self._name = name
         self._documentation = documentation
         self._labelnames = tuple(labelnames)
-        self._metrics: Dict[Tuple[str, ...], "_Sample"] = {}
+        self._metrics: Dict[Tuple[str, ...], _Sample] = {}
         if registry is not None:
             registry.register(self)
 
@@ -49,10 +71,17 @@ class _MetricBase:
             self._metrics[key] = _Sample()
         return self._metrics[key]
 
-    def _iter_samples(self) -> Iterable[Tuple[Dict[str, str], "_Sample"]]:
+    def _iter_samples(self) -> Iterator[Tuple[Dict[str, str], "_Sample"]]:
         for key, sample in self._metrics.items():
             label_map = dict(zip(self._labelnames, key))
             yield label_map, sample
+
+    def get_sample_value(self, labels: Dict[str, str]) -> float | None:
+        key = tuple(labels.get(label, "") for label in self._labelnames)
+        sample = self._metrics.get(key)
+        if sample is None:
+            return None
+        return sample._value.get()
 
 
 class _Sample:
@@ -69,22 +98,22 @@ class _Sample:
 class Counter(_MetricBase):
     """Counter metric stub."""
 
-    pass
+    _type = "counter"
 
 
 class Gauge(_MetricBase):
     """Gauge metric stub."""
 
-    pass
+    _type = "gauge"
 
 
 def generate_latest(registry: CollectorRegistry) -> bytes:
-    """Render metrics in a basic text format."""
+    """Render metrics in a Prometheus text exposition format."""
 
     lines: list[str] = []
-    for metric in registry._metrics:
+    for metric in registry.collect():
         lines.append(f"# HELP {metric._name} {metric._documentation}")
-        lines.append(f"# TYPE {metric._name} gauge")
+        lines.append(f"# TYPE {metric._name} {metric._type}")
         for label_map, sample in metric._iter_samples():
             if label_map:
                 labels = ",".join(f"{k}=\"{v}\"" for k, v in label_map.items())

--- a/backend/app/utils/metrics.py
+++ b/backend/app/utils/metrics.py
@@ -4,65 +4,98 @@ from __future__ import annotations
 
 from typing import Dict
 
-from prometheus_client import CollectorRegistry, Counter, Gauge, generate_latest
+try:  # pragma: no cover - exercised when dependency is available
+    from prometheus_client import CollectorRegistry, Counter, Gauge, generate_latest
+except ModuleNotFoundError:  # pragma: no cover - fallback for offline tests
+    from app.utils._prometheus_stub import (  # type: ignore
+        CollectorRegistry,
+        Counter,
+        Gauge,
+        generate_latest,
+    )
 
 
-REGISTRY: CollectorRegistry = CollectorRegistry(auto_describe=True)
+REGISTRY: CollectorRegistry
+REQUEST_COUNTER: Counter
+INGESTION_RUN_COUNTER: Counter
+INGESTED_RECORD_COUNTER: Counter
+ALERT_COUNTER: Counter
+COST_ADJUSTMENT_GAUGE: Gauge
 
-REQUEST_COUNTER: Counter = Counter(
-    "api_requests_total",
-    "Total API requests processed by endpoint.",
-    labelnames=("endpoint",),
-    registry=REGISTRY,
-)
 
-INGESTION_RUN_COUNTER: Counter = Counter(
-    "prefect_ingestion_runs_total",
-    "Number of Prefect ingestion runs recorded.",
-    labelnames=("flow",),
-    registry=REGISTRY,
-)
+def _initialize_metrics() -> None:
+    """Create a fresh registry and metric instances."""
 
-INGESTED_RECORD_COUNTER: Counter = Counter(
-    "prefect_ingested_records_total",
-    "Total records ingested by flow.",
-    labelnames=("flow",),
-    registry=REGISTRY,
-)
+    global REGISTRY
+    global REQUEST_COUNTER
+    global INGESTION_RUN_COUNTER
+    global INGESTED_RECORD_COUNTER
+    global ALERT_COUNTER
+    global COST_ADJUSTMENT_GAUGE
 
-ALERT_COUNTER: Counter = Counter(
-    "ingestion_alerts_total",
-    "Alerts emitted during ingestion runs by level.",
-    labelnames=("level",),
-    registry=REGISTRY,
-)
+    REGISTRY = CollectorRegistry(auto_describe=True)
 
-COST_ADJUSTMENT_GAUGE: Gauge = Gauge(
-    "pwp_cost_adjustment_scalar",
-    "Latest cost index scalar applied to PWP pro-forma adjustments.",
-    labelnames=("series",),
-    registry=REGISTRY,
-)
+    REQUEST_COUNTER = Counter(
+        "api_requests_total",
+        "Total API requests processed by endpoint.",
+        labelnames=("endpoint",),
+        registry=REGISTRY,
+    )
+
+    INGESTION_RUN_COUNTER = Counter(
+        "prefect_ingestion_runs_total",
+        "Number of Prefect ingestion runs recorded.",
+        labelnames=("flow",),
+        registry=REGISTRY,
+    )
+
+    INGESTED_RECORD_COUNTER = Counter(
+        "prefect_ingested_records_total",
+        "Total records ingested by flow.",
+        labelnames=("flow",),
+        registry=REGISTRY,
+    )
+
+    ALERT_COUNTER = Counter(
+        "ingestion_alerts_total",
+        "Alerts emitted during ingestion runs by level.",
+        labelnames=("level",),
+        registry=REGISTRY,
+    )
+
+    COST_ADJUSTMENT_GAUGE = Gauge(
+        "pwp_cost_adjustment_scalar",
+        "Latest cost index scalar applied to PWP pro-forma adjustments.",
+        labelnames=("series",),
+        registry=REGISTRY,
+    )
+
+
+_initialize_metrics()
 
 
 def reset_metrics() -> None:
     """Clear tracked metric values for tests."""
 
-    for metric in (
-        REQUEST_COUNTER,
-        INGESTION_RUN_COUNTER,
-        INGESTED_RECORD_COUNTER,
-        ALERT_COUNTER,
-        COST_ADJUSTMENT_GAUGE,
-    ):
-        metric.clear()
+    _initialize_metrics()
 
 
 def counter_value(counter: Counter, labels: Dict[str, str]) -> float:
     """Return the current value for a labelled counter."""
 
     sample = counter.labels(**labels)
-    return float(sample._value.get())
+    value_holder = getattr(sample, "_value", None)
+    if value_holder is not None and hasattr(value_holder, "get"):
+        return float(value_holder.get())
+
+    sample_getter = getattr(REGISTRY, "get_sample_value", None)
+    counter_name = getattr(counter, "_name", "")
+    if callable(sample_getter) and counter_name:
+        value = sample_getter(counter_name, labels)
+        if value is not None:
+            return float(value)
+
+    raise RuntimeError("Unable to read counter value from Prometheus metric")
 
 
 def render_latest_metrics() -> bytes:


### PR DESCRIPTION
## Summary
- remove the local `prometheus_client` stub and recreate metrics by building a fresh CollectorRegistry
- add a fallback Prometheus stub that is only used when the third-party dependency is unavailable
- update the metrics helpers to work with the real client API and surface Prometheus-formatted output

## Testing
- PYTHONPATH=. pytest
- PYTHONPATH=backend python - <<'PY' ...

------
https://chatgpt.com/codex/tasks/task_e_68d0070745148320b22e9788091c197f