### PR TITLE
Add locale-aware UI with custom i18n support

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "test:e2e": "node --test tests/smoke.test.mjs"
+    "test:e2e": "node --test tests"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/frontend/src/i18n/LocaleSwitcher.tsx
+++ b/frontend/src/i18n/LocaleSwitcher.tsx
@@ -1,0 +1,39 @@
+import type { ChangeEvent } from 'react'
+import { useCallback } from 'react'
+
+import { supportedLanguages, useTranslation } from './index'
+
+export function LocaleSwitcher() {
+  const { i18n, t } = useTranslation()
+  const currentLanguage = i18n.resolvedLanguage ?? i18n.language
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      const nextLanguage = event.target.value
+      void i18n.changeLanguage(nextLanguage)
+    },
+    [i18n],
+  )
+
+  return (
+    <div className="locale-switcher">
+      <label className="locale-switcher__label" htmlFor="app-locale-select">
+        {t('common.language.label')}
+      </label>
+      <select
+        id="app-locale-select"
+        className="locale-switcher__select"
+        value={currentLanguage}
+        onChange={handleChange}
+      >
+        {supportedLanguages.map((language) => (
+          <option key={language.value} value={language.value}>
+            {t(language.labelKey)}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+export default LocaleSwitcher

--- a/frontend/src/i18n/index.tsx
+++ b/frontend/src/i18n/index.tsx
@@ -1,0 +1,294 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+
+import en from './locales/en.json'
+import ja from './locales/ja.json'
+
+export const resources = {
+  en: { translation: en },
+  ja: { translation: ja },
+} as const
+
+export const supportedLanguages = [
+  { value: 'en', labelKey: 'common.language.options.en' },
+  { value: 'ja', labelKey: 'common.language.options.ja' },
+] as const
+
+export type SupportedLanguage = (typeof supportedLanguages)[number]['value']
+
+interface TranslationOptions {
+  ns?: string
+  defaultValue?: string
+  returnObjects?: boolean
+  [key: string]: unknown
+}
+
+type Listener = () => void
+
+type ResourceDictionary = Record<string, Record<string, unknown>>
+
+type Resources = Record<string, ResourceDictionary>
+
+const STORAGE_KEY = 'optimal_build:locale'
+const QUERY_KEYS = ['lang', 'locale', 'lng']
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined'
+}
+
+function parseQueryString(): URLSearchParams | null {
+  if (!isBrowser()) {
+    return null
+  }
+  try {
+    return new URLSearchParams(window.location.search)
+  } catch (error) {
+    console.error('Unable to parse query string for locale detection', error)
+    return null
+  }
+}
+
+class I18n {
+  private listeners: Set<Listener> = new Set()
+  private resources: Resources
+  private fallbackLng: SupportedLanguage
+  private supported: SupportedLanguage[]
+  private detectionOrder: string[]
+  private storageKey: string
+
+  language: string
+  resolvedLanguage: SupportedLanguage
+
+  constructor({
+    resources,
+    fallbackLng,
+    supportedLngs,
+    detectionOrder,
+    storageKey,
+  }: {
+    resources: Resources
+    fallbackLng: SupportedLanguage
+    supportedLngs: SupportedLanguage[]
+    detectionOrder: string[]
+    storageKey: string
+  }) {
+    this.resources = resources
+    this.fallbackLng = fallbackLng
+    this.supported = supportedLngs
+    this.detectionOrder = detectionOrder
+    this.storageKey = storageKey
+    this.language = fallbackLng
+    this.resolvedLanguage = fallbackLng
+    this.initialize()
+  }
+
+  private initialize() {
+    const detected = this.detectLanguage()
+    this.language = detected
+    this.resolvedLanguage = this.isSupported(detected) ? (detected as SupportedLanguage) : this.fallbackLng
+    this.persistLanguage(this.resolvedLanguage)
+  }
+
+  private detectLanguage(): string {
+    for (const method of this.detectionOrder) {
+      const detected = this.detectFrom(method)
+      if (detected) {
+        return detected
+      }
+    }
+    return this.fallbackLng
+  }
+
+  private detectFrom(method: string): string | null {
+    if (!isBrowser()) {
+      return null
+    }
+
+    try {
+      switch (method) {
+        case 'localStorage':
+          return window.localStorage.getItem(this.storageKey)
+        case 'querystring': {
+          const params = parseQueryString()
+          if (!params) {
+            return null
+          }
+          for (const key of QUERY_KEYS) {
+            const value = params.get(key)
+            if (value) {
+              return value
+            }
+          }
+          return null
+        }
+        case 'navigator':
+          return window.navigator.language || null
+        default:
+          return null
+      }
+    } catch (error) {
+      console.warn(`Locale detection via ${method} failed`, error)
+      return null
+    }
+  }
+
+  private isSupported(language: string): language is SupportedLanguage {
+    return this.supported.includes(language as SupportedLanguage)
+  }
+
+  private persistLanguage(language: string) {
+    if (!isBrowser()) {
+      return
+    }
+    try {
+      window.localStorage.setItem(this.storageKey, language)
+    } catch (error) {
+      console.warn('Unable to persist locale preference', error)
+    }
+  }
+
+  async changeLanguage(language: string) {
+    this.language = language
+    this.resolvedLanguage = this.isSupported(language)
+      ? (language as SupportedLanguage)
+      : this.fallbackLng
+    this.persistLanguage(this.resolvedLanguage)
+    this.notify()
+    return this
+  }
+
+  subscribe(listener: Listener) {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  private notify() {
+    for (const listener of this.listeners) {
+      listener()
+    }
+  }
+
+  private getResource(language: SupportedLanguage, namespace: string): Record<string, unknown> | null {
+    const namespaces = this.resources[language]
+    if (!namespaces) {
+      return null
+    }
+    return namespaces[namespace] ?? null
+  }
+
+  private getValue(resource: Record<string, unknown> | null, key: string): unknown {
+    if (!resource) {
+      return undefined
+    }
+    const segments = key.split('.')
+    let current: unknown = resource
+    for (const segment of segments) {
+      if (typeof current !== 'object' || current === null) {
+        return undefined
+      }
+      current = (current as Record<string, unknown>)[segment]
+    }
+    return current
+  }
+
+  private interpolate(template: string, options: TranslationOptions): string {
+    return template.replace(/\{\{\s*(.+?)\s*\}\}/g, (_, token: string) => {
+      const key = token.trim()
+      if (key in options && options[key] !== undefined && options[key] !== null) {
+        return String(options[key])
+      }
+      return ''
+    })
+  }
+
+  t(key: string, options: TranslationOptions = {}): any {
+    const namespace = options.ns ?? 'translation'
+    const languagesToCheck: SupportedLanguage[] = []
+    if (this.resolvedLanguage) {
+      languagesToCheck.push(this.resolvedLanguage)
+    }
+    if (!languagesToCheck.includes(this.fallbackLng)) {
+      languagesToCheck.push(this.fallbackLng)
+    }
+
+    for (const language of languagesToCheck) {
+      const resource = this.getResource(language, namespace)
+      const rawValue = this.getValue(resource, key)
+      if (rawValue !== undefined) {
+        if (options.returnObjects && typeof rawValue !== 'string') {
+          return rawValue
+        }
+        if (typeof rawValue === 'string') {
+          return this.interpolate(rawValue, options)
+        }
+        return rawValue
+      }
+    }
+
+    if (options.defaultValue !== undefined) {
+      return options.defaultValue
+    }
+
+    return options.returnObjects ? null : key
+  }
+}
+
+const detectionOrder = isBrowser()
+  ? ['localStorage', 'querystring', 'navigator']
+  : ['querystring']
+
+const i18n = new I18n({
+  resources: resources as Resources,
+  fallbackLng: 'en',
+  supportedLngs: supportedLanguages.map((item) => item.value),
+  detectionOrder,
+  storageKey: STORAGE_KEY,
+})
+
+const I18nContext = createContext<I18n>(i18n)
+
+export function TranslationProvider({ children }: { children: ReactNode }) {
+  return <I18nContext.Provider value={i18n}>{children}</I18nContext.Provider>
+}
+
+export function useTranslation() {
+  const instance = useContext(I18nContext)
+  const [, forceUpdate] = useState(0)
+
+  useEffect(() => instance.subscribe(() => forceUpdate((value) => value + 1)), [instance])
+
+  const translate = useCallback(
+    (key: string, options?: TranslationOptions) => instance.t(key, options),
+    [instance],
+  )
+
+  return useMemo(() => ({ t: translate, i18n: instance }), [instance, translate])
+}
+
+export const i18nReady = Promise.resolve(i18n)
+
+declare global {
+  interface Window {
+    __APP_I18N__?: I18n
+  }
+
+  // eslint-disable-next-line no-var
+  var __APP_I18N__: I18n | undefined
+}
+
+if (isBrowser()) {
+  window.__APP_I18N__ = i18n
+} else {
+  globalThis.__APP_I18N__ = i18n
+}
+
+export default i18n

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1,0 +1,183 @@
+{
+  "common": {
+    "language": {
+      "label": "Language",
+      "options": {
+        "en": "English",
+        "ja": "日本語"
+      }
+    },
+    "fallback": {
+      "dash": "—"
+    }
+  },
+  "app": {
+    "title": "Optimal Build Studio",
+    "tagline": "Explore automated compliance insights, land intelligence and feasibility analysis for Singapore developments.",
+    "nav": {
+      "feasibility": "Launch feasibility wizard",
+      "docs": "View API reference"
+    },
+    "status": {
+      "heading": "System status",
+      "loading": "Checking backend connection…",
+      "success": "✅ Backend Status: {{status}} ({{service}})",
+      "errors": {
+        "backendNotResponding": "Backend not responding",
+        "cannotConnect": "Cannot connect to backend"
+      }
+    },
+    "quickLinks": {
+      "heading": "Quick links",
+      "health": "Backend health check",
+      "docs": "API documentation",
+      "test": "API test endpoint"
+    },
+    "why": {
+      "heading": "Why start here?",
+      "items": [
+        "Capture project basics once and reuse across compliance workflows.",
+        "Review cross-agency rules synthesised from the knowledge platform.",
+        "Generate buildability insights with clear next steps for the team."
+      ]
+    },
+    "nextSteps": {
+      "heading": "Next steps",
+      "items": [
+        "✅ Frontend and backend are connected.",
+        "🔄 Add database integration.",
+        "🔄 Implement buildable analysis.",
+        "🔄 Add Singapore building codes."
+      ]
+    }
+  },
+  "wizard": {
+    "title": "Feasibility assessment",
+    "description": "Evaluate plot potential, identify binding regulations and generate next steps for compliance.",
+    "errors": {
+      "generic": "Something went wrong. Please try again."
+    },
+    "steps": {
+      "projectDetails": "Project details",
+      "complianceScope": "Compliance scope",
+      "buildabilityResults": "Buildability results"
+    },
+    "step1": {
+      "heading": "Step 1 · New project details",
+      "description": "Capture the essential site information that powers compliance lookups. This data will be used to determine zoning, plot ratio and envelope controls before fetching applicable rules.",
+      "fields": {
+        "name": {
+          "label": "Project name",
+          "placeholder": "e.g. Riverfront Residences"
+        },
+        "siteAddress": {
+          "label": "Site address",
+          "placeholder": "e.g. 123 Serangoon Ave 3"
+        },
+        "siteAreaSqm": {
+          "label": "Site area (sqm)",
+          "placeholder": "e.g. 4250"
+        },
+        "landUse": {
+          "label": "Land use",
+          "placeholder": "Select a land use"
+        },
+        "targetGrossFloorAreaSqm": {
+          "label": "Target GFA (sqm)",
+          "placeholder": "Optional"
+        },
+        "buildingHeightMeters": {
+          "label": "Target height (m)",
+          "placeholder": "Optional"
+        }
+      },
+      "landUseOptions": {
+        "residential": "Residential",
+        "commercial": "Commercial",
+        "mixed_use": "Mixed Use",
+        "industrial": "Industrial",
+        "institutional": "Institutional"
+      },
+      "errors": {
+        "nameRequired": "Project name is required",
+        "siteAddressRequired": "Site address is required",
+        "siteAreaRequired": "Site area is required",
+        "siteAreaInvalid": "Site area must be greater than zero",
+        "landUseRequired": "Select a land use to continue",
+        "targetGfaInvalid": "Target GFA must be greater than zero",
+        "heightInvalid": "Height must be greater than zero"
+      },
+      "actions": {
+        "saving": "Saving…",
+        "continue": "Continue to rules"
+      }
+    },
+    "step2": {
+      "heading": "Step 2 · Review suggested rules",
+      "description": "We analysed the project details and surfaced the most relevant codes across agencies. You can adjust the scope before running the compliance engine.",
+      "panel": {
+        "title": "Project summary",
+        "subtitleFallback": "Provide a quick confirmation before running the checks.",
+        "metrics": {
+          "siteArea": "Site area",
+          "landUse": "Land use",
+          "targetGfa": "Target GFA",
+          "targetHeight": "Target height"
+        },
+        "units": {
+          "sqm": "m²",
+          "meters": "m"
+        }
+      },
+      "loading": "Loading recommended rules…",
+      "empty": "No rules were found for this project configuration.",
+      "requirement": "Requirement: {{parameterKey}} {{operator}} {{value}}{{unit}}",
+      "actions": {
+        "back": "Back",
+        "evaluate": "Run buildability checks",
+        "evaluating": "Running assessment…"
+      }
+    },
+    "step3": {
+      "heading": "Step 3 · Buildability outlook",
+      "intro": {
+        "loading": "Finalising the analysis…",
+        "ready": "This snapshot summarises the achievable massing and highlights rules that require attention."
+      },
+      "panel": {
+        "title": "Envelope summary",
+        "metrics": {
+          "maxGfa": "Max permissible GFA",
+          "estimatedGfa": "Estimated achievable GFA",
+          "estimatedUnits": "Estimated units",
+          "siteCoverage": "Site coverage"
+        }
+      },
+      "siteEfficiency": "{{percentage}}% of permissible GFA utilised",
+      "allClear": "All tracked rules passed – consider expanding the scope to include more topics.",
+      "table": {
+        "rule": "Rule",
+        "agency": "Agency",
+        "status": "Status",
+        "notes": "Notes"
+      },
+      "status": {
+        "pass": "Pass",
+        "fail": "Fail",
+        "warning": "Review"
+      },
+      "recommendations": {
+        "title": "Next steps",
+        "subtitle": "Prioritised guidance to resolve outstanding compliance gaps."
+      },
+      "actions": {
+        "back": "Back to rules",
+        "restart": "Start a new assessment"
+      },
+      "placeholders": {
+        "preparingAssessment": "Preparing assessment…",
+        "pendingProjectName": "pending"
+      }
+    }
+  }
+}

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1,0 +1,183 @@
+{
+  "common": {
+    "language": {
+      "label": "表示言語",
+      "options": {
+        "en": "English",
+        "ja": "日本語"
+      }
+    },
+    "fallback": {
+      "dash": "—"
+    }
+  },
+  "app": {
+    "title": "Optimal Build Studio",
+    "tagline": "シンガポールの開発向けに、コンプライアンスのインサイト、土地インテリジェンス、フィージビリティ分析を自動で探索しましょう。",
+    "nav": {
+      "feasibility": "フィージビリティウィザードを起動",
+      "docs": "APIリファレンスを表示"
+    },
+    "status": {
+      "heading": "システムステータス",
+      "loading": "バックエンド接続を確認しています…",
+      "success": "✅ バックエンドの状態: {{status}} ({{service}})",
+      "errors": {
+        "backendNotResponding": "バックエンドが応答していません",
+        "cannotConnect": "バックエンドに接続できません"
+      }
+    },
+    "quickLinks": {
+      "heading": "クイックリンク",
+      "health": "バックエンドのヘルスチェック",
+      "docs": "APIドキュメント",
+      "test": "APIテストエンドポイント"
+    },
+    "why": {
+      "heading": "スタートする理由",
+      "items": [
+        "プロジェクトの基本情報を一度入力すれば、コンプライアンスのワークフロー全体で再利用できます。",
+        "ナレッジプラットフォームが整理した複数機関の規制を横断的に確認できます。",
+        "建築可能性のインサイトを生成し、チームに必要な次のアクションを提示します。"
+      ]
+    },
+    "nextSteps": {
+      "heading": "次のステップ",
+      "items": [
+        "✅ フロントエンドとバックエンドは接続済みです。",
+        "🔄 データベース連携を追加する。",
+        "🔄 建築可能性分析を実装する。",
+        "🔄 シンガポールの建築コードを追加する。"
+      ]
+    }
+  },
+  "wizard": {
+    "title": "フィージビリティ評価",
+    "description": "区画のポテンシャルを評価し、制約となる規制を特定して、コンプライアンス対応の次のステップを作成します。",
+    "errors": {
+      "generic": "エラーが発生しました。もう一度お試しください。"
+    },
+    "steps": {
+      "projectDetails": "プロジェクト詳細",
+      "complianceScope": "規制範囲",
+      "buildabilityResults": "建築可能性の結果"
+    },
+    "step1": {
+      "heading": "ステップ1・新規プロジェクトの詳細",
+      "description": "コンプライアンス検索を支えるサイト情報を入力してください。このデータを基に、ゾーニング、プロット比率、建築ボリューム制限を判定して適用可能な規制を取得します。",
+      "fields": {
+        "name": {
+          "label": "プロジェクト名",
+          "placeholder": "例：Riverfront Residences"
+        },
+        "siteAddress": {
+          "label": "敷地住所",
+          "placeholder": "例：123 Serangoon Ave 3"
+        },
+        "siteAreaSqm": {
+          "label": "敷地面積（平方メートル）",
+          "placeholder": "例：4250"
+        },
+        "landUse": {
+          "label": "用途地域",
+          "placeholder": "用途を選択してください"
+        },
+        "targetGrossFloorAreaSqm": {
+          "label": "目標延床面積（平方メートル）",
+          "placeholder": "任意"
+        },
+        "buildingHeightMeters": {
+          "label": "目標高さ（メートル）",
+          "placeholder": "任意"
+        }
+      },
+      "landUseOptions": {
+        "residential": "住宅",
+        "commercial": "商業",
+        "mixed_use": "複合用途",
+        "industrial": "工業",
+        "institutional": "公共"
+      },
+      "errors": {
+        "nameRequired": "プロジェクト名は必須です",
+        "siteAddressRequired": "敷地住所は必須です",
+        "siteAreaRequired": "敷地面積は必須です",
+        "siteAreaInvalid": "敷地面積は0より大きい値を入力してください",
+        "landUseRequired": "用途を選択してください",
+        "targetGfaInvalid": "目標延床面積は0より大きい値を入力してください",
+        "heightInvalid": "高さは0より大きい値を入力してください"
+      },
+      "actions": {
+        "saving": "保存中…",
+        "continue": "規制の確認に進む"
+      }
+    },
+    "step2": {
+      "heading": "ステップ2・推奨規制の確認",
+      "description": "入力したプロジェクト情報を分析し、関係機関の主要な規制を抽出しました。評価を実行する前に対象範囲を調整できます。",
+      "panel": {
+        "title": "プロジェクト概要",
+        "subtitleFallback": "チェックを実行する前に内容を確認してください。",
+        "metrics": {
+          "siteArea": "敷地面積",
+          "landUse": "用途地域",
+          "targetGfa": "目標延床面積",
+          "targetHeight": "目標高さ"
+        },
+        "units": {
+          "sqm": "㎡",
+          "meters": "m"
+        }
+      },
+      "loading": "推奨規制を読み込み中…",
+      "empty": "このプロジェクト設定に該当する規制は見つかりませんでした。",
+      "requirement": "要件: {{parameterKey}} {{operator}} {{value}}{{unit}}",
+      "actions": {
+        "back": "戻る",
+        "evaluate": "建築可能性チェックを実行",
+        "evaluating": "評価を実行中…"
+      }
+    },
+    "step3": {
+      "heading": "ステップ3・建築可能性の見通し",
+      "intro": {
+        "loading": "分析結果をまとめています…",
+        "ready": "達成可能なボリュームを要約し、注意が必要な規制をハイライトします。"
+      },
+      "panel": {
+        "title": "ボリュームサマリー",
+        "metrics": {
+          "maxGfa": "許容最大延床面積",
+          "estimatedGfa": "推定達成延床面積",
+          "estimatedUnits": "推定戸数",
+          "siteCoverage": "建蔽率"
+        }
+      },
+      "siteEfficiency": "許容延床面積の{{percentage}}%を活用",
+      "allClear": "すべての監視規制を満たしています。対象範囲を広げることも検討してください。",
+      "table": {
+        "rule": "規制",
+        "agency": "所管機関",
+        "status": "ステータス",
+        "notes": "メモ"
+      },
+      "status": {
+        "pass": "適合",
+        "fail": "不適合",
+        "warning": "要確認"
+      },
+      "recommendations": {
+        "title": "次のステップ",
+        "subtitle": "残っているコンプライアンスギャップを解消するための優先度付きガイダンスです。"
+      },
+      "actions": {
+        "back": "規制に戻る",
+        "restart": "新しい評価を開始"
+      },
+      "placeholders": {
+        "preparingAssessment": "評価を準備しています…",
+        "pendingProjectName": "準備中"
+      }
+    }
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -45,6 +45,17 @@ h1, h2, h3 {
   gap: 2rem;
 }
 
+.app-shell__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.app-shell__toolbar {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .app-shell__header h1 {
   margin-bottom: 0.5rem;
   font-size: 2.5rem;
@@ -65,6 +76,9 @@ h1, h2, h3 {
   background-color: #2563eb;
   color: #ffffff;
   font-weight: 600;
+  text-align: center;
+  white-space: normal;
+  line-height: 1.4;
 }
 
 .app-shell__nav-link + .app-shell__nav-link {
@@ -76,6 +90,31 @@ h1, h2, h3 {
   margin: 0;
   display: grid;
   gap: 0.75rem;
+}
+
+.locale-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.locale-switcher__label {
+  font-weight: 600;
+}
+
+.locale-switcher__select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid #cbd5f5;
+  font-size: 0.95rem;
+  background-color: #ffffff;
+  color: #0f172a;
+}
+
+.locale-switcher__select:focus {
+  outline: 2px solid #2563eb;
+  border-color: #2563eb;
 }
 
 .feasibility-wizard {
@@ -106,20 +145,25 @@ h1, h2, h3 {
 
 .feasibility-progress {
   display: flex;
-  gap: 1rem;
+  flex-wrap: wrap;
+  column-gap: 1rem;
+  row-gap: 0.75rem;
   padding: 0;
   margin: 0;
   list-style: none;
 }
 
 .feasibility-progress__item {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 0.75rem;
+  row-gap: 0.35rem;
   align-items: center;
-  gap: 0.75rem;
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
   background-color: #e2e8f0;
   color: #1f2937;
+  min-width: min(260px, 100%);
 }
 
 .feasibility-progress__item--active {
@@ -323,6 +367,7 @@ h1, h2, h3 {
   display: flex;
   gap: 1rem;
   justify-content: flex-end;
+  flex-wrap: wrap;
 }
 
 .feasibility-actions__primary,
@@ -332,6 +377,9 @@ h1, h2, h3 {
   font-weight: 600;
   cursor: pointer;
   border: none;
+  text-align: center;
+  white-space: normal;
+  line-height: 1.4;
 }
 
 .feasibility-actions__primary {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client'
 import { createBrowserRouter, RouterProvider } from './router'
 import App from './App'
 import FeasibilityWizard from './modules/feasibility/FeasibilityWizard'
+import { TranslationProvider } from './i18n'
 import './index.css'
 
 const router = createBrowserRouter([
@@ -18,6 +19,8 @@ const router = createBrowserRouter([
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <TranslationProvider>
+      <RouterProvider router={router} />
+    </TranslationProvider>
   </React.StrictMode>,
 )

--- a/frontend/src/modules/feasibility/Step1NewProject.tsx
+++ b/frontend/src/modules/feasibility/Step1NewProject.tsx
@@ -1,6 +1,8 @@
 import type { ChangeEvent, FormEvent } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 
+import { useTranslation } from '../../i18n'
+
 import { landUseOptions, LandUseType, NewFeasibilityProjectInput } from './types'
 
 type Step1FieldKey =
@@ -20,7 +22,16 @@ export interface Step1FormValues {
   buildingHeightMeters: string
 }
 
-type Step1FormErrors = Partial<Record<Step1FieldKey, string>>
+type Step1ErrorKey =
+  | 'nameRequired'
+  | 'siteAddressRequired'
+  | 'siteAreaRequired'
+  | 'siteAreaInvalid'
+  | 'landUseRequired'
+  | 'targetGfaInvalid'
+  | 'heightInvalid'
+
+type Step1FormErrors = Partial<Record<Step1FieldKey, Step1ErrorKey>>
 
 const initialFormState: Step1FormValues = {
   name: '',
@@ -64,6 +75,7 @@ export function Step1NewProject({
   onSubmit,
   isSubmitting = false,
 }: Step1NewProjectProps) {
+  const { t } = useTranslation()
   const [values, setValues] = useState<Step1FormValues>(() => formatDefaultValues(defaultValues))
   const [errors, setErrors] = useState<Step1FormErrors>({})
 
@@ -72,12 +84,7 @@ export function Step1NewProject({
     setErrors({})
   }, [defaultValues])
 
-  const description = useMemo(
-    () =>
-      `Capture the essential site information that powers compliance lookups. ` +
-      `This data will be used to determine zoning, plot ratio and envelope controls before fetching applicable rules.`,
-    [],
-  )
+  const description = useMemo(() => t('wizard.step1.description'), [t])
 
   const handleFieldChange = (field: Step1FieldKey) =>
     (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
@@ -90,35 +97,35 @@ export function Step1NewProject({
     const nextErrors: Step1FormErrors = {}
 
     if (!values.name.trim()) {
-      nextErrors.name = 'Project name is required'
+      nextErrors.name = 'nameRequired'
     }
 
     if (!values.siteAddress.trim()) {
-      nextErrors.siteAddress = 'Site address is required'
+      nextErrors.siteAddress = 'siteAddressRequired'
     }
 
     const siteArea = Number.parseFloat(values.siteAreaSqm)
     if (!values.siteAreaSqm.trim()) {
-      nextErrors.siteAreaSqm = 'Site area is required'
+      nextErrors.siteAreaSqm = 'siteAreaRequired'
     } else if (!Number.isFinite(siteArea) || siteArea <= 0) {
-      nextErrors.siteAreaSqm = 'Site area must be greater than zero'
+      nextErrors.siteAreaSqm = 'siteAreaInvalid'
     }
 
     if (!values.landUse) {
-      nextErrors.landUse = 'Select a land use to continue'
+      nextErrors.landUse = 'landUseRequired'
     }
 
     if (values.targetGrossFloorAreaSqm.trim()) {
       const targetGfa = Number.parseFloat(values.targetGrossFloorAreaSqm)
       if (!Number.isFinite(targetGfa) || targetGfa <= 0) {
-        nextErrors.targetGrossFloorAreaSqm = 'Target GFA must be greater than zero'
+        nextErrors.targetGrossFloorAreaSqm = 'targetGfaInvalid'
       }
     }
 
     if (values.buildingHeightMeters.trim()) {
       const height = Number.parseFloat(values.buildingHeightMeters)
       if (!Number.isFinite(height) || height <= 0) {
-        nextErrors.buildingHeightMeters = 'Height must be greater than zero'
+        nextErrors.buildingHeightMeters = 'heightInvalid'
       }
     }
 
@@ -155,94 +162,120 @@ export function Step1NewProject({
 
   return (
     <div className="feasibility-step">
-      <h2 className="feasibility-step__heading">Step 1 · New project details</h2>
+      <h2 className="feasibility-step__heading">{t('wizard.step1.heading')}</h2>
       <p className="feasibility-step__intro">{description}</p>
 
       <form className="feasibility-form" onSubmit={handleSubmit} noValidate>
         <div className="feasibility-form__field">
-          <label htmlFor="name">Project name</label>
+          <label htmlFor="name">{t('wizard.step1.fields.name.label')}</label>
           <input
             id="name"
             type="text"
             value={values.name}
             onChange={handleFieldChange('name')}
-            placeholder="e.g. Riverfront Residences"
+            placeholder={t('wizard.step1.fields.name.placeholder')}
           />
-          {errors.name && <p className="feasibility-form__error">{errors.name}</p>}
+          {errors.name && (
+            <p className="feasibility-form__error">
+              {t(`wizard.step1.errors.${errors.name}`)}
+            </p>
+          )}
         </div>
 
         <div className="feasibility-form__field">
-          <label htmlFor="siteAddress">Site address</label>
+          <label htmlFor="siteAddress">{t('wizard.step1.fields.siteAddress.label')}</label>
           <input
             id="siteAddress"
             type="text"
             value={values.siteAddress}
             onChange={handleFieldChange('siteAddress')}
-            placeholder="e.g. 123 Serangoon Ave 3"
+            placeholder={t('wizard.step1.fields.siteAddress.placeholder')}
           />
-          {errors.siteAddress && <p className="feasibility-form__error">{errors.siteAddress}</p>}
+          {errors.siteAddress && (
+            <p className="feasibility-form__error">
+              {t(`wizard.step1.errors.${errors.siteAddress}`)}
+            </p>
+          )}
         </div>
 
         <div className="feasibility-form__field">
-          <label htmlFor="siteAreaSqm">Site area (sqm)</label>
+          <label htmlFor="siteAreaSqm">{t('wizard.step1.fields.siteAreaSqm.label')}</label>
           <input
             id="siteAreaSqm"
             type="number"
             step="0.01"
             value={values.siteAreaSqm}
             onChange={handleFieldChange('siteAreaSqm')}
-            placeholder="e.g. 4250"
+            placeholder={t('wizard.step1.fields.siteAreaSqm.placeholder')}
           />
-          {errors.siteAreaSqm && <p className="feasibility-form__error">{errors.siteAreaSqm}</p>}
+          {errors.siteAreaSqm && (
+            <p className="feasibility-form__error">
+              {t(`wizard.step1.errors.${errors.siteAreaSqm}`)}
+            </p>
+          )}
         </div>
 
         <div className="feasibility-form__field">
-          <label htmlFor="landUse">Land use</label>
+          <label htmlFor="landUse">{t('wizard.step1.fields.landUse.label')}</label>
           <select id="landUse" value={values.landUse} onChange={handleFieldChange('landUse')}>
-            <option value="">Select a land use</option>
+            <option value="">{t('wizard.step1.fields.landUse.placeholder')}</option>
             {landUseOptions.map((option) => (
               <option key={option.value} value={option.value}>
-                {option.label}
+                {t(`wizard.step1.landUseOptions.${option.value}`)}
               </option>
             ))}
           </select>
-          {errors.landUse && <p className="feasibility-form__error">{errors.landUse}</p>}
+          {errors.landUse && (
+            <p className="feasibility-form__error">
+              {t(`wizard.step1.errors.${errors.landUse}`)}
+            </p>
+          )}
         </div>
 
         <div className="feasibility-form__grid">
           <div className="feasibility-form__field">
-            <label htmlFor="targetGrossFloorAreaSqm">Target GFA (sqm)</label>
+            <label htmlFor="targetGrossFloorAreaSqm">
+              {t('wizard.step1.fields.targetGrossFloorAreaSqm.label')}
+            </label>
             <input
               id="targetGrossFloorAreaSqm"
               type="number"
               step="0.01"
               value={values.targetGrossFloorAreaSqm}
               onChange={handleFieldChange('targetGrossFloorAreaSqm')}
-              placeholder="Optional"
+              placeholder={t('wizard.step1.fields.targetGrossFloorAreaSqm.placeholder')}
             />
             {errors.targetGrossFloorAreaSqm && (
-              <p className="feasibility-form__error">{errors.targetGrossFloorAreaSqm}</p>
+              <p className="feasibility-form__error">
+                {t(`wizard.step1.errors.${errors.targetGrossFloorAreaSqm}`)}
+              </p>
             )}
           </div>
 
           <div className="feasibility-form__field">
-            <label htmlFor="buildingHeightMeters">Target height (m)</label>
+            <label htmlFor="buildingHeightMeters">
+              {t('wizard.step1.fields.buildingHeightMeters.label')}
+            </label>
             <input
               id="buildingHeightMeters"
               type="number"
               step="0.1"
               value={values.buildingHeightMeters}
               onChange={handleFieldChange('buildingHeightMeters')}
-              placeholder="Optional"
+              placeholder={t('wizard.step1.fields.buildingHeightMeters.placeholder')}
             />
             {errors.buildingHeightMeters && (
-              <p className="feasibility-form__error">{errors.buildingHeightMeters}</p>
+              <p className="feasibility-form__error">
+                {t(`wizard.step1.errors.${errors.buildingHeightMeters}`)}
+              </p>
             )}
           </div>
         </div>
 
         <button className="feasibility-form__submit" type="submit" disabled={isSubmitting}>
-          {isSubmitting ? 'Saving…' : 'Continue to rules'}
+          {isSubmitting
+            ? t('wizard.step1.actions.saving')
+            : t('wizard.step1.actions.continue')}
         </button>
       </form>
     </div>

--- a/frontend/src/modules/feasibility/Step2Rules.tsx
+++ b/frontend/src/modules/feasibility/Step2Rules.tsx
@@ -1,4 +1,6 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
+
+import { useTranslation } from '../../i18n'
 
 import {
   FeasibilityRule,
@@ -19,16 +21,6 @@ interface Step2RulesProps {
   isEvaluating?: boolean
 }
 
-function formatNumber(value: number | undefined) {
-  if (value === undefined || Number.isNaN(value)) {
-    return '—'
-  }
-
-  return value.toLocaleString(undefined, {
-    maximumFractionDigits: 2,
-  })
-}
-
 export function Step2Rules({
   project,
   rules,
@@ -41,6 +33,7 @@ export function Step2Rules({
   onContinue,
   isEvaluating = false,
 }: Step2RulesProps) {
+  const { t, i18n } = useTranslation()
   const recommendationText = useMemo(() => {
     if (!summary) {
       return null
@@ -48,6 +41,36 @@ export function Step2Rules({
 
     return `${summary.complianceFocus}${summary.notes ? ` · ${summary.notes}` : ''}`
   }, [summary])
+
+  const fallbackDash = t('common.fallback.dash')
+  const numberFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(i18n.language, {
+        maximumFractionDigits: 2,
+      }),
+    [i18n.language],
+  )
+
+  const formatValue = useCallback(
+    (value: number | undefined) => {
+      if (value === undefined || Number.isNaN(value)) {
+        return fallbackDash
+      }
+      return numberFormatter.format(value)
+    },
+    [fallbackDash, numberFormatter],
+  )
+
+  const formatWithUnit = useCallback(
+    (value: number | undefined, unit: string) => {
+      const formatted = formatValue(value)
+      if (formatted === fallbackDash) {
+        return fallbackDash
+      }
+      return `${formatted} ${unit}`
+    },
+    [fallbackDash, formatValue],
+  )
 
   const toggleRule = (ruleId: string) => {
     if (selectedRuleIds.includes(ruleId)) {
@@ -59,53 +82,60 @@ export function Step2Rules({
 
   const selectedRulesSet = useMemo(() => new Set(selectedRuleIds), [selectedRuleIds])
 
+  const units = useMemo(
+    () => ({
+      sqm: t('wizard.step2.panel.units.sqm'),
+      meters: t('wizard.step2.panel.units.meters'),
+    }),
+    [t],
+  )
+
+  const landUseLabel = useMemo(() => t(`wizard.step1.landUseOptions.${project.landUse}`), [project.landUse, t])
+
   return (
     <div className="feasibility-step">
-      <h2 className="feasibility-step__heading">Step 2 · Review suggested rules</h2>
-      <p className="feasibility-step__intro">
-        We analysed the project details and surfaced the most relevant codes across agencies.
-        You can adjust the scope before running the compliance engine.
-      </p>
+      <h2 className="feasibility-step__heading">{t('wizard.step2.heading')}</h2>
+      <p className="feasibility-step__intro">{t('wizard.step2.description')}</p>
 
       <section className="feasibility-panel">
         <header className="feasibility-panel__header">
           <div>
-            <h3 className="feasibility-panel__title">Project summary</h3>
+            <h3 className="feasibility-panel__title">{t('wizard.step2.panel.title')}</h3>
             <p className="feasibility-panel__subtitle">
-              {recommendationText ?? 'Provide a quick confirmation before running the checks.'}
+              {recommendationText ?? t('wizard.step2.panel.subtitleFallback')}
             </p>
           </div>
           <div className="feasibility-panel__metrics">
             <div>
-              <span className="feasibility-panel__metric-label">Site area</span>
+              <span className="feasibility-panel__metric-label">{t('wizard.step2.panel.metrics.siteArea')}</span>
               <span className="feasibility-panel__metric-value">
-                {formatNumber(project.siteAreaSqm)} m²
+                {formatWithUnit(project.siteAreaSqm, units.sqm)}
               </span>
             </div>
             <div>
-              <span className="feasibility-panel__metric-label">Land use</span>
-              <span className="feasibility-panel__metric-value">{project.landUse}</span>
+              <span className="feasibility-panel__metric-label">{t('wizard.step2.panel.metrics.landUse')}</span>
+              <span className="feasibility-panel__metric-value">{landUseLabel}</span>
             </div>
             <div>
-              <span className="feasibility-panel__metric-label">Target GFA</span>
+              <span className="feasibility-panel__metric-label">{t('wizard.step2.panel.metrics.targetGfa')}</span>
               <span className="feasibility-panel__metric-value">
-                {formatNumber(project.targetGrossFloorAreaSqm)} m²
+                {formatWithUnit(project.targetGrossFloorAreaSqm, units.sqm)}
               </span>
             </div>
             <div>
-              <span className="feasibility-panel__metric-label">Target height</span>
+              <span className="feasibility-panel__metric-label">{t('wizard.step2.panel.metrics.targetHeight')}</span>
               <span className="feasibility-panel__metric-value">
-                {formatNumber(project.buildingHeightMeters)} m
+                {formatWithUnit(project.buildingHeightMeters, units.meters)}
               </span>
             </div>
           </div>
         </header>
 
         <div className="feasibility-panel__content">
-          {isLoading && <p>Loading recommended rules…</p>}
+          {isLoading && <p>{t('wizard.step2.loading')}</p>}
           {error && <p className="feasibility-panel__error">{error}</p>}
           {!isLoading && !error && rules.length === 0 && (
-            <p>No rules were found for this project configuration.</p>
+            <p>{t('wizard.step2.empty')}</p>
           )}
 
           {!isLoading && !error && rules.length > 0 && (
@@ -131,8 +161,12 @@ export function Step2Rules({
                         <p className="feasibility-rules__title">{rule.title}</p>
                         <p className="feasibility-rules__description">{rule.description}</p>
                         <p className="feasibility-rules__requirement">
-                          Requirement: {rule.parameterKey} {rule.operator} {rule.value}
-                          {rule.unit ? ` ${rule.unit}` : ''}
+                          {t('wizard.step2.requirement', {
+                            parameterKey: rule.parameterKey,
+                            operator: rule.operator,
+                            value: rule.value,
+                            unit: rule.unit ? ` ${rule.unit}` : '',
+                          })}
                         </p>
                       </div>
                     </label>
@@ -146,7 +180,7 @@ export function Step2Rules({
 
       <div className="feasibility-actions">
         <button type="button" className="feasibility-actions__secondary" onClick={onBack}>
-          Back
+          {t('wizard.step2.actions.back')}
         </button>
         <button
           type="button"
@@ -154,7 +188,9 @@ export function Step2Rules({
           onClick={onContinue}
           disabled={selectedRuleIds.length === 0 || isEvaluating || isLoading}
         >
-          {isEvaluating ? 'Running assessment…' : 'Run buildability checks'}
+          {isEvaluating
+            ? t('wizard.step2.actions.evaluating')
+            : t('wizard.step2.actions.evaluate')}
         </button>
       </div>
     </div>

--- a/frontend/src/modules/feasibility/Step3Buildable.tsx
+++ b/frontend/src/modules/feasibility/Step3Buildable.tsx
@@ -1,5 +1,7 @@
 import { useMemo } from 'react'
 
+import { useTranslation } from '../../i18n'
+
 import { FeasibilityAssessmentResponse } from './types'
 
 interface Step3BuildableProps {
@@ -9,71 +11,81 @@ interface Step3BuildableProps {
   isLoading?: boolean
 }
 
-const statusLabels = {
-  pass: 'Pass',
-  fail: 'Fail',
-  warning: 'Review',
-} as const
-
 export function Step3Buildable({
   assessment,
   onBack,
   onRestart,
   isLoading = false,
 }: Step3BuildableProps) {
+  const { t, i18n } = useTranslation()
   const { summary, rules, recommendations } = assessment
 
   const siteEfficiency = useMemo(() => {
     if (!summary.maxPermissibleGfaSqm) {
-      return '—'
+      return t('common.fallback.dash')
     }
 
     const ratio = summary.estimatedAchievableGfaSqm / summary.maxPermissibleGfaSqm
     if (!Number.isFinite(ratio)) {
-      return '—'
+      return t('common.fallback.dash')
     }
 
-    return `${Math.round(ratio * 100)}% of permissible GFA utilised`
-  }, [summary])
+    return t('wizard.step3.siteEfficiency', { percentage: Math.round(ratio * 100) })
+  }, [summary, t])
+
+  const numberFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(i18n.language, {
+        maximumFractionDigits: 0,
+      }),
+    [i18n.language],
+  )
+
+  const decimalFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(i18n.language, {
+        maximumFractionDigits: 1,
+        minimumFractionDigits: 1,
+      }),
+    [i18n.language],
+  )
 
   return (
     <div className="feasibility-step">
-      <h2 className="feasibility-step__heading">Step 3 · Buildability outlook</h2>
+      <h2 className="feasibility-step__heading">{t('wizard.step3.heading')}</h2>
       <p className="feasibility-step__intro">
-        {isLoading
-          ? 'Finalising the analysis…'
-          : 'This snapshot summarises the achievable massing and highlights rules that require attention.'}
+        {isLoading ? t('wizard.step3.intro.loading') : t('wizard.step3.intro.ready')}
       </p>
 
       <section className="feasibility-panel">
         <header className="feasibility-panel__header">
           <div>
-            <h3 className="feasibility-panel__title">Envelope summary</h3>
+            <h3 className="feasibility-panel__title">{t('wizard.step3.panel.title')}</h3>
             <p className="feasibility-panel__subtitle">{summary.remarks ?? siteEfficiency}</p>
           </div>
           <div className="feasibility-panel__metrics">
             <div>
-              <span className="feasibility-panel__metric-label">Max permissible GFA</span>
+              <span className="feasibility-panel__metric-label">{t('wizard.step3.panel.metrics.maxGfa')}</span>
               <span className="feasibility-panel__metric-value">
-                {summary.maxPermissibleGfaSqm.toLocaleString()} m²
+                {numberFormatter.format(summary.maxPermissibleGfaSqm)} {t('wizard.step2.panel.units.sqm')}
               </span>
             </div>
             <div>
-              <span className="feasibility-panel__metric-label">Estimated achievable GFA</span>
+              <span className="feasibility-panel__metric-label">{t('wizard.step3.panel.metrics.estimatedGfa')}</span>
               <span className="feasibility-panel__metric-value">
-                {summary.estimatedAchievableGfaSqm.toLocaleString()} m²
+                {numberFormatter.format(summary.estimatedAchievableGfaSqm)} {t('wizard.step2.panel.units.sqm')}
               </span>
             </div>
             <div>
-              <span className="feasibility-panel__metric-label">Estimated units</span>
+              <span className="feasibility-panel__metric-label">{t('wizard.step3.panel.metrics.estimatedUnits')}</span>
               <span className="feasibility-panel__metric-value">
-                {summary.estimatedUnitCount.toLocaleString()}
+                {numberFormatter.format(summary.estimatedUnitCount)}
               </span>
             </div>
             <div>
-              <span className="feasibility-panel__metric-label">Site coverage</span>
+              <span className="feasibility-panel__metric-label">{t('wizard.step3.panel.metrics.siteCoverage')}</span>
               <span className="feasibility-panel__metric-value">
-                {summary.siteCoveragePercent.toFixed(1)}%
+                {decimalFormatter.format(summary.siteCoveragePercent)}%
               </span>
             </div>
           </div>
@@ -81,15 +93,15 @@ export function Step3Buildable({
 
         <div className="feasibility-panel__content">
           {rules.length === 0 ? (
-            <p>All tracked rules passed – consider expanding the scope to include more topics.</p>
+            <p>{t('wizard.step3.allClear')}</p>
           ) : (
             <table className="feasibility-results">
               <thead>
                 <tr>
-                  <th scope="col">Rule</th>
-                  <th scope="col">Agency</th>
-                  <th scope="col">Status</th>
-                  <th scope="col">Notes</th>
+                  <th scope="col">{t('wizard.step3.table.rule')}</th>
+                  <th scope="col">{t('wizard.step3.table.agency')}</th>
+                  <th scope="col">{t('wizard.step3.table.status')}</th>
+                  <th scope="col">{t('wizard.step3.table.notes')}</th>
                 </tr>
               </thead>
               <tbody>
@@ -112,11 +124,11 @@ export function Step3Buildable({
                       <span
                         className={`feasibility-results__status feasibility-results__status--${rule.status}`}
                       >
-                        {statusLabels[rule.status]}
+                        {t(`wizard.step3.status.${rule.status}`)}
                       </span>
                     </td>
                     <td>
-                      <span>{rule.notes ?? rule.actualValue ?? '—'}</span>
+                      <span>{rule.notes ?? rule.actualValue ?? t('common.fallback.dash')}</span>
                     </td>
                   </tr>
                 ))}
@@ -130,9 +142,9 @@ export function Step3Buildable({
         <section className="feasibility-panel">
           <header className="feasibility-panel__header">
             <div>
-              <h3 className="feasibility-panel__title">Next steps</h3>
+              <h3 className="feasibility-panel__title">{t('wizard.step3.recommendations.title')}</h3>
               <p className="feasibility-panel__subtitle">
-                Prioritised guidance to resolve outstanding compliance gaps.
+                {t('wizard.step3.recommendations.subtitle')}
               </p>
             </div>
           </header>
@@ -148,10 +160,10 @@ export function Step3Buildable({
 
       <div className="feasibility-actions">
         <button type="button" className="feasibility-actions__secondary" onClick={onBack}>
-          Back to rules
+          {t('wizard.step3.actions.back')}
         </button>
         <button type="button" className="feasibility-actions__primary" onClick={onRestart}>
-          Start a new assessment
+          {t('wizard.step3.actions.restart')}
         </button>
       </div>
     </div>

--- a/frontend/src/modules/feasibility/types.ts
+++ b/frontend/src/modules/feasibility/types.ts
@@ -1,12 +1,14 @@
 export const landUseOptions = [
-  { value: 'residential', label: 'Residential' },
-  { value: 'commercial', label: 'Commercial' },
-  { value: 'mixed_use', label: 'Mixed Use' },
-  { value: 'industrial', label: 'Industrial' },
-  { value: 'institutional', label: 'Institutional' },
+  { value: 'residential', labelKey: 'wizard.step1.landUseOptions.residential' },
+  { value: 'commercial', labelKey: 'wizard.step1.landUseOptions.commercial' },
+  { value: 'mixed_use', labelKey: 'wizard.step1.landUseOptions.mixed_use' },
+  { value: 'industrial', labelKey: 'wizard.step1.landUseOptions.industrial' },
+  { value: 'institutional', labelKey: 'wizard.step1.landUseOptions.institutional' },
 ] as const
 
-export type LandUseType = (typeof landUseOptions)[number]['value']
+export type LandUseOption = (typeof landUseOptions)[number]
+
+export type LandUseType = LandUseOption['value']
 
 export interface NewFeasibilityProjectInput {
   name: string

--- a/frontend/tests/i18n.test.mjs
+++ b/frontend/tests/i18n.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+
+import { getGlobalI18n, loadComponent } from './utils.mjs'
+
+const japaneseTagline =
+  'シンガポールの開発向けに、コンプライアンスのインサイト、土地インテリジェンス、フィージビリティ分析を自動で探索しましょう。'
+
+await test('internationalisation renders expected content', async (t) => {
+  await t.test('App renders Japanese tagline when locale is set to ja', async () => {
+    const { default: App } = await loadComponent('tests/support/appEntry.tsx')
+    const i18n = getGlobalI18n()
+    await i18n.changeLanguage('ja')
+
+    const html = renderToString(React.createElement(App))
+    assert.ok(
+      html.includes(japaneseTagline),
+      'Expected Japanese tagline to be rendered in the App component',
+    )
+
+    await i18n.changeLanguage('en')
+  })
+
+  await t.test('Feasibility wizard falls back to English for unsupported locales', async () => {
+    const { default: FeasibilityWizard } = await loadComponent(
+      'tests/support/feasibilityWizardEntry.tsx',
+    )
+    const i18n = getGlobalI18n()
+    await i18n.changeLanguage('fr')
+
+    const html = renderToString(React.createElement(FeasibilityWizard))
+    assert.ok(
+      html.includes('Feasibility assessment'),
+      'Expected wizard heading to use English fallback when locale is unsupported',
+    )
+
+    await i18n.changeLanguage('en')
+  })
+})

--- a/frontend/tests/smoke.test.mjs
+++ b/frontend/tests/smoke.test.mjs
@@ -1,63 +1,13 @@
 import assert from 'node:assert/strict'
-import fs from 'node:fs/promises'
-import path from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
 import test from 'node:test'
 
-import { build } from 'esbuild'
 import React from 'react'
 import { renderToString } from 'react-dom/server'
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-const projectRoot = path.resolve(__dirname, '..')
-
-async function loadAppComponent() {
-  const result = await build({
-    entryPoints: [path.join(projectRoot, 'src', 'App.tsx')],
-    absWorkingDir: projectRoot,
-    bundle: true,
-    format: 'esm',
-    platform: 'node',
-    write: false,
-    jsx: 'automatic',
-    jsxImportSource: 'react',
-    logLevel: 'silent',
-    external: ['react', 'react-dom', 'react/jsx-runtime'],
-    loader: {
-      '.ts': 'ts',
-      '.tsx': 'tsx',
-    },
-    define: {
-      'import.meta.env.VITE_API_BASE_URL': 'undefined',
-      'import.meta.env': '{}',
-    },
-  })
-
-  if (!result.outputFiles || result.outputFiles.length === 0) {
-    throw new Error('esbuild did not produce any output files')
-  }
-
-  const [output] = result.outputFiles
-  const tempDir = await fs.mkdtemp(path.join(projectRoot, '.tmp-e2e-'))
-  const tempFile = path.join(tempDir, 'App.bundle.mjs')
-
-  try {
-    await fs.writeFile(tempFile, output.text, 'utf8')
-    const module = await import(pathToFileURL(tempFile).href)
-
-    if (!module.default) {
-      throw new Error('App component was not exported as default')
-    }
-
-    return module.default
-  } finally {
-    await fs.rm(tempDir, { recursive: true, force: true })
-  }
-}
+import { loadComponent } from './utils.mjs'
 
 test('App renders the expected headline', async () => {
-  const App = await loadAppComponent()
+  const { default: App } = await loadComponent('tests/support/appEntry.tsx')
   const html = renderToString(React.createElement(App))
   const expectedHeadingText = 'Optimal Build Studio'
   const headingPattern = new RegExp(

--- a/frontend/tests/support/appEntry.tsx
+++ b/frontend/tests/support/appEntry.tsx
@@ -1,0 +1,4 @@
+import '../../src/i18n'
+import App from '../../src/App'
+
+export default App

--- a/frontend/tests/support/feasibilityWizardEntry.tsx
+++ b/frontend/tests/support/feasibilityWizardEntry.tsx
@@ -1,0 +1,4 @@
+import '../../src/i18n'
+import FeasibilityWizard from '../../src/modules/feasibility/FeasibilityWizard'
+
+export default FeasibilityWizard

--- a/frontend/tests/utils.mjs
+++ b/frontend/tests/utils.mjs
@@ -1,0 +1,57 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import { build } from 'esbuild'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+export const projectRoot = path.resolve(__dirname, '..')
+
+export async function loadComponent(entryRelativePath) {
+  const entryPoint = path.join(projectRoot, entryRelativePath)
+  const result = await build({
+    entryPoints: [entryPoint],
+    absWorkingDir: projectRoot,
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    write: false,
+    jsx: 'automatic',
+    jsxImportSource: 'react',
+    logLevel: 'silent',
+    external: ['react', 'react-dom', 'react/jsx-runtime'],
+    loader: {
+      '.ts': 'ts',
+      '.tsx': 'tsx',
+      '.json': 'json',
+    },
+    define: {
+      'import.meta.env.VITE_API_BASE_URL': 'undefined',
+      'import.meta.env': '{}',
+    },
+  })
+
+  if (!result.outputFiles || result.outputFiles.length === 0) {
+    throw new Error('esbuild did not produce any output files')
+  }
+
+  const [output] = result.outputFiles
+  const tempDir = await fs.mkdtemp(path.join(projectRoot, '.tmp-e2e-'))
+  const tempFile = path.join(tempDir, `${path.basename(entryRelativePath)}.bundle.mjs`)
+
+  try {
+    await fs.writeFile(tempFile, output.text, 'utf8')
+    return await import(pathToFileURL(tempFile).href)
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  }
+}
+
+export function getGlobalI18n() {
+  const instance = globalThis.__APP_I18N__
+  if (!instance) {
+    throw new Error('i18n instance is not initialised')
+  }
+  return instance
+}


### PR DESCRIPTION
## Summary
- implement a lightweight i18n engine with English and Japanese resource bundles plus a locale switcher and persistence
- replace hard-coded copy across the app and feasibility wizard with translation keys and tweak layouts to support longer Japanese strings
- add automated tests to confirm localized rendering and fallback behaviour for unsupported locales

## Testing
- npm run test:e2e
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d00efc62088320b735aa958522fa0f