### PR TITLE
Add ROI analytics endpoint and audit instrumentation

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -2,7 +2,18 @@
 
 from fastapi import APIRouter
 
-from . import costs, ergonomics, imports, overlay, products, review, rules, screen, standards
+from . import (
+    costs,
+    ergonomics,
+    imports,
+    overlay,
+    products,
+    review,
+    roi,
+    rules,
+    screen,
+    standards,
+)
 
 api_router = APIRouter()
 api_router.include_router(review.router)
@@ -14,5 +25,6 @@ api_router.include_router(standards.router)
 api_router.include_router(costs.router)
 api_router.include_router(overlay.router)
 api_router.include_router(imports.router)
+api_router.include_router(roi.router)
 
 __all__ = ["api_router"]

--- a/backend/app/api/v1/overlay.py
+++ b/backend/app/api/v1/overlay.py
@@ -6,17 +6,26 @@ from datetime import datetime, timezone
 from typing import Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.core.database import get_session
 from app.models.overlay import OverlayDecision, OverlaySuggestion
+from app.services.audit import record_project_event
 from app.schemas.overlay import OverlayDecisionPayload, OverlaySuggestion as OverlaySuggestionSchema
 from jobs.overlay_run import OverlayRunResult, run_overlay_for_project
 
 
 router = APIRouter(prefix="/overlay")
+
+
+OVERLAY_RUN_BASELINE_SECONDS = 45 * 60
+OVERLAY_RUN_AUTOMATED_SECONDS = 5 * 60
+OVERLAY_DECISION_BASELINE_SECONDS = 20 * 60
+OVERLAY_DECISION_AUTOMATED_SECONDS = 3 * 60
+EXPORT_BASELINE_SECONDS = 30 * 60
+EXPORT_AUTOMATED_SECONDS = 5 * 60
 
 
 @router.post("/{project_id}/run")
