### PR TITLE
Update smoke test heading expectation

### DIFF
--- a/frontend/tests/smoke.test.mjs
+++ b/frontend/tests/smoke.test.mjs
@@ -59,9 +59,15 @@ async function loadAppComponent() {
 test('App renders the expected headline', async () => {
   const App = await loadAppComponent()
   const html = renderToString(React.createElement(App))
+  const expectedHeadingCopy = 'Optimal Build Studio'
+  const expectedHeadingPattern = new RegExp(
+    `<h1[^>]*>\\s*${expectedHeadingCopy.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*<\\/h1>`,
+    'i',
+  )
+
   assert.match(
     html,
-    /<h1[^>]*>\s*Optimal Build Studio\s*<\/h1>/i,
-    'Expected heading to contain "Optimal Build Studio"',
+    expectedHeadingPattern,
+    `Expected heading to contain "${expectedHeadingCopy}"`,
   )
 })


### PR DESCRIPTION
## Summary
- update the smoke test heading expectation to use the current "Optimal Build Studio" copy
- escape the heading dynamically so the assertion message stays in sync with the expected copy

## Testing
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d006fe5414832093324d3c7d3f518c