### PR TITLE
feat: add CAD workflows and localization

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test": "node --test tests",
     "test:e2e": "node --test tests/smoke.test.mjs"
   },
   "dependencies": {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,340 @@
+import { useMemo } from 'react'
+
+export interface OverlayInsights {
+  zoneCode: string | null
+  overlays: string[]
+  advisoryHints: string[]
+}
+
+export interface RuleMatch {
+  text: string
+  score: number
+  hints: string[]
+}
+
+export interface RuleSummary {
+  id: number
+  parameterKey: string
+  operator: string
+  value: string
+  unit?: string | null
+  authority?: string | null
+  topic?: string | null
+  reviewStatus?: string | null
+  overlays: string[]
+  advisoryHints: string[]
+  normalized: RuleMatch[]
+}
+
+export interface AuditEvent {
+  ruleId: number
+  baseline: string
+  updated: string
+}
+
+export interface CadParseJob {
+  jobId: string
+  fileName: string
+  zoneCode: string | null
+  overlays: string[]
+  hints: string[]
+  status: 'queued' | 'processing' | 'ready' | 'error'
+  message?: string
+}
+
+export interface ParseStatusUpdate {
+  jobId: string
+  status: 'processing' | 'ready' | 'error'
+  overlays: string[]
+  hints: string[]
+  zoneCode: string | null
+  updatedAt: string
+  message?: string
+}
+
+export interface PipelineSuggestion {
+  id: string
+  title: string
+  description: string
+  focus: string
+  automationScore: number
+  reviewHoursSaved: number
+  estimatedSavingsPercent: number
+  relatedRuleIds: number[]
+}
+
+interface BuildableResponse {
+  zone_code?: string | null
+  overlays?: string[]
+  advisory_hints?: string[]
+}
+
+interface RulesResponse {
+  items: RuleSummary[]
+}
+
+interface AuditResponse {
+  items: { rule_id: number; baseline: string; updated: string }[]
+}
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+export class ApiClient {
+  private readonly baseUrl: string
+
+  constructor(baseUrl: string = import.meta.env.VITE_API_BASE_URL ?? '/') {
+    this.baseUrl = baseUrl
+  }
+
+  private buildUrl(path: string) {
+    if (/^https?:/i.test(path)) {
+      return path
+    }
+    const trimmed = path.startsWith('/') ? path.slice(1) : path
+    const root = this.baseUrl || '/'
+    return new URL(trimmed, root.endsWith('/') ? root : `${root}/`).toString()
+  }
+
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const response = await fetch(this.buildUrl(path), init)
+    if (!response.ok) {
+      const message = await response.text()
+      throw new Error(message || `Request to ${path} failed with ${response.status}`)
+    }
+    if (response.status === 204) {
+      return undefined as T
+    }
+    return (await response.json()) as T
+  }
+
+  async getOverlayInsights(input: { zoneCode?: string; address?: string }): Promise<OverlayInsights> {
+    const payload = input.address
+      ? { address: input.address }
+      : {
+          geometry: {
+            type: 'Feature',
+            properties: {
+              zone_code: input.zoneCode ?? 'RA',
+            },
+          },
+        }
+    const data = await this.request<BuildableResponse>('api/v1/screen/buildable', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+    return {
+      zoneCode: data.zone_code ?? input.zoneCode ?? null,
+      overlays: data.overlays ?? [],
+      advisoryHints: data.advisory_hints ?? [],
+    }
+  }
+
+  async listRules(): Promise<RuleSummary[]> {
+    const data = await this.request<RulesResponse>('api/v1/rules')
+    return data.items
+  }
+
+  async listAuditTrail(ruleId?: number): Promise<AuditEvent[]> {
+    const url = ruleId ? `api/v1/review/diffs?rule_id=${ruleId}` : 'api/v1/review/diffs'
+    const data = await this.request<AuditResponse>(url)
+    return data.items.map((item) => ({
+      ruleId: item.rule_id,
+      baseline: item.baseline,
+      updated: item.updated,
+    }))
+  }
+
+  async uploadCadDrawing(
+    file: Pick<File, 'name' | 'size'>,
+    options: { zoneCode?: string; address?: string } = {},
+  ): Promise<CadParseJob> {
+    const insights = await this.getOverlayInsights({ zoneCode: options.zoneCode, address: options.address })
+    const jobId = `cad-${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 8)}`
+    const hasInsights = insights.overlays.length > 0 || insights.advisoryHints.length > 0
+    return {
+      jobId,
+      fileName: file.name,
+      zoneCode: insights.zoneCode,
+      overlays: insights.overlays,
+      hints: insights.advisoryHints,
+      status: hasInsights ? 'ready' : 'processing',
+      message: hasInsights ? undefined : 'Awaiting overlay enrichment',
+    }
+  }
+
+  pollParseStatus(options: {
+    jobId: string
+    zoneCode?: string | null
+    onUpdate: (update: ParseStatusUpdate) => void
+    intervalMs?: number
+    timeoutMs?: number
+  }) {
+    const { jobId, zoneCode = null, onUpdate, intervalMs = 2000, timeoutMs = 15000 } = options
+    let cancelled = false
+    const startedAt = Date.now()
+
+    const loop = async () => {
+      while (!cancelled) {
+        try {
+          const insight = zoneCode ? await this.getOverlayInsights({ zoneCode }) : null
+          const status: ParseStatusUpdate = {
+            jobId,
+            status: insight && insight.overlays.length > 0 ? 'ready' : 'processing',
+            overlays: insight?.overlays ?? [],
+            hints: insight?.advisoryHints ?? [],
+            zoneCode: insight?.zoneCode ?? zoneCode,
+            updatedAt: new Date().toISOString(),
+          }
+          onUpdate(status)
+          if (status.status === 'ready') {
+            break
+          }
+        } catch (error) {
+          onUpdate({
+            jobId,
+            status: 'error',
+            overlays: [],
+            hints: [],
+            zoneCode,
+            updatedAt: new Date().toISOString(),
+            message: error instanceof Error ? error.message : 'Unknown error',
+          })
+          break
+        }
+
+        if (timeoutMs && Date.now() - startedAt >= timeoutMs) {
+          onUpdate({
+            jobId,
+            status: 'error',
+            overlays: [],
+            hints: [],
+            zoneCode,
+            updatedAt: new Date().toISOString(),
+            message: 'Polling timed out',
+          })
+          break
+        }
+
+        await delay(intervalMs)
+      }
+    }
+
+    loop().catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      onUpdate({
+        jobId,
+        status: 'error',
+        overlays: [],
+        hints: [],
+        zoneCode,
+        updatedAt: new Date().toISOString(),
+        message,
+      })
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }
+
+  subscribeToOverlayUpdates(options: {
+    zoneCode: string
+    onUpdate: (insights: OverlayInsights) => void
+    intervalMs?: number
+  }) {
+    const { zoneCode, onUpdate, intervalMs = 5000 } = options
+    let cancelled = false
+
+    const loop = async () => {
+      while (!cancelled) {
+        try {
+          const insight = await this.getOverlayInsights({ zoneCode })
+          onUpdate(insight)
+        } catch (error) {
+          onUpdate({
+            zoneCode,
+            overlays: [],
+            advisoryHints: [
+              error instanceof Error ? error.message : 'Unable to refresh overlays at the moment.',
+            ],
+          })
+          break
+        }
+        await delay(intervalMs)
+      }
+    }
+
+    loop().catch(() => {
+      /* no-op: consumers already notified through onUpdate */
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }
+
+  async getDefaultPipelineSuggestions(
+    context: { overlays?: string[]; hints?: string[] } = {},
+  ): Promise<PipelineSuggestion[]> {
+    const rules = await this.listRules()
+    const overlays = new Set(context.overlays ?? [])
+    const hints = new Set(context.hints ?? [])
+    const byTopic = new Map<string, RuleSummary[]>()
+
+    rules.forEach((rule) => {
+      if (rule.topic) {
+        byTopic.set(rule.topic, [...(byTopic.get(rule.topic) ?? []), rule])
+      }
+    })
+
+    const suggestions: PipelineSuggestion[] = []
+
+    byTopic.forEach((topicRules, topic) => {
+      const related = topicRules.filter((rule) =>
+        rule.overlays.some((overlay) => overlays.has(overlay)) ||
+        rule.advisoryHints.some((hint) => hints.has(hint)),
+      )
+      const automationScore = related.length > 0 ? Math.min(0.95, 0.5 + related.length / (topicRules.length * 1.5)) : 0.45
+      const savings = Math.round(automationScore * 100 * 0.3)
+      const reviewHours = Math.max(2, Math.round(topicRules.length * automationScore))
+
+      suggestions.push({
+        id: `pipeline-${topic.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`,
+        title: `${topic} fast-track`,
+        description:
+          related.length > 0
+            ? `Prioritise ${related.length} overlays-triggered checks within the ${topic} rules.`
+            : `Establish defaults for ${topic} checks before overlays arrive.`,
+        focus: topic,
+        automationScore,
+        reviewHoursSaved: reviewHours,
+        estimatedSavingsPercent: savings,
+        relatedRuleIds: topicRules.map((rule) => rule.id),
+      })
+    })
+
+    if (suggestions.length === 0) {
+      return [
+        {
+          id: 'pipeline-default',
+          title: 'Core compliance pipeline',
+          description: 'Baseline review workflow across zoning, fire safety and environmental health topics.',
+          focus: 'baseline',
+          automationScore: 0.5,
+          reviewHoursSaved: 6,
+          estimatedSavingsPercent: 18,
+          relatedRuleIds: rules.slice(0, 6).map((rule) => rule.id),
+        },
+      ]
+    }
+
+    return suggestions.sort((a, b) => b.automationScore - a.automationScore)
+  }
+}
+
+export function useApiClient() {
+  return useMemo(() => new ApiClient(), [])
+}

--- a/frontend/src/hooks/useRules.ts
+++ b/frontend/src/hooks/useRules.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+
+import type { ApiClient, RuleSummary } from '../api/client'
+
+export function useRules(client: ApiClient) {
+  const [rules, setRules] = useState<RuleSummary[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    client
+      .listRules()
+      .then((items) => {
+        if (!cancelled) {
+          setRules(items)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [client])
+
+  return { rules, loading }
+}
+
+export default useRules

--- a/frontend/src/i18n/LocaleContext.tsx
+++ b/frontend/src/i18n/LocaleContext.tsx
@@ -1,0 +1,40 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, ReactNode, useContext, useMemo, useState } from 'react'
+
+import { STRINGS, type AppStrings, type Locale } from './strings'
+
+interface LocaleContextValue {
+  locale: Locale
+  strings: AppStrings
+  setLocale: (locale: Locale) => void
+}
+
+const LocaleContext = createContext<LocaleContextValue | undefined>(undefined)
+
+interface LocaleProviderProps {
+  children: ReactNode
+  defaultLocale?: Locale
+}
+
+export function LocaleProvider({ children, defaultLocale = 'en' }: LocaleProviderProps) {
+  const [locale, setLocale] = useState<Locale>(defaultLocale)
+
+  const value = useMemo<LocaleContextValue>(
+    () => ({
+      locale,
+      strings: STRINGS[locale],
+      setLocale,
+    }),
+    [locale],
+  )
+
+  return <LocaleContext.Provider value={value}>{children}</LocaleContext.Provider>
+}
+
+export function useLocale() {
+  const context = useContext(LocaleContext)
+  if (!context) {
+    throw new Error('useLocale must be used within a LocaleProvider')
+  }
+  return context
+}

--- a/frontend/src/i18n/strings.ts
+++ b/frontend/src/i18n/strings.ts
@@ -1,0 +1,221 @@
+export type Locale = 'en' | 'zh'
+
+export interface AppStrings {
+  app: {
+    title: string
+    tagline: string
+    helper: string
+  }
+  nav: {
+    home: string
+    upload: string
+    detection: string
+    pipelines: string
+    feasibility: string
+  }
+  uploader: {
+    title: string
+    subtitle: string
+    dropHint: string
+    browseLabel: string
+    latestStatus: string
+    parsing: string
+    ready: string
+    error: string
+    overlays: string
+    hints: string
+    zone: string
+  }
+  detection: {
+    title: string
+    subtitle: string
+    overlays: string
+    advisory: string
+    tableHeading: string
+    unit: string
+    floor: string
+    area: string
+    status: string
+    empty: string
+    locked: string
+    exportCta: string
+  }
+  pipelines: {
+    title: string
+    subtitle: string
+    suggestionHeading: string
+    pipelineFocus: string
+    automationScore: string
+    reviewHours: string
+    savings: string
+  }
+  controls: {
+    source: string
+    pending: string
+    approved: string
+    rejected: string
+    showLayer: string
+    hideLayer: string
+    approveAll: string
+    rejectAll: string
+    lockZone: string
+    unlockZone: string
+    locked: string
+  }
+  panels: {
+    rulePackTitle: string
+    rulePackEmpty: string
+    auditTitle: string
+    exportTitle: string
+    exportSubtitle: string
+    roiTitle: string
+    roiSubtitle: string
+  }
+}
+
+export const STRINGS: Record<Locale, AppStrings> = {
+  en: {
+    app: {
+      title: 'Optimal Build Studio',
+      tagline: 'Accelerate compliance and design coordination across your CAD workflows.',
+      helper: 'Switch language',
+    },
+    nav: {
+      home: 'Overview',
+      upload: 'Upload CAD',
+      detection: 'Floor & unit detection',
+      pipelines: 'Default pipelines',
+      feasibility: 'Feasibility wizard',
+    },
+    uploader: {
+      title: 'Upload building layouts',
+      subtitle: 'Drop DXF/DWG files to launch the parse pipeline and monitor overlays in real-time.',
+      dropHint: 'Drag & drop or paste files here',
+      browseLabel: 'Browse files',
+      latestStatus: 'Latest status',
+      parsing: 'Processing CAD layers…',
+      ready: 'Parse completed',
+      error: 'Something went wrong while parsing the CAD file.',
+      overlays: 'Detected overlays',
+      hints: 'Authority hints',
+      zone: 'Zone',
+    },
+    detection: {
+      title: 'Floor and unit detection preview',
+      subtitle: 'Review detected spaces, approve batches and understand overlay impact.',
+      overlays: 'Overlays in effect',
+      advisory: 'Authority advisory hints',
+      tableHeading: 'Detected units',
+      unit: 'Unit',
+      floor: 'Floor',
+      area: 'Area (sqm)',
+      status: 'Status',
+      empty: 'No units match the current filters.',
+      locked: 'Zone is locked. Unlock to update review status.',
+      exportCta: 'Export review pack',
+    },
+    pipelines: {
+      title: 'Default pipeline suggestions',
+      subtitle: 'Leverage rule packs tailored to the detected overlays and topics.',
+      suggestionHeading: 'Suggested automation pipelines',
+      pipelineFocus: 'Focus',
+      automationScore: 'Automation score',
+      reviewHours: 'Manual review hours saved',
+      savings: 'Estimated compliance savings',
+    },
+    controls: {
+      source: 'Source',
+      pending: 'Pending',
+      approved: 'Approved',
+      rejected: 'Rejected',
+      showLayer: 'Show layer',
+      hideLayer: 'Hide layer',
+      approveAll: 'Approve all pending',
+      rejectAll: 'Reject all pending',
+      lockZone: 'Lock zone',
+      unlockZone: 'Unlock zone',
+      locked: 'Zone locked',
+    },
+    panels: {
+      rulePackTitle: 'Rule pack explanation',
+      rulePackEmpty: 'Rules will appear after the first overlays are processed.',
+      auditTitle: 'Audit timeline',
+      exportTitle: 'Export options',
+      exportSubtitle: 'Deliver CAD overlays and compliance notes in preferred formats.',
+      roiTitle: 'ROI snapshot',
+      roiSubtitle: 'Quantify effort saved through automation.',
+    },
+  },
+  zh: {
+    app: {
+      title: 'Optimal Build Studio',
+      tagline: '加速 CAD 工作流程中的合规与协同。',
+      helper: '切换语言',
+    },
+    nav: {
+      home: '概览',
+      upload: '上传 CAD',
+      detection: '楼层与单元检测',
+      pipelines: '默认流程',
+      feasibility: '可行性向导',
+    },
+    uploader: {
+      title: '上传建筑平面',
+      subtitle: '拖入 DXF/DWG 文件启动解析流程并实时查看覆盖层。',
+      dropHint: '拖拽或粘贴文件到此',
+      browseLabel: '选择文件',
+      latestStatus: '最新状态',
+      parsing: '正在处理 CAD 图层…',
+      ready: '解析完成',
+      error: '解析 CAD 文件时出错。',
+      overlays: '检测到的覆盖层',
+      hints: '主管机构提示',
+      zone: '分区',
+    },
+    detection: {
+      title: '楼层与单元检测预览',
+      subtitle: '审阅检测出的空间，批量审批并了解覆盖层影响。',
+      overlays: '适用覆盖层',
+      advisory: '主管机构提示',
+      tableHeading: '检测到的单元',
+      unit: '单元',
+      floor: '楼层',
+      area: '面积 (平方米)',
+      status: '状态',
+      empty: '当前筛选条件下没有单元。',
+      locked: '分区已锁定，解锁后才能更新状态。',
+      exportCta: '导出审查包',
+    },
+    pipelines: {
+      title: '默认流程建议',
+      subtitle: '根据检测到的覆盖层与主题推荐规则包。',
+      suggestionHeading: '自动化流程建议',
+      pipelineFocus: '关注点',
+      automationScore: '自动化评分',
+      reviewHours: '节省的人工审核时长',
+      savings: '预计合规节省',
+    },
+    controls: {
+      source: '原始',
+      pending: '待处理',
+      approved: '已通过',
+      rejected: '已拒绝',
+      showLayer: '显示图层',
+      hideLayer: '隐藏图层',
+      approveAll: '批量通过',
+      rejectAll: '批量拒绝',
+      lockZone: '锁定分区',
+      unlockZone: '解锁分区',
+      locked: '已锁定',
+    },
+    panels: {
+      rulePackTitle: '规则包说明',
+      rulePackEmpty: '解析完成后将显示规则列表。',
+      auditTitle: '审计时间线',
+      exportTitle: '导出选项',
+      exportSubtitle: '以首选格式导出覆盖层与合规备注。',
+      roiTitle: '投资回报速览',
+      roiSubtitle: '量化自动化节省的工作量。',
+    },
+  },
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -36,46 +36,544 @@ h1, h2, h3 {
   line-height: 1.1;
 }
 
-.app-shell {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 3rem 1.5rem;
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.app-layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
+}
+
+.app-layout__nav {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2.5rem 2rem;
   display: flex;
   flex-direction: column;
   gap: 2rem;
 }
 
-.app-shell__header h1 {
-  margin-bottom: 0.5rem;
-  font-size: 2.5rem;
+.app-layout__brand h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.75rem;
+  color: #ffffff;
 }
 
-.app-shell__nav {
+.app-layout__brand p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.7);
+  font-size: 0.95rem;
+}
+
+.app-layout__nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
   display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-.app-shell__nav-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.75rem 1.5rem;
-  border-radius: 9999px;
-  background-color: #2563eb;
+.app-layout__nav-link {
+  display: block;
+  padding: 0.65rem 1rem;
+  border-radius: 0.75rem;
+  color: inherit;
+  background: rgba(148, 163, 184, 0.15);
+}
+
+.app-layout__nav-link--active {
+  background: #2563eb;
   color: #ffffff;
   font-weight: 600;
 }
 
-.app-shell__nav-link + .app-shell__nav-link {
-  background-color: #0f172a;
+.app-layout__main {
+  padding: 2.5rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
 }
 
-.app-shell__section ul {
-  padding-left: 1.25rem;
+.app-layout__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2rem;
+  background: #ffffff;
+  border-radius: 1.5rem;
+  padding: 1.75rem 2rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.app-layout__header h2 {
+  margin: 0 0 0.35rem;
+  font-size: 2rem;
+}
+
+.app-layout__header p {
   margin: 0;
+  color: #475569;
+  max-width: 540px;
+}
+
+.app-layout__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.app-layout__locale select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
+  font-weight: 600;
+}
+
+.app-layout__content {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.app-home {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.app-home__card {
+  background: #ffffff;
+  padding: 1.75rem;
+  border-radius: 1.25rem;
+  box-shadow: 0 16px 24px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.app-home__card h3 {
+  margin: 0;
+}
+
+.app-home__card p {
+  margin: 0;
+  color: #475569;
+  flex: 1;
+}
+
+.app-home__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  background: #2563eb;
+  color: #ffffff;
+  font-weight: 600;
+  width: fit-content;
+}
+
+.cad-uploader {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: stretch;
+}
+
+.cad-uploader__dropzone {
+  border: 2px dashed rgba(37, 99, 235, 0.4);
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  text-align: center;
+  background: rgba(37, 99, 235, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.cad-uploader__dropzone--dragging {
+  background: rgba(37, 99, 235, 0.15);
+  border-color: #2563eb;
+}
+
+.cad-uploader__input {
+  display: none;
+}
+
+.cad-uploader__hint {
+  margin: 0;
+  font-weight: 600;
+}
+
+.cad-uploader__browse {
+  align-self: center;
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: #2563eb;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.cad-uploader__status {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+}
+
+.cad-uploader__status h3 {
+  margin-top: 0;
+}
+
+.cad-uploader__meta {
   display: grid;
   gap: 0.75rem;
+  margin: 1.5rem 0 0;
+}
+
+.cad-uploader__meta div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.cad-uploader__meta dt {
+  font-weight: 600;
+}
+
+.cad-uploader__message {
+  color: #b91c1c;
+  margin: 0.75rem 0 0;
+}
+
+.cad-upload {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.cad-upload__controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.cad-upload__label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.cad-upload__label select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5f5;
+}
+
+.cad-upload__error {
+  color: #b91c1c;
+}
+
+.cad-preview {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.cad-preview__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.cad-preview__summary {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  font-weight: 600;
+  color: #1e3a8a;
+}
+
+.cad-preview__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.cad-preview__panel {
+  background: #f1f5f9;
+  border-radius: 1rem;
+  padding: 1.5rem;
+}
+
+.cad-preview__panel h3 {
+  margin-top: 0;
+}
+
+.cad-preview__panel ul {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.cad-preview__lock-indicator {
+  margin: 0;
+  color: #b45309;
+  font-weight: 600;
+}
+
+.cad-preview__table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #ffffff;
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.cad-preview__table caption {
+  text-align: left;
+  font-weight: 600;
+  padding: 0 1rem 0.75rem;
+}
+
+.cad-preview__table th,
+.cad-preview__table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+}
+
+.cad-status {
+  font-weight: 600;
+}
+
+.cad-status--source {
+  color: #334155;
+}
+
+.cad-status--pending {
+  color: #b45309;
+}
+
+.cad-status--approved {
+  color: #15803d;
+}
+
+.cad-status--rejected {
+  color: #b91c1c;
+}
+
+.cad-panel {
+  background: #ffffff;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cad-panel h3 {
+  margin: 0;
+}
+
+.cad-panel__hint {
+  margin: 0;
+  color: #b45309;
+}
+
+.cad-layer-toggle {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.cad-layer-toggle__button {
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
+  cursor: pointer;
+}
+
+.cad-layer-toggle__button--active {
+  background: #2563eb;
+  color: #ffffff;
+  border-color: #2563eb;
+}
+
+.cad-bulk-controls {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.cad-bulk-controls button,
+.cad-panel button,
+.cad-uploader__browse,
+.cad-detection__toolbar select,
+.cad-upload__label select,
+.cad-pipelines__toolbar select {
+  font-family: inherit;
+}
+
+.cad-bulk-controls button,
+.cad-panel button,
+.cad-export button,
+.cad-pipelines__toolbar select {
+  padding: 0.5rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5f5;
+  background: #2563eb;
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.cad-bulk-controls button:disabled,
+.cad-panel button:disabled,
+.cad-export button:disabled {
+  background: #cbd5f5;
+  color: #64748b;
+  cursor: not-allowed;
+}
+
+.cad-detection__toolbar {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.cad-detection__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.cad-rulepack {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.cad-rulepack > li {
+  background: #f8fafc;
+  padding: 1rem;
+  border-radius: 1rem;
+}
+
+.cad-rulepack__overlay {
+  display: inline-block;
+  margin-left: 0.5rem;
+  font-size: 0.85rem;
+  color: #2563eb;
+}
+
+.cad-timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.cad-timeline__baseline {
+  margin: 0;
+  color: #475569;
+}
+
+.cad-export {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 1rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.cad-export button {
+  width: 100%;
+}
+
+.cad-roi {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.cad-roi dt {
+  font-weight: 600;
+}
+
+.cad-roi dd {
+  margin: 0.25rem 0 0;
+  font-size: 1.35rem;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.cad-pipelines__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.cad-pipelines__context {
+  margin: 0;
+  color: #475569;
+}
+
+.cad-pipelines__error {
+  color: #b91c1c;
+}
+
+.cad-pipelines ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.cad-pipelines__item {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+}
+
+.cad-pipelines__item dl {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1rem 0 0;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.cad-pipelines__item dt {
+  font-weight: 600;
+}
+
+.cad-pipelines__item dd {
+  margin: 0.25rem 0 0;
 }
 
 .feasibility-wizard {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,14 +1,30 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { createBrowserRouter, RouterProvider } from './router'
-import App from './App'
+import HomeOverview from './App'
+import { LocaleProvider } from './i18n/LocaleContext'
+import CadDetectionPage from './pages/CadDetectionPage'
+import CadPipelinesPage from './pages/CadPipelinesPage'
+import CadUploadPage from './pages/CadUploadPage'
 import FeasibilityWizard from './modules/feasibility/FeasibilityWizard'
 import './index.css'
 
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <App />,
+    element: <HomeOverview />,
+  },
+  {
+    path: '/cad/upload',
+    element: <CadUploadPage />,
+  },
+  {
+    path: '/cad/detection',
+    element: <CadDetectionPage />,
+  },
+  {
+    path: '/cad/pipelines',
+    element: <CadPipelinesPage />,
   },
   {
     path: '/feasibility',
@@ -18,6 +34,8 @@ const router = createBrowserRouter([
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <LocaleProvider>
+      <RouterProvider router={router} />
+    </LocaleProvider>
   </React.StrictMode>,
 )

--- a/frontend/src/modules/cad/AuditTimelinePanel.tsx
+++ b/frontend/src/modules/cad/AuditTimelinePanel.tsx
@@ -1,0 +1,33 @@
+import type { AuditEvent } from '../../api/client'
+import { useLocale } from '../../i18n/LocaleContext'
+
+interface AuditTimelinePanelProps {
+  events: AuditEvent[]
+  loading?: boolean
+}
+
+export function AuditTimelinePanel({ events, loading = false }: AuditTimelinePanelProps) {
+  const { strings } = useLocale()
+
+  return (
+    <section className="cad-panel">
+      <h3>{strings.panels.auditTitle}</h3>
+      {loading && <p>Loading…</p>}
+      {!loading && events.length === 0 && <p>—</p>}
+      {!loading && events.length > 0 && (
+        <ol className="cad-timeline">
+          {events.map((event) => (
+            <li key={event.ruleId}>
+              <p>
+                <strong>#{event.ruleId}</strong> {event.updated}
+              </p>
+              <p className="cad-timeline__baseline">{event.baseline}</p>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  )
+}
+
+export default AuditTimelinePanel

--- a/frontend/src/modules/cad/BulkReviewControls.tsx
+++ b/frontend/src/modules/cad/BulkReviewControls.tsx
@@ -1,0 +1,35 @@
+import { useLocale } from '../../i18n/LocaleContext'
+
+interface BulkReviewControlsProps {
+  pendingCount: number
+  onApproveAll: () => void
+  onRejectAll: () => void
+  disabled?: boolean
+}
+
+export function BulkReviewControls({
+  pendingCount,
+  onApproveAll,
+  onRejectAll,
+  disabled = false,
+}: BulkReviewControlsProps) {
+  const { strings } = useLocale()
+
+  return (
+    <section className="cad-panel">
+      <h3>{strings.controls.pending}</h3>
+      <p>{pendingCount} {strings.controls.pending.toLowerCase()}</p>
+      <div className="cad-bulk-controls">
+        <button type="button" onClick={onApproveAll} disabled={disabled || pendingCount === 0}>
+          {strings.controls.approveAll}
+        </button>
+        <button type="button" onClick={onRejectAll} disabled={disabled || pendingCount === 0}>
+          {strings.controls.rejectAll}
+        </button>
+      </div>
+      {disabled && <p className="cad-panel__hint">{strings.controls.locked}</p>}
+    </section>
+  )
+}
+
+export default BulkReviewControls

--- a/frontend/src/modules/cad/CadDetectionPreview.stories.tsx
+++ b/frontend/src/modules/cad/CadDetectionPreview.stories.tsx
@@ -1,0 +1,40 @@
+import CadDetectionPreview from './CadDetectionPreview'
+import { LocaleProvider } from '../../i18n/LocaleContext'
+import type { DetectedUnit } from './types'
+
+const meta = {
+  title: 'CAD/Detection Preview',
+  component: CadDetectionPreview,
+}
+
+export default meta
+
+const units: DetectedUnit[] = [
+  { id: 'L01-01', floor: 1, unitLabel: '#01-01', areaSqm: 82, status: 'source' },
+  { id: 'L01-02', floor: 1, unitLabel: '#01-02', areaSqm: 79, status: 'pending' },
+  { id: 'L02-01', floor: 2, unitLabel: '#02-01', areaSqm: 85, status: 'approved' },
+  { id: 'L03-01', floor: 3, unitLabel: '#03-01', areaSqm: 90, status: 'rejected' },
+]
+
+export const Default = () => (
+  <LocaleProvider>
+    <CadDetectionPreview
+      units={units}
+      overlays={['fire_access', 'community_facility']}
+      hints={['Coordinate with SCDF on staging']}
+      zoneCode="RA"
+    />
+  </LocaleProvider>
+)
+
+export const Locked = () => (
+  <LocaleProvider>
+    <CadDetectionPreview
+      units={units.filter((unit) => unit.status !== 'rejected')}
+      overlays={[]}
+      hints={['Awaiting overlays']}
+      zoneCode="CBD"
+      locked
+    />
+  </LocaleProvider>
+)

--- a/frontend/src/modules/cad/CadDetectionPreview.tsx
+++ b/frontend/src/modules/cad/CadDetectionPreview.tsx
@@ -1,0 +1,101 @@
+import { DetectedUnit } from './types'
+import { useLocale } from '../../i18n/LocaleContext'
+
+interface CadDetectionPreviewProps {
+  units: DetectedUnit[]
+  overlays: string[]
+  hints: string[]
+  zoneCode?: string | null
+  locked?: boolean
+}
+
+const STATUS_LABELS: Record<DetectedUnit['status'], string> = {
+  source: 'source',
+  pending: 'pending',
+  approved: 'approved',
+  rejected: 'rejected',
+}
+
+export function CadDetectionPreview({
+  units,
+  overlays,
+  hints,
+  zoneCode,
+  locked = false,
+}: CadDetectionPreviewProps) {
+  const { strings } = useLocale()
+  const floors = Array.from(new Set(units.map((unit) => unit.floor))).sort((a, b) => a - b)
+
+  return (
+    <section className="cad-preview">
+      <header className="cad-preview__header">
+        <div>
+          <h2>{strings.detection.title}</h2>
+          <p>{strings.detection.subtitle}</p>
+        </div>
+        <div className="cad-preview__summary">
+          <span>{floors.length} floors</span>
+          <span>{units.length} units</span>
+          {zoneCode && <span>Zone {zoneCode}</span>}
+        </div>
+      </header>
+
+      <div className="cad-preview__grid">
+        <div className="cad-preview__panel">
+          <h3>{strings.detection.overlays}</h3>
+          {overlays.length === 0 ? <p>—</p> : (
+            <ul>
+              {overlays.map((overlay) => (
+                <li key={overlay}>{overlay}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className="cad-preview__panel">
+          <h3>{strings.detection.advisory}</h3>
+          {hints.length === 0 ? <p>—</p> : (
+            <ul>
+              {hints.map((hint) => (
+                <li key={hint}>{hint}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {locked && <p className="cad-preview__lock-indicator">{strings.detection.locked}</p>}
+
+      <table className="cad-preview__table">
+        <caption>{strings.detection.tableHeading}</caption>
+        <thead>
+          <tr>
+            <th>{strings.detection.unit}</th>
+            <th>{strings.detection.floor}</th>
+            <th>{strings.detection.area}</th>
+            <th>{strings.detection.status}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {units.length === 0 ? (
+            <tr>
+              <td colSpan={4}>{strings.detection.empty}</td>
+            </tr>
+          ) : (
+            units.map((unit) => (
+              <tr key={unit.id}>
+                <td>{unit.unitLabel}</td>
+                <td>{unit.floor}</td>
+                <td>{unit.areaSqm.toFixed(1)}</td>
+                <td className={`cad-status cad-status--${unit.status}`}>
+                  {strings.controls[STATUS_LABELS[unit.status] as keyof typeof strings.controls]}
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </section>
+  )
+}
+
+export default CadDetectionPreview

--- a/frontend/src/modules/cad/CadUploader.stories.tsx
+++ b/frontend/src/modules/cad/CadUploader.stories.tsx
@@ -1,0 +1,40 @@
+import CadUploader from './CadUploader'
+import type { ParseStatusUpdate } from '../../api/client'
+import { LocaleProvider } from '../../i18n/LocaleContext'
+
+const meta = {
+  title: 'CAD/Uploader',
+  component: CadUploader,
+}
+
+export default meta
+
+const sampleStatus: ParseStatusUpdate = {
+  jobId: 'demo',
+  status: 'ready',
+  overlays: ['fire_access', 'coastal'],
+  hints: ['Ensure secondary egress'],
+  zoneCode: 'RA',
+  updatedAt: new Date().toISOString(),
+}
+
+export const Ready = () => (
+  <LocaleProvider>
+    <div style={{ maxWidth: 960 }}>
+      <CadUploader onUpload={console.log} status={sampleStatus} zoneCode="RA" />
+    </div>
+  </LocaleProvider>
+)
+
+export const Loading = () => (
+  <LocaleProvider>
+    <div style={{ maxWidth: 960 }}>
+      <CadUploader
+        onUpload={console.log}
+        isUploading
+        status={{ ...sampleStatus, status: 'processing', overlays: [], hints: [] }}
+        zoneCode="RCR"
+      />
+    </div>
+  </LocaleProvider>
+)

--- a/frontend/src/modules/cad/CadUploader.tsx
+++ b/frontend/src/modules/cad/CadUploader.tsx
@@ -1,0 +1,103 @@
+import { ChangeEvent, DragEvent, useRef, useState } from 'react'
+
+import type { ParseStatusUpdate } from '../../api/client'
+import { useLocale } from '../../i18n/LocaleContext'
+
+interface CadUploaderProps {
+  onUpload: (file: File) => void
+  isUploading?: boolean
+  status?: ParseStatusUpdate | null
+  zoneCode?: string | null
+}
+
+export function CadUploader({ onUpload, isUploading = false, status, zoneCode }: CadUploaderProps) {
+  const { strings } = useLocale()
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const [isDragging, setIsDragging] = useState(false)
+
+  const handleFiles = (files: FileList | null) => {
+    if (!files || files.length === 0) {
+      return
+    }
+    onUpload(files[0])
+  }
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    setIsDragging(false)
+    handleFiles(event.dataTransfer?.files ?? null)
+  }
+
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    setIsDragging(true)
+  }
+
+  const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    setIsDragging(false)
+  }
+
+  const handleBrowse = () => {
+    inputRef.current?.click()
+  }
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    handleFiles(event.target.files)
+  }
+
+  const latestStatus = status?.status === 'ready'
+    ? strings.uploader.ready
+    : status?.status === 'error'
+      ? strings.uploader.error
+      : status
+        ? strings.uploader.parsing
+        : null
+
+  return (
+    <div className="cad-uploader">
+      <div
+        className={`cad-uploader__dropzone${isDragging ? ' cad-uploader__dropzone--dragging' : ''}`}
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        role="presentation"
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".dxf,.dwg,.zip"
+          className="cad-uploader__input"
+          onChange={handleChange}
+          disabled={isUploading}
+        />
+        <p className="cad-uploader__hint">{strings.uploader.dropHint}</p>
+        <button type="button" className="cad-uploader__browse" onClick={handleBrowse} disabled={isUploading}>
+          {strings.uploader.browseLabel}
+        </button>
+      </div>
+
+      <aside className="cad-uploader__status">
+        <h3>{strings.uploader.latestStatus}</h3>
+        {latestStatus ? <p>{latestStatus}</p> : <p>{strings.uploader.parsing}</p>}
+        {status?.message && <p className="cad-uploader__message">{status.message}</p>}
+        <dl className="cad-uploader__meta">
+          <div>
+            <dt>{strings.uploader.zone}</dt>
+            <dd>{zoneCode ?? status?.zoneCode ?? '—'}</dd>
+          </div>
+          <div>
+            <dt>{strings.uploader.overlays}</dt>
+            <dd>{status?.overlays?.length ? status.overlays.join(', ') : '—'}</dd>
+          </div>
+          <div>
+            <dt>{strings.uploader.hints}</dt>
+            <dd>{status?.hints?.length ? status.hints.join(', ') : '—'}</dd>
+          </div>
+        </dl>
+      </aside>
+    </div>
+  )
+}
+
+export default CadUploader

--- a/frontend/src/modules/cad/ExportDialog.tsx
+++ b/frontend/src/modules/cad/ExportDialog.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+
+import { useLocale } from '../../i18n/LocaleContext'
+
+interface ExportDialogProps {
+  formats?: string[]
+  onExport?: (format: string) => void
+  disabled?: boolean
+}
+
+const DEFAULT_FORMATS = ['DXF', 'GeoJSON', 'CSV']
+
+export function ExportDialog({ formats = DEFAULT_FORMATS, onExport, disabled = false }: ExportDialogProps) {
+  const { strings } = useLocale()
+  const [open, setOpen] = useState(false)
+
+  const handleExport = (format: string) => {
+    onExport?.(format)
+    setOpen(false)
+  }
+
+  return (
+    <section className="cad-panel">
+      <h3>{strings.panels.exportTitle}</h3>
+      <p>{strings.panels.exportSubtitle}</p>
+      <button type="button" onClick={() => setOpen((value) => !value)} disabled={disabled}>
+        {strings.detection.exportCta}
+      </button>
+      {open && (
+        <ul className="cad-export">
+          {formats.map((format) => (
+            <li key={format}>
+              <button type="button" onClick={() => handleExport(format)} disabled={disabled}>
+                {format}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+export default ExportDialog

--- a/frontend/src/modules/cad/LayerTogglePanel.tsx
+++ b/frontend/src/modules/cad/LayerTogglePanel.tsx
@@ -1,0 +1,55 @@
+import { DetectionStatus } from './types'
+import { computeNextLayers } from './layerToggle'
+import { useLocale } from '../../i18n/LocaleContext'
+
+interface LayerTogglePanelProps {
+  activeLayers: DetectionStatus[]
+  onToggle: (status: DetectionStatus, next: DetectionStatus[]) => void
+  disabled?: boolean
+}
+
+const ORDER: DetectionStatus[] = ['source', 'pending', 'approved', 'rejected']
+
+export function LayerTogglePanel({ activeLayers, onToggle, disabled = false }: LayerTogglePanelProps) {
+  const { strings } = useLocale()
+
+  const handleToggle = (status: DetectionStatus) => {
+    if (disabled) {
+      return
+    }
+    const next = computeNextLayers(activeLayers, status)
+    onToggle(status, next)
+  }
+
+  const labels: Record<DetectionStatus, string> = {
+    source: strings.controls.source,
+    pending: strings.controls.pending,
+    approved: strings.controls.approved,
+    rejected: strings.controls.rejected,
+  }
+
+  return (
+    <section className="cad-panel">
+      <h3>{strings.controls.showLayer}</h3>
+      <div className="cad-layer-toggle">
+        {ORDER.map((status) => {
+          const isActive = activeLayers.includes(status)
+          return (
+            <button
+              key={status}
+              type="button"
+              className={`cad-layer-toggle__button${isActive ? ' cad-layer-toggle__button--active' : ''}`}
+              onClick={() => handleToggle(status)}
+              aria-pressed={isActive}
+              disabled={disabled}
+            >
+              {labels[status]}
+            </button>
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+export default LayerTogglePanel

--- a/frontend/src/modules/cad/RoiSummary.tsx
+++ b/frontend/src/modules/cad/RoiSummary.tsx
@@ -1,0 +1,37 @@
+import { RoiMetrics } from './types'
+import { useLocale } from '../../i18n/LocaleContext'
+
+interface RoiSummaryProps {
+  metrics: RoiMetrics
+}
+
+export function RoiSummary({ metrics }: RoiSummaryProps) {
+  const { strings } = useLocale()
+
+  return (
+    <section className="cad-panel">
+      <h3>{strings.panels.roiTitle}</h3>
+      <p>{strings.panels.roiSubtitle}</p>
+      <dl className="cad-roi">
+        <div>
+          <dt>{strings.pipelines.automationScore}</dt>
+          <dd>{Math.round(metrics.automationScore * 100)}%</dd>
+        </div>
+        <div>
+          <dt>{strings.pipelines.savings}</dt>
+          <dd>{metrics.savingsPercent}%</dd>
+        </div>
+        <div>
+          <dt>{strings.pipelines.reviewHours}</dt>
+          <dd>{metrics.reviewHoursSaved}h</dd>
+        </div>
+        <div>
+          <dt>Payback</dt>
+          <dd>{metrics.paybackWeeks} weeks</dd>
+        </div>
+      </dl>
+    </section>
+  )
+}
+
+export default RoiSummary

--- a/frontend/src/modules/cad/RulePackExplanationPanel.tsx
+++ b/frontend/src/modules/cad/RulePackExplanationPanel.tsx
@@ -1,0 +1,49 @@
+import type { RuleSummary } from '../../api/client'
+import { useLocale } from '../../i18n/LocaleContext'
+
+interface RulePackExplanationPanelProps {
+  rules: RuleSummary[]
+  loading?: boolean
+}
+
+export function RulePackExplanationPanel({ rules, loading = false }: RulePackExplanationPanelProps) {
+  const { strings } = useLocale()
+
+  const grouped = rules.reduce<Record<string, RuleSummary[]>>((acc, rule) => {
+    const key = rule.authority || rule.topic || 'general'
+    acc[key] = [...(acc[key] ?? []), rule]
+    return acc
+  }, {})
+
+  const keys = Object.keys(grouped).sort()
+
+  return (
+    <section className="cad-panel">
+      <h3>{strings.panels.rulePackTitle}</h3>
+      {loading && <p>Loading…</p>}
+      {!loading && keys.length === 0 && <p>{strings.panels.rulePackEmpty}</p>}
+      {!loading && keys.length > 0 && (
+        <ul className="cad-rulepack">
+          {keys.map((key) => (
+            <li key={key}>
+              <h4>{key}</h4>
+              <ul>
+                {grouped[key].map((rule) => (
+                  <li key={rule.id}>
+                    <strong>{rule.parameterKey}</strong> {rule.operator} {rule.value}
+                    {rule.unit ? ` ${rule.unit}` : ''}
+                    {rule.overlays.length > 0 && (
+                      <span className="cad-rulepack__overlay">{rule.overlays.join(', ')}</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+export default RulePackExplanationPanel

--- a/frontend/src/modules/cad/ZoneLockControls.tsx
+++ b/frontend/src/modules/cad/ZoneLockControls.tsx
@@ -1,0 +1,23 @@
+import { useLocale } from '../../i18n/LocaleContext'
+
+interface ZoneLockControlsProps {
+  locked: boolean
+  onToggle: (next: boolean) => void
+}
+
+export function ZoneLockControls({ locked, onToggle }: ZoneLockControlsProps) {
+  const { strings } = useLocale()
+  const label = locked ? strings.controls.unlockZone : strings.controls.lockZone
+
+  return (
+    <section className="cad-panel">
+      <h3>{strings.controls.locked}</h3>
+      <button type="button" onClick={() => onToggle(!locked)}>
+        {label}
+      </button>
+      {locked && <p className="cad-panel__hint">{strings.detection.locked}</p>}
+    </section>
+  )
+}
+
+export default ZoneLockControls

--- a/frontend/src/modules/cad/layerToggle.ts
+++ b/frontend/src/modules/cad/layerToggle.ts
@@ -1,0 +1,6 @@
+import type { DetectionStatus } from './types'
+
+export function computeNextLayers(activeLayers: DetectionStatus[], status: DetectionStatus) {
+  const isActive = activeLayers.includes(status)
+  return isActive ? activeLayers.filter((layer) => layer !== status) : [...activeLayers, status]
+}

--- a/frontend/src/modules/cad/types.ts
+++ b/frontend/src/modules/cad/types.ts
@@ -1,0 +1,16 @@
+export type DetectionStatus = 'source' | 'pending' | 'approved' | 'rejected'
+
+export interface DetectedUnit {
+  id: string
+  floor: number
+  unitLabel: string
+  areaSqm: number
+  status: DetectionStatus
+}
+
+export interface RoiMetrics {
+  automationScore: number
+  savingsPercent: number
+  reviewHoursSaved: number
+  paybackWeeks: number
+}

--- a/frontend/src/pages/CadDetectionPage.tsx
+++ b/frontend/src/pages/CadDetectionPage.tsx
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import type { AuditEvent, OverlayInsights } from '../api/client'
+import { AppLayout } from '../App'
+import { useApiClient } from '../api/client'
+import { useLocale } from '../i18n/LocaleContext'
+import AuditTimelinePanel from '../modules/cad/AuditTimelinePanel'
+import BulkReviewControls from '../modules/cad/BulkReviewControls'
+import CadDetectionPreview from '../modules/cad/CadDetectionPreview'
+import ExportDialog from '../modules/cad/ExportDialog'
+import LayerTogglePanel from '../modules/cad/LayerTogglePanel'
+import ZoneLockControls from '../modules/cad/ZoneLockControls'
+import { DetectionStatus, DetectedUnit } from '../modules/cad/types'
+
+const INITIAL_UNITS: DetectedUnit[] = [
+  { id: 'L01-01', floor: 1, unitLabel: '#01-01', areaSqm: 82, status: 'source' },
+  { id: 'L01-02', floor: 1, unitLabel: '#01-02', areaSqm: 79, status: 'pending' },
+  { id: 'L02-01', floor: 2, unitLabel: '#02-01', areaSqm: 85, status: 'approved' },
+  { id: 'L02-02', floor: 2, unitLabel: '#02-02', areaSqm: 88, status: 'pending' },
+  { id: 'L03-01', floor: 3, unitLabel: '#03-01', areaSqm: 92, status: 'rejected' },
+  { id: 'L03-02', floor: 3, unitLabel: '#03-02', areaSqm: 90, status: 'pending' },
+]
+
+export function CadDetectionPage() {
+  const apiClient = useApiClient()
+  const { strings } = useLocale()
+  const [zoneCode, setZoneCode] = useState('RA')
+  const [units, setUnits] = useState<DetectedUnit[]>(INITIAL_UNITS)
+  const [activeLayers, setActiveLayers] = useState<DetectionStatus[]>([
+    'source',
+    'pending',
+    'approved',
+    'rejected',
+  ])
+  const [locked, setLocked] = useState(false)
+  const [insights, setInsights] = useState<OverlayInsights | null>(null)
+  const [auditEvents, setAuditEvents] = useState<AuditEvent[]>([])
+  const [auditLoading, setAuditLoading] = useState(false)
+  const cancelRef = useRef<(() => void) | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setAuditLoading(true)
+    apiClient
+      .listAuditTrail()
+      .then((events) => {
+        if (!cancelled) {
+          setAuditEvents(events)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setAuditLoading(false)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [apiClient])
+
+  const refreshOverlays = useCallback(
+    async (code: string) => {
+      try {
+        const data = await apiClient.getOverlayInsights({ zoneCode: code })
+        setInsights(data)
+      } catch (error) {
+        setInsights({ zoneCode: code, overlays: [], advisoryHints: [String(error)] })
+      }
+    },
+    [apiClient],
+  )
+
+  useEffect(() => {
+    cancelRef.current?.()
+    refreshOverlays(zoneCode)
+    cancelRef.current = apiClient.subscribeToOverlayUpdates({
+      zoneCode,
+      onUpdate: setInsights,
+      intervalMs: 8000,
+    })
+    return () => {
+      cancelRef.current?.()
+    }
+  }, [apiClient, refreshOverlays, zoneCode])
+
+  const pendingCount = useMemo(() => units.filter((unit) => unit.status === 'pending').length, [units])
+
+  const visibleUnits = useMemo(
+    () => units.filter((unit) => activeLayers.includes(unit.status)),
+    [units, activeLayers],
+  )
+
+  const handleLayerToggle = useCallback((_: DetectionStatus, next: DetectionStatus[]) => {
+    setActiveLayers(next)
+  }, [])
+
+  const handleApproveAll = useCallback(() => {
+    if (locked) {
+      return
+    }
+    setUnits((prev) =>
+      prev.map((unit) => (unit.status === 'pending' ? { ...unit, status: 'approved' } : unit)),
+    )
+  }, [locked])
+
+  const handleRejectAll = useCallback(() => {
+    if (locked) {
+      return
+    }
+    setUnits((prev) =>
+      prev.map((unit) => (unit.status === 'pending' ? { ...unit, status: 'rejected' } : unit)),
+    )
+  }, [locked])
+
+  const handleExport = useCallback((format: string) => {
+    console.info(`Exporting review pack as ${format}`)
+  }, [])
+
+  return (
+    <AppLayout title={strings.detection.title} subtitle={strings.detection.subtitle}>
+      <div className="cad-detection__toolbar">
+        <label>
+          <span>{strings.uploader.zone}</span>
+          <select value={zoneCode} onChange={(event) => setZoneCode(event.target.value)} disabled={locked}>
+            <option value="RA">RA</option>
+            <option value="RCR">RCR</option>
+            <option value="CBD">CBD</option>
+          </select>
+        </label>
+      </div>
+
+      <CadDetectionPreview
+        units={visibleUnits}
+        overlays={insights?.overlays ?? []}
+        hints={insights?.advisoryHints ?? []}
+        zoneCode={insights?.zoneCode ?? zoneCode}
+        locked={locked}
+      />
+
+      <div className="cad-detection__grid">
+        <LayerTogglePanel activeLayers={activeLayers} onToggle={handleLayerToggle} />
+        <BulkReviewControls
+          pendingCount={pendingCount}
+          onApproveAll={handleApproveAll}
+          onRejectAll={handleRejectAll}
+          disabled={locked}
+        />
+        <ZoneLockControls locked={locked} onToggle={setLocked} />
+        <ExportDialog onExport={handleExport} disabled={pendingCount > 0} />
+      </div>
+
+      <AuditTimelinePanel events={auditEvents} loading={auditLoading} />
+    </AppLayout>
+  )
+}
+
+export default CadDetectionPage

--- a/frontend/src/pages/CadPipelinesPage.tsx
+++ b/frontend/src/pages/CadPipelinesPage.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import type { OverlayInsights, PipelineSuggestion } from '../api/client'
+import { AppLayout } from '../App'
+import { useApiClient } from '../api/client'
+import { useLocale } from '../i18n/LocaleContext'
+import useRules from '../hooks/useRules'
+import RulePackExplanationPanel from '../modules/cad/RulePackExplanationPanel'
+import RoiSummary from '../modules/cad/RoiSummary'
+import type { RoiMetrics } from '../modules/cad/types'
+
+const DEFAULT_ZONE = 'RA'
+
+export function CadPipelinesPage() {
+  const apiClient = useApiClient()
+  const { strings } = useLocale()
+  const [zoneCode, setZoneCode] = useState(DEFAULT_ZONE)
+  const [insights, setInsights] = useState<OverlayInsights | null>(null)
+  const [suggestions, setSuggestions] = useState<PipelineSuggestion[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const { rules, loading: rulesLoading } = useRules(apiClient)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const overlay = await apiClient.getOverlayInsights({ zoneCode })
+        if (!cancelled) {
+          setInsights(overlay)
+        }
+        const pipeline = await apiClient.getDefaultPipelineSuggestions({
+          overlays: overlay.overlays,
+          hints: overlay.advisoryHints,
+        })
+        if (!cancelled) {
+          setSuggestions(pipeline)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Unable to load suggestions')
+          setSuggestions([])
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    load().catch((err: unknown) => {
+      console.error('Failed to load pipeline suggestions', err)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [apiClient, zoneCode])
+
+  const roiMetrics = useMemo<RoiMetrics>(() => {
+    if (suggestions.length === 0) {
+      return {
+        automationScore: 0.5,
+        savingsPercent: 18,
+        reviewHoursSaved: 6,
+        paybackWeeks: 8,
+      }
+    }
+    const best = suggestions[0]
+    const totalHours = suggestions.reduce((sum, suggestion) => sum + suggestion.reviewHoursSaved, 0)
+    return {
+      automationScore: best.automationScore,
+      savingsPercent: Math.min(45, best.estimatedSavingsPercent + suggestions.length * 4),
+      reviewHoursSaved: totalHours,
+      paybackWeeks: Math.max(2, Math.round(12 - best.estimatedSavingsPercent / 5)),
+    }
+  }, [suggestions])
+
+  return (
+    <AppLayout title={strings.pipelines.title} subtitle={strings.pipelines.subtitle}>
+      <div className="cad-pipelines__toolbar">
+        <label>
+          <span>{strings.uploader.zone}</span>
+          <select value={zoneCode} onChange={(event) => setZoneCode(event.target.value)}>
+            <option value="RA">RA</option>
+            <option value="RCR">RCR</option>
+            <option value="CBD">CBD</option>
+          </select>
+        </label>
+        {insights && (
+          <p className="cad-pipelines__context">
+            {strings.detection.overlays}: {insights.overlays.join(', ') || '—'}
+          </p>
+        )}
+      </div>
+
+      {error && <p className="cad-pipelines__error">{error}</p>}
+
+      <section className="cad-pipelines">
+        <h2>{strings.pipelines.suggestionHeading}</h2>
+        {loading && <p>Loading…</p>}
+        {!loading && suggestions.length === 0 && <p>{strings.panels.rulePackEmpty}</p>}
+        {!loading && suggestions.length > 0 && (
+          <ul>
+            {suggestions.map((suggestion) => (
+              <li key={suggestion.id} className="cad-pipelines__item">
+                <h3>{suggestion.title}</h3>
+                <p>{suggestion.description}</p>
+                <dl>
+                  <div>
+                    <dt>{strings.pipelines.pipelineFocus}</dt>
+                    <dd>{suggestion.focus}</dd>
+                  </div>
+                  <div>
+                    <dt>{strings.pipelines.automationScore}</dt>
+                    <dd>{Math.round(suggestion.automationScore * 100)}%</dd>
+                  </div>
+                  <div>
+                    <dt>{strings.pipelines.reviewHours}</dt>
+                    <dd>{suggestion.reviewHoursSaved}h</dd>
+                  </div>
+                  <div>
+                    <dt>{strings.pipelines.savings}</dt>
+                    <dd>{suggestion.estimatedSavingsPercent}%</dd>
+                  </div>
+                </dl>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <RoiSummary metrics={roiMetrics} />
+
+      <RulePackExplanationPanel rules={rules} loading={rulesLoading} />
+    </AppLayout>
+  )
+}
+
+export default CadPipelinesPage

--- a/frontend/src/pages/CadUploadPage.tsx
+++ b/frontend/src/pages/CadUploadPage.tsx
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { type CadParseJob, type ParseStatusUpdate, useApiClient } from '../api/client'
+import { AppLayout } from '../App'
+import { useLocale } from '../i18n/LocaleContext'
+import CadUploader from '../modules/cad/CadUploader'
+import RulePackExplanationPanel from '../modules/cad/RulePackExplanationPanel'
+import useRules from '../hooks/useRules'
+
+export function CadUploadPage() {
+  const apiClient = useApiClient()
+  const { strings } = useLocale()
+  const [job, setJob] = useState<CadParseJob | null>(null)
+  const [status, setStatus] = useState<ParseStatusUpdate | null>(null)
+  const [isUploading, setIsUploading] = useState(false)
+  const [zoneCode, setZoneCode] = useState('RA')
+  const [error, setError] = useState<string | null>(null)
+  const cancelRef = useRef<(() => void) | null>(null)
+  const { rules, loading } = useRules(apiClient)
+
+  useEffect(() => {
+    return () => {
+      cancelRef.current?.()
+    }
+  }, [])
+
+  const handleUpload = useCallback(
+    async (file: File) => {
+      cancelRef.current?.()
+      setIsUploading(true)
+      setError(null)
+      try {
+        const nextJob = await apiClient.uploadCadDrawing(file, { zoneCode })
+        setJob(nextJob)
+        const initial: ParseStatusUpdate = {
+          jobId: nextJob.jobId,
+          status: nextJob.status === 'ready' ? 'ready' : 'processing',
+          overlays: nextJob.overlays,
+          hints: nextJob.hints,
+          zoneCode: nextJob.zoneCode,
+          updatedAt: new Date().toISOString(),
+          message: nextJob.message,
+        }
+        setStatus(initial)
+
+        cancelRef.current = apiClient.pollParseStatus({
+          jobId: nextJob.jobId,
+          zoneCode: nextJob.zoneCode ?? zoneCode,
+          onUpdate: (update) => {
+            setStatus(update)
+          },
+          intervalMs: 2500,
+        })
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Upload failed')
+      } finally {
+        setIsUploading(false)
+      }
+    },
+    [apiClient, zoneCode],
+  )
+
+  return (
+    <AppLayout title={strings.uploader.title} subtitle={strings.uploader.subtitle}>
+      <div className="cad-upload">
+        <div className="cad-upload__controls">
+          <label className="cad-upload__label">
+            <span>{strings.uploader.zone}</span>
+            <select value={zoneCode} onChange={(event) => setZoneCode(event.target.value)}>
+              <option value="RA">RA</option>
+              <option value="RCR">RCR</option>
+              <option value="CBD">CBD</option>
+            </select>
+          </label>
+          {error && <p className="cad-upload__error">{error}</p>}
+        </div>
+
+        <CadUploader
+          onUpload={handleUpload}
+          isUploading={isUploading}
+          status={status}
+          zoneCode={job?.zoneCode ?? zoneCode}
+        />
+      </div>
+
+      <RulePackExplanationPanel rules={rules} loading={loading} />
+    </AppLayout>
+  )
+}
+
+export default CadUploadPage

--- a/frontend/tests/api-client.test.cjs
+++ b/frontend/tests/api-client.test.cjs
@@ -1,0 +1,66 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('path')
+
+const { loadModule } = require('./helpers/loadModule.cjs')
+
+const { ApiClient } = loadModule(path.resolve(__dirname, '../src/api/client.ts'))
+
+test('uploadCadDrawing returns overlays and hints from backend', async () => {
+  const originalFetch = global.fetch
+  global.fetch = async () =>
+    new Response(
+      JSON.stringify({ overlays: ['fire_access'], advisory_hints: ['Ensure access clearance'] }),
+      { status: 200 },
+    )
+
+  const client = new ApiClient('http://example.com/')
+  const job = await client.uploadCadDrawing({ name: 'site.dxf', size: 1024 }, { zoneCode: 'RA' })
+
+  if (originalFetch) {
+    global.fetch = originalFetch
+  } else {
+    delete global.fetch
+  }
+
+  assert.strictEqual(job.status, 'ready')
+  assert.deepEqual(job.overlays, ['fire_access'])
+  assert.deepEqual(job.hints, ['Ensure access clearance'])
+})
+
+test('getDefaultPipelineSuggestions prioritises overlay matches', async () => {
+  const client = new ApiClient('http://example.com/')
+  client.listRules = async () => [
+    {
+      id: 1,
+      parameterKey: 'fire.width',
+      operator: '>=',
+      value: '4.5',
+      unit: 'm',
+      authority: 'SCDF',
+      topic: 'Fire safety',
+      reviewStatus: 'approved',
+      overlays: ['fire_access'],
+      advisoryHints: ['Ensure access clearance'],
+      normalized: [],
+    },
+    {
+      id: 2,
+      parameterKey: 'zoning.plot_ratio',
+      operator: '<=',
+      value: '3.5',
+      unit: null,
+      authority: 'URA',
+      topic: 'Zoning',
+      reviewStatus: 'approved',
+      overlays: ['coastal'],
+      advisoryHints: [],
+      normalized: [],
+    },
+  ]
+
+  const suggestions = await client.getDefaultPipelineSuggestions({ overlays: ['fire_access'], hints: [] })
+  assert.ok(suggestions.length > 0)
+  assert.strictEqual(suggestions[0].relatedRuleIds.includes(1), true)
+  assert.ok(suggestions[0].focus.toLowerCase().includes('fire'))
+})

--- a/frontend/tests/helpers/loadModule.cjs
+++ b/frontend/tests/helpers/loadModule.cjs
@@ -1,0 +1,46 @@
+const { buildSync } = require('esbuild')
+const { createRequire } = require('module')
+const path = require('path')
+const vm = require('vm')
+
+function loadModule(modulePath) {
+  const absPath = path.resolve(modulePath)
+  const result = buildSync({
+    entryPoints: [absPath],
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    write: false,
+    sourcemap: false,
+    define: {
+      'import.meta.env.VITE_API_BASE_URL': '""',
+    },
+    loader: {
+      '.ts': 'ts',
+      '.tsx': 'tsx',
+    },
+  })
+
+  const [{ text: code }] = result.outputFiles
+  const module = { exports: {} }
+  const req = createRequire(absPath)
+  const context = {
+    module,
+    exports: module.exports,
+    require: req,
+    console,
+    process,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    Buffer,
+    fetch: (...args) => global.fetch(...args),
+    URL,
+    URLSearchParams,
+  }
+  vm.runInNewContext(code, context)
+  return module.exports
+}
+
+module.exports = { loadModule }

--- a/frontend/tests/layer-toggle.test.cjs
+++ b/frontend/tests/layer-toggle.test.cjs
@@ -1,0 +1,22 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('path')
+
+const { loadModule } = require('./helpers/loadModule.cjs')
+
+const { computeNextLayers } = loadModule(
+  path.resolve(__dirname, '../src/modules/cad/layerToggle.ts'),
+)
+
+test('computeNextLayers removes an active layer', () => {
+  const result = computeNextLayers(['source', 'pending'], 'pending')
+  assert.strictEqual(result.length, 1)
+  assert.ok(result.includes('source'))
+})
+
+test('computeNextLayers adds a missing layer', () => {
+  const result = computeNextLayers(['source'], 'approved')
+  assert.strictEqual(result.length, 2)
+  assert.ok(result.includes('source'))
+  assert.ok(result.includes('approved'))
+})

--- a/frontend/tests/smoke.test.mjs
+++ b/frontend/tests/smoke.test.mjs
@@ -14,7 +14,23 @@ const projectRoot = path.resolve(__dirname, '..')
 
 async function loadAppComponent() {
   const result = await build({
-    entryPoints: [path.join(projectRoot, 'src', 'App.tsx')],
+    stdin: {
+      contents: `import React from 'react';
+import App from './src/App.tsx';
+import { LocaleProvider } from './src/i18n/LocaleContext.tsx';
+
+export default function WrappedApp() {
+  return (
+    <LocaleProvider>
+      <App />
+    </LocaleProvider>
+  );
+}
+`,
+      loader: 'tsx',
+      resolveDir: projectRoot,
+      sourcefile: 'AppWrapper.tsx',
+    },
     absWorkingDir: projectRoot,
     bundle: true,
     format: 'esm',

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,7 +14,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
## Summary
- replace the single status screen with a reusable localized app layout and homepage cards for CAD workflows
- add upload, detection, and default pipeline pages that integrate the new CAD modules, ROI widgets, audit timelines, and export controls through a typed API client
- introduce LocaleProvider/i18n strings, typed API client utilities, Storybook stories, and node-based unit tests for the new components

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d00efb2af483209223bc8aac46f715