@@ -27,6 +36,21 @@ async def run_overlay(
     """Execute the overlay feasibility engine for a project."""
 
     result: OverlayRunResult = await run_overlay_for_project(session, project_id=project_id)
+    evaluated = max(result.evaluated, 1)
+    await record_project_event(
+        session,
+        project_id=project_id,
+        event_type="overlay_run",
+        baseline_seconds=evaluated * OVERLAY_RUN_BASELINE_SECONDS,
+        automated_seconds=evaluated * OVERLAY_RUN_AUTOMATED_SECONDS,
+        metadata={
+            "evaluated": result.evaluated,
+            "created": result.created,
+            "updated": result.updated,
+        },
+    )
+    await session.commit()
+
     return {
         "status": "completed",
         "project_id": project_id,
@@ -106,10 +130,59 @@ async def decide_overlay(
     suggestion.decided_by = payload.decided_by
     suggestion.decision_notes = payload.notes
 
+    await record_project_event(
+        session,
+        project_id=project_id,
+        event_type="overlay_decision",
+        baseline_seconds=OVERLAY_DECISION_BASELINE_SECONDS,
+        automated_seconds=OVERLAY_DECISION_AUTOMATED_SECONDS,
+        accepted_suggestions=1 if decision_value == "approved" else 0,
+        metadata={
+            "suggestion_id": suggestion.id,
+            "decision": decision_value,
+        },
+    )
+
     await session.commit()
     await session.refresh(suggestion)
     item = OverlaySuggestionSchema.model_validate(suggestion, from_attributes=True)
     return {"item": item.model_dump(mode="json")}
+
+
+@router.post("/{project_id}/export")
+async def export_overlay(
+    project_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> Dict[str, object]:
+    """Record an export event for analytics and report suggestion counts."""
+
+    approved_count_result = await session.execute(
+        select(func.count())
+        .select_from(OverlaySuggestion)
+        .where(
+            OverlaySuggestion.project_id == project_id,
+            OverlaySuggestion.status == "approved",
+        )
+    )
+    approved_count = int(approved_count_result.scalar_one() or 0)
+    multiplier = max(approved_count, 1)
+    log_entry = await record_project_event(
+        session,
+        project_id=project_id,
+        event_type="overlay_export",
+        baseline_seconds=multiplier * EXPORT_BASELINE_SECONDS,
+        automated_seconds=multiplier * EXPORT_AUTOMATED_SECONDS,
+        accepted_suggestions=approved_count,
+        metadata={"approved": approved_count},
+    )
+    await session.commit()
+    return {
+        "status": "exported",
+        "accepted": approved_count,
+        "baseline_seconds": log_entry.baseline_seconds,
+        "automated_seconds": log_entry.automated_seconds,
+        "logged_at": log_entry.created_at.isoformat() if log_entry.created_at else None,
+    }
 
 
 __all__ = ["router"]

--- a/backend/app/api/v1/roi.py
+++ b/backend/app/api/v1/roi.py
@@ -1,0 +1,26 @@
+"""ROI analytics endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_session
+from app.core.metrics import compute_project_roi
+
+
+router = APIRouter(prefix="/roi", tags=["roi"])
+
+
+@router.get("/{project_id}")
+async def get_project_roi(
+    project_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, object]:
+    """Return ROI metrics for the requested project."""
+
+    snapshot = await compute_project_roi(session, project_id)
+    return dict(snapshot.to_payload())
+
+
+__all__ = ["router"]

--- a/backend/app/core/metrics/__init__.py
+++ b/backend/app/core/metrics/__init__.py
@@ -1,0 +1,5 @@
+"""Core analytics helpers."""
+
+from .roi import RoiSnapshot, compute_project_roi
+
+__all__ = ["RoiSnapshot", "compute_project_roi"]

--- a/backend/app/core/metrics/roi.py
+++ b/backend/app/core/metrics/roi.py
@@ -1,0 +1,127 @@
+"""ROI metric computations for CAD automation workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import math
+from typing import Iterable, Mapping
+
+from sqlalchemy import case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit import ProjectAuditLog
+from app.models.overlay import OverlayDecision
+
+
+@dataclass(slots=True)
+class RoiSnapshot:
+    """Container for derived ROI metrics."""
+
+    project_id: int
+    iterations: int
+    approvals: int
+    total_decisions: int
+    acceptance_rate: float
+    automation_score: float
+    savings_percent: float
+    review_hours_saved: float
+    payback_weeks: int
+    baseline_hours: float
+    automated_hours: float
+    event_count: int
+    last_event_at: datetime | None
+
+    def to_payload(self) -> Mapping[str, object]:
+        """Serialize the snapshot for API responses."""
+
+        return {
+            "project_id": self.project_id,
+            "iterations": self.iterations,
+            "approvals": self.approvals,
+            "total_decisions": self.total_decisions,
+            "acceptance_rate": round(self.acceptance_rate, 4),
+            "automation_score": round(self.automation_score, 4),
+            "savings_percent": round(self.savings_percent, 2),
+            "review_hours_saved": round(self.review_hours_saved, 2),
+            "payback_weeks": self.payback_weeks,
+            "baseline_hours": round(self.baseline_hours, 2),
+            "automated_hours": round(self.automated_hours, 2),
+            "event_count": self.event_count,
+            "last_event_at": self.last_event_at.isoformat() if self.last_event_at else None,
+        }
+
+
+def _sum(values: Iterable[int | float | None]) -> float:
+    total = 0.0
+    for value in values:
+        if value is None:
+            continue
+        total += float(value)
+    return total
+
+
+async def compute_project_roi(session: AsyncSession, project_id: int) -> RoiSnapshot:
+    """Aggregate audit logs and overlay decisions into ROI metrics."""
+
+    approval_case = case((OverlayDecision.decision == "approved", 1), else_=0)
+    counts_result = await session.execute(
+        select(
+            func.count(OverlayDecision.id),
+            func.coalesce(func.sum(approval_case), 0),
+        ).where(OverlayDecision.project_id == project_id)
+    )
+    total_decisions, approvals = counts_result.one()
+    total_decisions = int(total_decisions or 0)
+    approvals = int(approvals or 0)
+
+    audit_rows = (
+        await session.execute(
+            select(ProjectAuditLog)
+            .where(ProjectAuditLog.project_id == project_id)
+            .order_by(ProjectAuditLog.created_at)
+        )
+    ).scalars().all()
+
+    baseline_seconds = _sum(log.baseline_seconds for log in audit_rows)
+    automated_seconds = _sum(log.automated_seconds for log in audit_rows)
+    time_saved_seconds = max(0.0, baseline_seconds - automated_seconds)
+
+    baseline_hours = baseline_seconds / 3600.0
+    automated_hours = automated_seconds / 3600.0
+    review_hours_saved = time_saved_seconds / 3600.0
+
+    acceptance_rate = approvals / total_decisions if total_decisions else 0.0
+    savings_ratio = time_saved_seconds / baseline_seconds if baseline_seconds else 0.0
+
+    automation_score = min(1.0, (acceptance_rate * 0.6) + (savings_ratio * 0.4))
+    savings_percent = savings_ratio * 100.0
+
+    if review_hours_saved <= 0:
+        payback_weeks = 0
+    else:
+        payback_weeks = max(1, math.ceil(40.0 / review_hours_saved))
+
+    last_event_at = max((log.created_at for log in audit_rows if log.created_at), default=None)
+
+    iterations = sum(1 for log in audit_rows if log.event_type.startswith("overlay_"))
+    event_count = len(audit_rows)
+
+    return RoiSnapshot(
+        project_id=project_id,
+        iterations=iterations,
+        approvals=approvals,
+        total_decisions=total_decisions,
+        acceptance_rate=acceptance_rate,
+        automation_score=automation_score,
+        savings_percent=savings_percent,
+        review_hours_saved=review_hours_saved,
+        payback_weeks=payback_weeks,
+        baseline_hours=baseline_hours,
+        automated_hours=automated_hours,
+        event_count=event_count,
+        last_event_at=last_event_at,
+    )
+
+
+__all__ = ["RoiSnapshot", "compute_project_roi"]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,6 +3,6 @@
 from .base import Base  # noqa: F401
 
 # Import model modules so their metadata is registered with SQLAlchemy.
-from . import imports, overlay, rkp  # noqa: F401  pylint: disable=unused-import
+from . import audit, imports, overlay, rkp  # noqa: F401  pylint: disable=unused-import
 
 __all__ = ["Base"]

--- a/backend/app/models/audit.py
+++ b/backend/app/models/audit.py
@@ -1,0 +1,35 @@
+"""Project audit logging models."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.models.base import BaseModel
+from app.models.types import FlexibleJSONB
+
+
+class ProjectAuditLog(BaseModel):
+    """Discrete audit events captured for ROI analytics."""
+
+    __tablename__ = "project_audit_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    project_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    event_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    baseline_seconds: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    automated_seconds: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    accepted_suggestions: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    metadata: Mapped[dict] = mapped_column(FlexibleJSONB, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        index=True,
+    )
+
+
+__all__ = ["ProjectAuditLog"]

--- a/backend/app/services/audit.py
+++ b/backend/app/services/audit.py
@@ -1,0 +1,37 @@
+"""Helpers for recording project audit events."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit import ProjectAuditLog
+
+
+async def record_project_event(
+    session: AsyncSession,
+    *,
+    project_id: int,
+    event_type: str,
+    baseline_seconds: int = 0,
+    automated_seconds: int = 0,
+    accepted_suggestions: int = 0,
+    metadata: Mapping[str, Any] | None = None,
+) -> ProjectAuditLog:
+    """Persist an audit log entry summarising automation impact."""
+
+    payload = ProjectAuditLog(
+        project_id=project_id,
+        event_type=event_type,
+        baseline_seconds=max(int(baseline_seconds), 0),
+        automated_seconds=max(int(automated_seconds), 0),
+        accepted_suggestions=max(int(accepted_suggestions), 0),
+        metadata=dict(metadata or {}),
+    )
+    session.add(payload)
+    await session.flush()
+    return payload
+
+
+__all__ = ["record_project_event"]

--- a/backend/tests/test_api/test_roi.py
+++ b/backend/tests/test_api/test_roi.py
@@ -1,0 +1,122 @@
+"""ROI analytics API tests."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("pytest_asyncio")
+
+import pytest_asyncio
+from httpx import AsyncClient
+
+from app.core.database import get_session
+from app.core.models.geometry import CanonicalGeometry, GeometryNode, serialize_geometry
+from app.main import app
+from app.models.overlay import OverlaySourceGeometry
+
+PROJECT_ID = 8125
+
+
+@pytest_asyncio.fixture
+async def roi_client(async_session_factory):
+    """Seed overlay geometry and provide an instrumented client."""
+
+    geometry = CanonicalGeometry(
+        root=GeometryNode(
+            node_id="site-002",
+            kind="site",
+            properties={
+                "heritage_zone": False,
+                "flood_zone": "coastal",
+                "site_area_sqm": 14250,
+            },
+            children=[
+                GeometryNode(
+                    node_id="tower-roi",
+                    kind="building",
+                    properties={"height_m": 58},
+                )
+            ],
+        ),
+        metadata={"source": "roi-test"},
+    )
+    serialized = serialize_geometry(geometry)
+    checksum = geometry.fingerprint()
+
+    async with async_session_factory() as session:
+        record = OverlaySourceGeometry(
+            project_id=PROJECT_ID,
+            source_geometry_key="roi-source",
+            graph=serialized,
+            metadata={"fixture": "roi"},
+            checksum=checksum,
+        )
+        session.add(record)
+        await session.commit()
+
+    async def _override_get_session():
+        async with async_session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = _override_get_session
+    async with AsyncClient(app=app, base_url="http://testserver") as client:
+        yield client
+    app.dependency_overrides.pop(get_session, None)
+
+
+@pytest.mark.asyncio
+async def test_roi_metrics_after_workflow(roi_client: AsyncClient) -> None:
+    """Running overlay, decisions and export produces meaningful ROI metrics."""
+
+    run_response = await roi_client.post(f"/api/v1/overlay/{PROJECT_ID}/run")
+    assert run_response.status_code == 200
+
+    list_response = await roi_client.get(f"/api/v1/overlay/{PROJECT_ID}")
+    assert list_response.status_code == 200
+    items = list_response.json()["items"]
+    assert items
+
+    approve_target = next(item for item in items if item["code"] == "tall_building_review")
+    reject_target = next(item for item in items if item["code"] == "flood_mitigation")
+
+    approve_response = await roi_client.post(
+        f"/api/v1/overlay/{PROJECT_ID}/decision",
+        json={
+            "suggestion_id": approve_target["id"],
+            "decision": "approve",
+            "decided_by": "Planner",
+            "notes": "High impact automation.",
+        },
+    )
+    assert approve_response.status_code == 200
+
+    reject_response = await roi_client.post(
+        f"/api/v1/overlay/{PROJECT_ID}/decision",
+        json={
+            "suggestion_id": reject_target["id"],
+            "decision": "reject",
+            "decided_by": "Planner",
+            "notes": "Handled via external review.",
+        },
+    )
+    assert reject_response.status_code == 200
+
+    export_response = await roi_client.post(f"/api/v1/overlay/{PROJECT_ID}/export")
+    assert export_response.status_code == 200
+    export_payload = export_response.json()
+    assert export_payload["baseline_seconds"] > export_payload["automated_seconds"]
+
+    roi_response = await roi_client.get(f"/api/v1/roi/{PROJECT_ID}")
+    assert roi_response.status_code == 200
+    metrics = roi_response.json()
+
+    assert metrics["iterations"] >= 1
+    assert metrics["event_count"] >= 3
+    assert metrics["review_hours_saved"] > 0
+    assert metrics["savings_percent"] > 0
+    assert metrics["automation_score"] > 0
+    assert metrics["acceptance_rate"] > 0
+    assert metrics["last_event_at"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,5 @@ codebase so that policy, engineering, and review practices remain in lockstep.
   monitoring expectations for each upstream feed.
 * [`reviewer_sop.md`](reviewer_sop.md) — the checklist followed by data
   reviewers prior to promoting new references to production.
+* [`roi_metrics.md`](roi_metrics.md) — definition of ROI metrics powering the
+  CAD dashboard panels.

--- a/docs/roi_metrics.md
+++ b/docs/roi_metrics.md
@@ -1,0 +1,23 @@
+# ROI Metrics Reference
+
+The ROI analytics endpoint backs the CAD dashboard panels.  Metrics are
+calculated from overlay review activity and the audit logs captured during
+exports.  Each event records a manual baseline estimate (in seconds), the
+automated duration, and the number of accepted suggestions delivered.
+
+| Metric | Description |
+| --- | --- |
+| `automation_score` | Blended score combining decision acceptance rate and the share of baseline review time saved through automation.  Values are normalised between `0` and `1`. |
+| `savings_percent` | Percentage of manual review time avoided across overlay runs, decisions and exports. |
+| `review_hours_saved` | Total hours of reviewer effort avoided compared to the manual baseline. |
+| `payback_weeks` | Estimated number of weeks to recover a notional 40 hour onboarding investment.  Falls as saved hours increase. |
+| `iterations` | Count of overlay-related events (`overlay_run`, `overlay_decision`, `overlay_export`) recorded for the project. |
+| `acceptance_rate` | Share of overlay decisions marked as approved. |
+| `event_count` | Total audit events available for the ROI snapshot. |
+| `baseline_hours` / `automated_hours` | Aggregated manual baseline versus automated execution hours backing the savings computation. |
+
+The analytics module treats baselines and savings as additive across events, so
+instrumentation should populate `baseline_seconds` and `automated_seconds` on
+`project_audit_logs` entries.  Export flows should also store
+`accepted_suggestions` to provide downstream dashboards with context about the
+volume of automated deliverables.


### PR DESCRIPTION
## Summary
- add project audit log model and helpers to capture overlay run, decision, and export events
- compute ROI metrics from overlay decisions and audit logs with a new API endpoint
- instrument overlay flows plus export hook to emit baselines and accepted counts, document metric semantics, and cover with integration tests

## Testing
- `pytest backend/tests/test_api/test_roi.py` *(skipped: fastapi missing)*

------
https://chatgpt.com/codex/tasks/task_e_68d0629873208320960676ec76ae1e3e