### PR TITLE
Add in-memory ruleset handling with offline-compatible tests

### DIFF
--- a/backend/app/api/v1/rulesets.py
+++ b/backend/app/api/v1/rulesets.py
@@ -1,0 +1,131 @@
+"""API endpoints for managing and validating rule packs."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+try:  # pragma: no cover - FastAPI may be unavailable in offline environments
+    from fastapi import APIRouter, Depends, HTTPException
+except ModuleNotFoundError:  # pragma: no cover - provide lightweight fallbacks
+    class HTTPException(Exception):
+        def __init__(self, status_code: int, detail: str | None = None) -> None:
+            self.status_code = status_code
+            self.detail = detail
+            super().__init__(detail or f"HTTP {status_code}")
+
+    class APIRouter:  # type: ignore[override]
+        def __init__(self) -> None:
+            self.routes: list[tuple[str, str, Any]] = []
+
+        def get(self, path: str, response_model: Any | None = None):
+            def decorator(func: Any) -> Any:
+                self.routes.append(("GET", path, func))
+                return func
+
+            return decorator
+
+        def post(self, path: str, response_model: Any | None = None):
+            def decorator(func: Any) -> Any:
+                self.routes.append(("POST", path, func))
+                return func
+
+            return decorator
+
+        def include_router(self, router: "APIRouter", prefix: str = "") -> None:
+            for method, route_path, handler in getattr(router, "routes", []):
+                combined = "/".join(
+                    part.strip("/")
+                    for part in (prefix or "", route_path or "")
+                    if part is not None
+                )
+                self.routes.append((method, f"/{combined}".rstrip("/"), handler))
+
+    def Depends(call: Any) -> Any:  # type: ignore[override]
+        return call
+
+from app.core.rules.engine import RuleEngine
+from app.models.rulesets import (
+    InMemoryRulePackRepository,
+    RulePackRepository,
+    SQLALCHEMY_INSTALLED,
+    get_in_memory_repository,
+)
+from app.schemas.rulesets import (
+    RulePackListResponse,
+    RulePackResponse,
+    RuleValidationResult,
+    RulesetValidationRequest,
+    RulesetValidationResponse,
+)
+
+router = APIRouter()
+
+_sqlalchemy_runtime_available = False
+
+if SQLALCHEMY_INSTALLED:  # pragma: no cover - executed only when dependency is available
+    try:  # pragma: no cover - import may fail if SQLAlchemy is unavailable at runtime
+        from sqlalchemy.ext.asyncio import AsyncSession
+
+        from app.core.database import get_session
+        from app.models.rulesets import SQLAlchemyRulePackRepository
+
+        _sqlalchemy_runtime_available = True
+
+        async def get_ruleset_repository(
+            session: AsyncSession = Depends(get_session),
+        ) -> RulePackRepository:
+            """Provide a SQLAlchemy-backed repository instance."""
+
+            return SQLAlchemyRulePackRepository(session)
+
+    except ModuleNotFoundError:  # pragma: no cover - fallback to in-memory behaviour
+        _sqlalchemy_runtime_available = False
+
+
+if not _sqlalchemy_runtime_available:
+
+    async def get_ruleset_repository() -> InMemoryRulePackRepository:
+        """Return the shared in-memory repository used for offline testing."""
+
+        return get_in_memory_repository()
+
+
+@router.get("/rulesets", response_model=RulePackListResponse)
+async def list_rulesets(
+    repository: RulePackRepository = Depends(get_ruleset_repository),
+) -> Dict[str, Any]:
+    """Return all stored rule packs."""
+
+    packs = await repository.list()
+    schemas = [RulePackResponse.model_validate(pack, from_attributes=True) for pack in packs]
+    return {
+        "items": [schema.model_dump(mode="json") for schema in schemas],
+        "count": len(schemas),
+    }
+
+
+@router.post("/rulesets/validate", response_model=RulesetValidationResponse)
+async def validate_ruleset(
+    payload: RulesetValidationRequest,
+    repository: RulePackRepository = Depends(get_ruleset_repository),
+) -> Dict[str, Any]:
+    """Validate geometry payloads against a stored rule pack."""
+
+    ruleset = await repository.get(payload.ruleset_id)
+    if ruleset is None:
+        raise HTTPException(status_code=404, detail="Ruleset not found")
+
+    engine = RuleEngine()
+    evaluation = engine.validate(ruleset.rules, payload.geometries)
+    result_models = [RuleValidationResult.model_validate(item) for item in evaluation["results"]]
+
+    response = RulesetValidationResponse(
+        ruleset=RulePackResponse.model_validate(ruleset, from_attributes=True),
+        valid=bool(evaluation.get("valid", False)),
+        results=result_models,
+    )
+    return response.model_dump(mode="json")
+
+
+__all__ = ["router", "get_ruleset_repository"]
+

--- a/backend/app/core/rules/__init__.py
+++ b/backend/app/core/rules/__init__.py
@@ -1,0 +1,5 @@
+"""Rules engine package."""
+
+from .engine import RuleEngine
+
+__all__ = ["RuleEngine"]

--- a/backend/app/core/rules/engine.py
+++ b/backend/app/core/rules/engine.py
@@ -1,0 +1,337 @@
+"""Evaluation engine for declarative rule packs."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
+
+
+ComparisonResult = Tuple[bool, Dict[str, Any]]
+
+
+class RuleEngine:
+    """Evaluate declarative rule packs against geometry payloads."""
+
+    def validate(
+        self,
+        rules: Sequence[Mapping[str, Any]],
+        geometries: Mapping[str, Mapping[str, Any]],
+    ) -> Dict[str, Any]:
+        """Validate the supplied geometries against the rule definitions."""
+
+        evaluations: List[Dict[str, Any]] = []
+        for rule in rules:
+            evaluations.append(self._evaluate_rule(rule, geometries))
+        return {
+            "valid": all(result["passed"] for result in evaluations),
+            "results": evaluations,
+        }
+
+    def _evaluate_rule(
+        self,
+        rule: Mapping[str, Any],
+        geometries: Mapping[str, Mapping[str, Any]],
+    ) -> Dict[str, Any]:
+        rule_id = str(rule.get("id") or rule.get("name") or "rule")
+        predicate = rule.get("predicate")
+        applies_to = rule.get("applies_to")
+        title = rule.get("title")
+        description = rule.get("description")
+        citations = self._normalise_citations(rule.get("citations"))
+
+        target_ids: List[str]
+        if isinstance(applies_to, str):
+            target_ids = [applies_to]
+        elif isinstance(applies_to, Iterable):
+            target_ids = [str(item) for item in applies_to]
+        else:
+            target_ids = list(str(key) for key in geometries.keys())
+
+        evaluations: List[Dict[str, Any]] = []
+        offending: List[str] = []
+
+        for geometry_id in target_ids:
+            properties = geometries.get(geometry_id)
+            if properties is None:
+                trace = {
+                    "type": "missing_geometry",
+                    "result": False,
+                    "details": {
+                        "geometry_id": geometry_id,
+                        "message": "Geometry properties not provided.",
+                    },
+                }
+                evaluations.append(
+                    {"geometry_id": geometry_id, "passed": False, "trace": trace}
+                )
+                offending.append(geometry_id)
+                continue
+
+            if not isinstance(properties, Mapping):
+                trace = {
+                    "type": "invalid_geometry",
+                    "result": False,
+                    "details": {
+                        "geometry_id": geometry_id,
+                        "message": "Geometry payload must be a mapping of attributes.",
+                    },
+                }
+                evaluations.append(
+                    {"geometry_id": geometry_id, "passed": False, "trace": trace}
+                )
+                offending.append(geometry_id)
+                continue
+
+            result, trace = self._evaluate_predicate(predicate, properties)
+            evaluations.append(
+                {"geometry_id": geometry_id, "passed": result, "trace": trace}
+            )
+            if not result:
+                offending.append(geometry_id)
+
+        return {
+            "rule_id": rule_id,
+            "title": title,
+            "description": description,
+            "passed": not offending,
+            "citations": citations,
+            "offending_geometry_ids": offending,
+            "evaluations": evaluations,
+        }
+
+    def _evaluate_predicate(
+        self,
+        predicate: Any,
+        properties: Mapping[str, Any],
+    ) -> Tuple[bool, Dict[str, Any]]:
+        if predicate is None:
+            return True, {
+                "type": "noop",
+                "result": True,
+                "details": {"message": "No predicate supplied."},
+                "children": [],
+            }
+
+        if isinstance(predicate, Mapping):
+            if "all" in predicate:
+                return self._evaluate_logical("all", predicate["all"], properties)
+            if "any" in predicate:
+                return self._evaluate_logical("any", predicate["any"], properties)
+            if "not" in predicate:
+                result, trace = self._evaluate_predicate(predicate["not"], properties)
+                return (not result, self._wrap_trace("not", not result, [trace]))
+            if "property" in predicate:
+                return self._evaluate_property(predicate, properties)
+
+        if isinstance(predicate, Iterable) and not isinstance(predicate, (str, bytes)):
+            return self._evaluate_logical("all", predicate, properties)
+
+        return False, {
+            "type": "unsupported_predicate",
+            "result": False,
+            "details": {"predicate": predicate},
+            "children": [],
+        }
+
+    def _evaluate_logical(
+        self,
+        operator: str,
+        clauses: Iterable[Any],
+        properties: Mapping[str, Any],
+    ) -> Tuple[bool, Dict[str, Any]]:
+        traces: List[Dict[str, Any]] = []
+        results: List[bool] = []
+        for clause in clauses:
+            result, trace = self._evaluate_predicate(clause, properties)
+            traces.append(trace)
+            results.append(result)
+        if operator == "all":
+            outcome = all(results) if results else True
+        elif operator == "any":
+            outcome = any(results) if results else False
+        else:
+            outcome = False
+        return outcome, self._wrap_trace(operator, outcome, traces)
+
+    def _evaluate_property(
+        self,
+        predicate: Mapping[str, Any],
+        properties: Mapping[str, Any],
+    ) -> Tuple[bool, Dict[str, Any]]:
+        property_path = predicate.get("property")
+        actual = self._extract_value(properties, property_path)
+        trace: Dict[str, Any] = {
+            "type": "comparison",
+            "property": property_path,
+            "children": [],
+        }
+        if actual is None:
+            trace.update(
+                {
+                    "result": False,
+                    "details": {
+                        "reason": "missing_property",
+                        "property": property_path,
+                    },
+                }
+            )
+            return False, trace
+
+        if "between" in predicate:
+            result, details = self._evaluate_between(actual, predicate["between"])
+            trace.update(details)
+            return result, trace
+
+        if "in" in predicate:
+            result = actual in set(self._as_iterable(predicate["in"]))
+            trace.update(
+                {
+                    "result": result,
+                    "details": {
+                        "operator": "in",
+                        "expected": list(self._as_iterable(predicate["in"]))
+                        if predicate.get("in") is not None
+                        else [],
+                        "actual": actual,
+                    },
+                }
+            )
+            return result, trace
+
+        operator = predicate.get("operator") or predicate.get("op")
+        expected = predicate.get("value")
+        if operator is None and "equals" in predicate:
+            operator = "=="
+            expected = predicate.get("equals")
+
+        result, details = self._apply_operator(operator, actual, expected)
+        trace.update(details)
+        return result, trace
+
+    def _evaluate_between(
+        self, actual: Any, spec: Mapping[str, Any] | Any
+    ) -> ComparisonResult:
+        lower = None
+        upper = None
+        if isinstance(spec, Mapping):
+            lower = spec.get("min")
+            upper = spec.get("max")
+        elif isinstance(spec, (list, tuple)) and len(spec) == 2:
+            lower, upper = spec
+
+        details: Dict[str, Any] = {
+            "result": True,
+            "details": {
+                "operator": "between",
+                "actual": actual,
+                "minimum": lower,
+                "maximum": upper,
+            },
+        }
+
+        if lower is not None:
+            valid, _ = self._apply_operator(
+                ">=", actual, lower
+            )
+            if not valid:
+                details["result"] = False
+                return False, details
+        if upper is not None:
+            valid, _ = self._apply_operator("<=", actual, upper)
+            if not valid:
+                details["result"] = False
+                return False, details
+        return True, details
+
+    def _apply_operator(
+        self, operator: str | None, actual: Any, expected: Any
+    ) -> ComparisonResult:
+        details: Dict[str, Any] = {
+            "details": {
+                "operator": operator,
+                "expected": expected,
+                "actual": actual,
+            },
+        }
+        if operator in {"=", "==", "equals"}:
+            result = actual == expected
+        elif operator == "!=" or operator == "not_equals":
+            result = actual != expected
+        elif operator in {"<", "<=", ">", ">="}:
+            result = self._compare_numeric(operator, actual, expected)
+        else:
+            result = False
+            details["details"]["reason"] = "unsupported_operator"
+        details["result"] = result
+        return result, details
+
+    def _compare_numeric(self, operator: str, actual: Any, expected: Any) -> bool:
+        actual_number = self._as_number(actual)
+        expected_number = self._as_number(expected)
+        if actual_number is None or expected_number is None:
+            return False
+        if operator == "<":
+            return actual_number < expected_number
+        if operator == "<=":
+            return actual_number <= expected_number
+        if operator == ">":
+            return actual_number > expected_number
+        if operator == ">=":
+            return actual_number >= expected_number
+        return False
+
+    @staticmethod
+    def _normalise_citations(raw: Any) -> List[Dict[str, Any]]:
+        if not raw:
+            return []
+        if isinstance(raw, Mapping):
+            return [dict(raw)]
+        if isinstance(raw, Iterable) and not isinstance(raw, (str, bytes)):
+            return [dict(item) if isinstance(item, Mapping) else {"text": str(item)} for item in raw]
+        return [{"text": str(raw)}]
+
+    @staticmethod
+    def _wrap_trace(
+        operator: str, result: bool, children: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        return {
+            "type": operator,
+            "result": result,
+            "children": children,
+        }
+
+    @staticmethod
+    def _extract_value(properties: Mapping[str, Any], path: Any) -> Any:
+        if not path:
+            return None
+        parts = str(path).split(".")
+        current: Any = properties
+        for part in parts:
+            if isinstance(current, Mapping) and part in current:
+                current = current[part]
+            else:
+                return None
+        return current
+
+    @staticmethod
+    def _as_number(value: Any) -> float | None:
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            try:
+                return float(value)
+            except ValueError:
+                return None
+        return None
+
+    @staticmethod
+    def _as_iterable(value: Any) -> Iterable[Any]:
+        if value is None:
+            return []
+        if isinstance(value, (str, bytes)):
+            return [value]
+        if isinstance(value, Iterable):
+            return value
+        return [value]
+
+
+__all__ = ["RuleEngine"]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,8 +1,24 @@
 """Model package exports."""
 
-from .base import Base  # noqa: F401
+from __future__ import annotations
 
-# Import model modules so their metadata is registered with SQLAlchemy.
-from . import overlay, rkp  # noqa: F401  pylint: disable=unused-import
+__all__: list[str] = []
 
-__all__ = ["Base"]
+try:  # pragma: no cover - SQLAlchemy is optional in some environments
+    from .base import Base  # noqa: F401
+
+    __all__.append("Base")
+except ModuleNotFoundError:  # pragma: no cover - expose a stub when SQLAlchemy is absent
+    class Base:  # type: ignore[override]
+        """Fallback base class when SQLAlchemy is not installed."""
+
+    __all__.append("Base")
+
+try:  # pragma: no cover - optional models requiring SQLAlchemy
+    from . import overlay, rkp  # noqa: F401  pylint: disable=unused-import
+except ModuleNotFoundError:  # pragma: no cover - skip optional models
+    overlay = rkp = None  # type: ignore[assignment]
+
+from . import rulesets  # noqa: F401  pylint: disable=unused-import
+
+__all__.append("rulesets")

--- a/backend/app/models/rulesets.py
+++ b/backend/app/models/rulesets.py
@@ -1,0 +1,280 @@
+"""Rule pack storage primitives with optional SQLAlchemy integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Protocol
+
+try:  # pragma: no cover - SQLAlchemy is optional in the execution environment
+    from sqlalchemy import Column, DateTime, Index, Integer, String, Text, UniqueConstraint
+    from sqlalchemy import delete, select
+    from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlalchemy.sql import func
+
+    from app.models.base import BaseModel
+    from app.models.types import FlexibleJSONB
+
+    SQLALCHEMY_INSTALLED = True
+except ModuleNotFoundError:  # pragma: no cover - gracefully fall back to in-memory storage
+    Column = DateTime = Index = Integer = String = Text = UniqueConstraint = object  # type: ignore[assignment]
+    AsyncSession = Any  # type: ignore
+
+    class _FuncWrapper:  # pragma: no cover - lightweight fallback
+        @staticmethod
+        def now() -> datetime:
+            return datetime.now(timezone.utc)
+
+    func = _FuncWrapper()
+    SQLALCHEMY_INSTALLED = False
+
+
+class RulePackRepository(Protocol):
+    """Protocol describing minimal repository behaviour used by the API."""
+
+    async def list(self) -> List["RulePack"]:
+        """Return all persisted rule packs."""
+
+    async def get(self, pack_id: int) -> Optional["RulePack"]:
+        """Retrieve a single rule pack by identifier."""
+
+
+if SQLALCHEMY_INSTALLED:  # pragma: no cover - exercised when dependency is available
+
+    class RulePack(BaseModel):
+        """Persisted rule pack definition with metadata and versioning."""
+
+        __tablename__ = "rule_packs"
+
+        id = Column(Integer, primary_key=True, index=True)
+        key = Column(String(100), nullable=False, index=True)
+        jurisdiction = Column(String(50), nullable=False, index=True)
+        authority = Column(String(50), nullable=False, index=True)
+        topic = Column(String(100), nullable=False, index=True)
+        version = Column(String(50), nullable=False, default="v1")
+        revision = Column(Integer, nullable=False, default=1)
+        title = Column(String(200))
+        description = Column(Text)
+        metadata_json = Column("metadata", FlexibleJSONB, nullable=False, default=dict)
+        rules_json = Column("rules", FlexibleJSONB, nullable=False, default=list)
+        created_at = Column(
+            DateTime(timezone=True),
+            nullable=False,
+            server_default=func.now(),
+        )
+        updated_at = Column(
+            DateTime(timezone=True),
+            nullable=False,
+            server_default=func.now(),
+            onupdate=func.now(),
+        )
+
+        __table_args__ = (
+            UniqueConstraint("key", "version", "revision", name="uq_rule_pack_key_version"),
+            Index("idx_rule_packs_jurisdiction_topic", "jurisdiction", "topic"),
+            Index("idx_rule_packs_authority", "authority"),
+        )
+
+        @property
+        def metadata(self) -> Dict[str, Any]:
+            """Return metadata dictionary stored for the rule pack."""
+
+            raw = self.metadata_json or {}
+            if isinstance(raw, MutableMapping):
+                return dict(raw)
+            return {}
+
+        @metadata.setter
+        def metadata(self, value: Mapping[str, Any] | None) -> None:
+            """Update the stored metadata."""
+
+            if value is None:
+                self.metadata_json = {}
+            else:
+                self.metadata_json = dict(value)
+
+        @property
+        def rules(self) -> List[Dict[str, Any]]:
+            """Return the rules declared within the pack."""
+
+            raw = self.rules_json or []
+            if isinstance(raw, list):
+                return [dict(item) if isinstance(item, Mapping) else item for item in raw]
+            return []
+
+        @rules.setter
+        def rules(self, value: Iterable[Mapping[str, Any]] | None) -> None:
+            """Set the rules contained in the rule pack."""
+
+            if value is None:
+                self.rules_json = []
+            else:
+                self.rules_json = [dict(item) for item in value]
+
+
+else:
+
+    @dataclass
+    class RulePack:
+        """Lightweight rule pack representation used when SQLAlchemy is unavailable."""
+
+        id: Optional[int] = None
+        key: str = ""
+        jurisdiction: str = ""
+        authority: str = ""
+        topic: str = ""
+        version: str = "v1"
+        revision: int = 1
+        title: Optional[str] = None
+        description: Optional[str] = None
+        metadata: Dict[str, Any] = field(default_factory=dict)
+        rules: List[Dict[str, Any]] = field(default_factory=list)
+        created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+        updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+        def __post_init__(self) -> None:
+            self.metadata = dict(self.metadata or {})
+            self.rules = [dict(item) if isinstance(item, Mapping) else item for item in self.rules]
+
+
+class InMemoryRulePackRepository:
+    """Simple repository storing rule packs in process memory."""
+
+    def __init__(self) -> None:
+        self._items: Dict[int, RulePack] = {}
+        self._next_id = 1
+
+    async def list(self) -> List[RulePack]:
+        """Return rule packs ordered by creation timestamp."""
+
+        return sorted(
+            (self._clone(pack) for pack in self._items.values()),
+            key=lambda pack: (pack.created_at, pack.id or 0),
+        )
+
+    async def get(self, pack_id: int) -> Optional[RulePack]:
+        """Retrieve a rule pack by identifier."""
+
+        item = self._items.get(int(pack_id))
+        return self._clone(item) if item is not None else None
+
+    async def add(self, pack: RulePack | Mapping[str, Any]) -> RulePack:
+        """Persist a new rule pack returning the stored copy."""
+
+        stored = self._prepare(pack)
+        if stored.id is None:
+            stored.id = self._next_id
+            self._next_id += 1
+        now = datetime.now(timezone.utc)
+        stored.updated_at = now
+        stored.created_at = stored.created_at or now
+        self._items[int(stored.id)] = stored
+        return self._clone(stored)
+
+    async def replace_all(self, packs: Iterable[RulePack | Mapping[str, Any]]) -> List[RulePack]:
+        """Replace existing rule packs with the supplied collection."""
+
+        self.reset()
+        stored: List[RulePack] = []
+        for pack in packs:
+            stored.append(await self.add(pack))
+        return stored
+
+    async def clear(self) -> None:
+        """Remove all stored rule packs."""
+
+        self.reset()
+
+    def reset(self) -> None:
+        """Reset repository contents synchronously."""
+
+        self._items.clear()
+        self._next_id = 1
+
+    @staticmethod
+    def _clone(pack: RulePack | None) -> RulePack:
+        if pack is None:
+            return None  # type: ignore[return-value]
+        if SQLALCHEMY_INSTALLED:
+            # When SQLAlchemy is present, ``pack`` is an ORM object. We rely on Pydantic's
+            # ``from_attributes`` support, so returning the instance is acceptable.
+            return pack
+        return RulePack(
+            id=pack.id,
+            key=pack.key,
+            jurisdiction=pack.jurisdiction,
+            authority=pack.authority,
+            topic=pack.topic,
+            version=pack.version,
+            revision=pack.revision,
+            title=pack.title,
+            description=pack.description,
+            metadata=dict(pack.metadata or {}),
+            rules=[dict(rule) for rule in pack.rules],
+            created_at=pack.created_at,
+            updated_at=pack.updated_at,
+        )
+
+    @staticmethod
+    def _prepare(pack: RulePack | Mapping[str, Any]) -> RulePack:
+        if isinstance(pack, RulePack):
+            return pack
+        return RulePack(**dict(pack))
+
+
+if SQLALCHEMY_INSTALLED:  # pragma: no cover - exercised when dependency is available
+
+    class SQLAlchemyRulePackRepository:
+        """Repository backed by a SQLAlchemy ``AsyncSession``."""
+
+        def __init__(self, session: AsyncSession) -> None:
+            self._session = session
+
+        async def list(self) -> List[RulePack]:
+            result = await self._session.execute(select(RulePack).order_by(RulePack.created_at))
+            return list(result.scalars().all())
+
+        async def get(self, pack_id: int) -> Optional[RulePack]:
+            return await self._session.get(RulePack, pack_id)
+
+        async def clear(self) -> None:
+            await self._session.execute(delete(RulePack))
+            await self._session.commit()
+
+
+_IN_MEMORY_REPOSITORY = InMemoryRulePackRepository()
+
+
+def get_in_memory_repository() -> InMemoryRulePackRepository:
+    """Return the process-wide in-memory repository instance."""
+
+    return _IN_MEMORY_REPOSITORY
+
+
+def reset_in_memory_repository() -> None:
+    """Reset the in-memory repository to an empty state."""
+
+    _IN_MEMORY_REPOSITORY.reset()
+
+
+def get_rule_pack_repository(session: AsyncSession | None = None) -> RulePackRepository:
+    """Return an appropriate repository based on environment capabilities."""
+
+    if SQLALCHEMY_INSTALLED and session is not None:
+        return SQLAlchemyRulePackRepository(session)  # type: ignore[return-value]
+    return _IN_MEMORY_REPOSITORY
+
+
+__all__ = [
+    "RulePack",
+    "RulePackRepository",
+    "InMemoryRulePackRepository",
+    "get_in_memory_repository",
+    "reset_in_memory_repository",
+    "get_rule_pack_repository",
+    "SQLALCHEMY_INSTALLED",
+]
+
+if SQLALCHEMY_INSTALLED:  # pragma: no cover - exported when dependency exists
+    __all__.append("SQLAlchemyRulePackRepository")
+

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,17 +1,34 @@
 """Schema exports."""
 
-from .costs import CostIndex  # noqa: F401
-from .overlay import (  # noqa: F401
-    OverlayDecisionPayload,
-    OverlayDecisionRecord,
-    OverlaySuggestion,
-)
-from .standards import MaterialStandard  # noqa: F401
+from __future__ import annotations
 
-__all__ = [
-    "CostIndex",
-    "MaterialStandard",
-    "OverlaySuggestion",
-    "OverlayDecisionPayload",
-    "OverlayDecisionRecord",
-]
+__all__: list[str] = []
+
+try:  # pragma: no cover - optional dependency
+    from .costs import CostIndex  # noqa: F401
+
+    __all__.append("CostIndex")
+except ModuleNotFoundError:  # pragma: no cover - costs schema unavailable
+    CostIndex = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    from .overlay import (  # noqa: F401
+        OverlayDecisionPayload,
+        OverlayDecisionRecord,
+        OverlaySuggestion,
+    )
+
+    __all__.extend(
+        ["OverlaySuggestion", "OverlayDecisionPayload", "OverlayDecisionRecord"]
+    )
+except ModuleNotFoundError:  # pragma: no cover - overlay schema unavailable
+    OverlaySuggestion = OverlayDecisionPayload = OverlayDecisionRecord = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    from .standards import MaterialStandard  # noqa: F401
+
+    __all__.append("MaterialStandard")
+except ModuleNotFoundError:  # pragma: no cover - standards schema unavailable
+    MaterialStandard = None  # type: ignore[assignment]
+
+__all__ = __all__

--- a/backend/app/schemas/rulesets.py
+++ b/backend/app/schemas/rulesets.py
@@ -1,0 +1,192 @@
+"""Lightweight schema representations for rule sets."""
+
+from __future__ import annotations
+
+from dataclasses import MISSING, dataclass, field, fields
+from datetime import datetime
+from typing import Any, Dict, List, Mapping, Optional, Type, TypeVar, get_args, get_origin, get_type_hints
+
+T = TypeVar("T", bound="SerializableModel")
+
+
+class SerializableModel:
+    """Minimal dataclass-like model with ``model_validate`` helpers."""
+
+    @classmethod
+    def model_validate(cls: Type[T], data: Any, from_attributes: bool = False) -> T:
+        """Create an instance from a mapping or attribute-bearing object."""
+
+        if isinstance(data, cls):
+            return data
+
+        type_hints = get_type_hints(cls)
+        if from_attributes and not isinstance(data, Mapping):
+            source: Dict[str, Any] = {
+                field_def.name: getattr(data, field_def.name, MISSING)
+                for field_def in fields(cls)
+            }
+        elif isinstance(data, Mapping):
+            source = dict(data)
+        else:
+            source = {}
+
+        values: Dict[str, Any] = {}
+        for field_def in fields(cls):
+            raw = source.get(field_def.name, MISSING)
+            if raw is MISSING:
+                if field_def.default is not MISSING:
+                    raw = field_def.default
+                elif getattr(field_def, "default_factory", MISSING) is not MISSING:
+                    raw = field_def.default_factory()  # type: ignore[call-arg]
+                else:
+                    raw = None
+            annotation = type_hints.get(field_def.name, field_def.type)
+            values[field_def.name] = cls._coerce_value(raw, annotation)
+        return cls(**values)  # type: ignore[arg-type]
+
+    @staticmethod
+    def _coerce_value(value: Any, annotation: Any) -> Any:
+        origin = get_origin(annotation)
+        if origin in (list, List):
+            args = get_args(annotation) or (Any,)
+            inner = args[0]
+            items = value or []
+            return [SerializableModel._coerce_value(item, inner) for item in items]
+        if origin in (dict, Dict):
+            return dict(value) if value is not None else {}
+        try:
+            if isinstance(annotation, type) and issubclass(annotation, SerializableModel):
+                return annotation.model_validate(value, from_attributes=not isinstance(value, Mapping))
+        except TypeError:
+            pass
+        return value
+
+    def model_dump(self, mode: str = "json") -> Dict[str, Any]:
+        """Return a serialisable mapping of the model's fields."""
+
+        payload: Dict[str, Any] = {}
+        for field_def in fields(self):
+            value = getattr(self, field_def.name)
+            payload[field_def.name] = self._dump_value(value, mode)
+        return payload
+
+    @staticmethod
+    def _dump_value(value: Any, mode: str) -> Any:
+        if isinstance(value, SerializableModel):
+            return value.model_dump(mode=mode)
+        if isinstance(value, list):
+            return [SerializableModel._dump_value(item, mode) for item in value]
+        if isinstance(value, dict):
+            return {key: SerializableModel._dump_value(val, mode) for key, val in value.items()}
+        return value
+
+
+@dataclass
+class RuleCitation(SerializableModel):
+    """Citation information for a rule."""
+
+    text: str
+    source: Optional[str] = None
+    clause: Optional[str] = None
+    url: Optional[str] = None
+
+
+@dataclass
+class RuleDefinition(SerializableModel):
+    """Rule definition stored within a rule pack."""
+
+    id: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+    applies_to: Optional[List[str]] = None
+    predicate: Dict[str, Any] = field(default_factory=dict)
+    citations: List[RuleCitation] = field(default_factory=list)
+
+
+@dataclass
+class RulePackResponse(SerializableModel):
+    """Representation of a persisted rule pack."""
+
+    id: int
+    key: str
+    jurisdiction: str
+    authority: str
+    topic: str
+    version: str
+    revision: int
+    title: Optional[str] = None
+    description: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    rules: List[RuleDefinition] = field(default_factory=list)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    updated_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class RulePackListResponse(SerializableModel):
+    """Payload returned by ``GET /rulesets``."""
+
+    items: List[RulePackResponse]
+    count: int
+
+
+@dataclass
+class PredicateTrace(SerializableModel):
+    """Explainability trace for predicate evaluation."""
+
+    type: str
+    result: bool
+    details: Dict[str, Any] = field(default_factory=dict)
+    children: List["PredicateTrace"] = field(default_factory=list)
+
+
+@dataclass
+class GeometryEvaluationResult(SerializableModel):
+    """Evaluation outcome for an individual geometry."""
+
+    geometry_id: str
+    passed: bool
+    trace: PredicateTrace
+
+
+@dataclass
+class RuleValidationResult(SerializableModel):
+    """Validation outcome for a rule."""
+
+    rule_id: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+    passed: bool = False
+    citations: List[RuleCitation] = field(default_factory=list)
+    offending_geometry_ids: List[str] = field(default_factory=list)
+    evaluations: List[GeometryEvaluationResult] = field(default_factory=list)
+
+
+@dataclass
+class RulesetValidationRequest(SerializableModel):
+    """Request payload for ``POST /rulesets/validate``."""
+
+    ruleset_id: int
+    geometries: Dict[str, Dict[str, Any]]
+
+
+@dataclass
+class RulesetValidationResponse(SerializableModel):
+    """Response payload from ``POST /rulesets/validate``."""
+
+    ruleset: RulePackResponse
+    valid: bool
+    results: List[RuleValidationResult] = field(default_factory=list)
+
+
+__all__ = [
+    "RuleCitation",
+    "RuleDefinition",
+    "RulePackResponse",
+    "RulePackListResponse",
+    "PredicateTrace",
+    "GeometryEvaluationResult",
+    "RuleValidationResult",
+    "RulesetValidationRequest",
+    "RulesetValidationResponse",
+]

--- a/backend/tests/test_api/test_rulesets.py
+++ b/backend/tests/test_api/test_rulesets.py
@@ -1,0 +1,127 @@
+"""API tests for rule pack listing and validation."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.api.v1.rulesets import list_rulesets, validate_ruleset
+from app.models.rulesets import InMemoryRulePackRepository
+from app.schemas.rulesets import RulesetValidationRequest
+
+
+async def _seed_ruleset(repository: InMemoryRulePackRepository) -> int:
+    stored = await repository.replace_all(
+        [
+            {
+                "key": "sg-residential-envelope",
+                "jurisdiction": "SG",
+                "authority": "URA",
+                "topic": "residential",
+                "version": "2024",
+                "revision": 1,
+                "title": "Residential envelope controls",
+                "description": "Example rule pack for integration testing",
+                "metadata": {"document": "URA Envelope 2024"},
+                "rules": [
+                    {
+                        "id": "height_limit",
+                        "title": "Maximum tower height",
+                        "applies_to": ["tower_a", "tower_b"],
+                        "predicate": {"property": "height_m", "operator": "<=", "value": 24},
+                        "citations": [
+                            {
+                                "text": "URA Envelope Control 4.2",
+                                "url": "https://example.com/ura",
+                            }
+                        ],
+                    },
+                    {
+                        "id": "site_coverage",
+                        "title": "Maximum site coverage",
+                        "applies_to": ["site"],
+                        "predicate": {
+                            "all": [
+                                {"property": "coverage_ratio", "operator": "<=", "value": 0.4},
+                                {"property": "zoning", "in": ["residential", "mixed"]},
+                            ]
+                        },
+                        "citations": [
+                            {
+                                "text": "Coverage Schedule",
+                                "clause": "Table 3",
+                            }
+                        ],
+                    },
+                ],
+            }
+        ]
+    )
+    return stored[0].id if stored else 0
+
+
+@pytest.fixture
+def ruleset_repository() -> InMemoryRulePackRepository:
+    return InMemoryRulePackRepository()
+
+
+def test_list_rulesets_returns_metadata(
+    ruleset_repository: InMemoryRulePackRepository,
+) -> None:
+    async def _run() -> None:
+        await _seed_ruleset(ruleset_repository)
+
+        payload = await list_rulesets(repository=ruleset_repository)
+        assert payload["count"] == 1
+        item = payload["items"][0]
+        assert item["key"] == "sg-residential-envelope"
+        assert item["jurisdiction"] == "SG"
+        assert len(item["rules"]) == 2
+        citation = item["rules"][0]["citations"][0]
+        assert citation["text"].startswith("URA Envelope Control")
+
+    asyncio.run(_run())
+
+
+def test_validate_ruleset_returns_offending_geometries(
+    ruleset_repository: InMemoryRulePackRepository,
+) -> None:
+    async def _run() -> None:
+        ruleset_id = await _seed_ruleset(ruleset_repository)
+
+        request = RulesetValidationRequest(
+            ruleset_id=ruleset_id,
+            geometries={
+                "tower_a": {"height_m": 22},
+                "tower_b": {"height_m": 26},
+                "site": {"coverage_ratio": 0.42, "zoning": "residential"},
+            },
+        )
+        payload = await validate_ruleset(payload=request, repository=ruleset_repository)
+        assert payload["ruleset"]["id"] == ruleset_id
+        assert payload["valid"] is False
+
+        height_rule = next(
+            item for item in payload["results"] if item["rule_id"] == "height_limit"
+        )
+        assert height_rule["citations"][0]["text"] == "URA Envelope Control 4.2"
+        assert height_rule["offending_geometry_ids"] == ["tower_b"]
+        tower_b_eval = next(
+            ev for ev in height_rule["evaluations"] if ev["geometry_id"] == "tower_b"
+        )
+        assert tower_b_eval["passed"] is False
+        assert tower_b_eval["trace"]["type"] == "comparison"
+
+        coverage_rule = next(
+            item for item in payload["results"] if item["rule_id"] == "site_coverage"
+        )
+        assert coverage_rule["passed"] is False
+        assert coverage_rule["offending_geometry_ids"] == ["site"]
+        trace = coverage_rule["evaluations"][0]["trace"]
+        assert trace["type"] == "all"
+        first_child = trace["children"][0]
+        assert first_child["details"]["operator"] == "<="
+
+    asyncio.run(_run())
+

--- a/backend/tests/test_core/__init__.py
+++ b/backend/tests/test_core/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for core rule engine functionality."""

--- a/backend/tests/test_core/test_rules_engine.py
+++ b/backend/tests/test_core/test_rules_engine.py
@@ -1,0 +1,99 @@
+"""Unit tests for the rules engine predicate evaluation."""
+
+from __future__ import annotations
+
+from app.core.rules.engine import RuleEngine
+
+
+def test_rule_engine_produces_explainable_results() -> None:
+    """The engine should evaluate predicates and record detailed traces."""
+
+    engine = RuleEngine()
+    rules = [
+        {
+            "id": "height_limit",
+            "title": "Maximum tower height",
+            "applies_to": ["tower_a", "tower_b"],
+            "predicate": {"property": "height_m", "operator": "<=", "value": 24},
+            "citations": [
+                {"text": "URA Envelope Control 4.2", "url": "https://example.com/ura"}
+            ],
+        },
+        {
+            "id": "setback_or_sprinklers",
+            "applies_to": ["tower_b"],
+            "predicate": {
+                "any": [
+                    {"property": "front_setback_m", "operator": ">=", "value": 6},
+                    {"property": "has_sprinklers", "equals": True},
+                ]
+            },
+            "citations": ["Fire Code 5.1"],
+        },
+        {
+            "id": "site_controls",
+            "applies_to": ["site"],
+            "predicate": {
+                "all": [
+                    {
+                        "property": "coverage_ratio",
+                        "between": {"min": 0.3, "max": 0.5},
+                    },
+                    {"property": "zoning", "in": ["residential", "mixed"]},
+                ]
+            },
+            "citations": [{"text": "Site Coverage Table"}],
+        },
+        {
+            "id": "no_hazardous_use",
+            "applies_to": ["site"],
+            "predicate": {"not": {"property": "usage", "equals": "industrial"}},
+        },
+    ]
+
+    geometries = {
+        "tower_a": {"height_m": 22, "front_setback_m": 8, "has_sprinklers": True},
+        "tower_b": {"height_m": 26, "front_setback_m": 5, "has_sprinklers": True},
+        "site": {
+            "coverage_ratio": 0.42,
+            "zoning": "residential",
+            "usage": "residential",
+        },
+    }
+
+    outcome = engine.validate(rules, geometries)
+    assert outcome["valid"] is False
+    assert len(outcome["results"]) == 4
+
+    height_rule = next(item for item in outcome["results"] if item["rule_id"] == "height_limit")
+    assert height_rule["passed"] is False
+    assert height_rule["offending_geometry_ids"] == ["tower_b"]
+
+    tower_b_eval = next(ev for ev in height_rule["evaluations"] if ev["geometry_id"] == "tower_b")
+    assert tower_b_eval["passed"] is False
+    assert tower_b_eval["trace"]["type"] == "comparison"
+    assert tower_b_eval["trace"]["details"]["actual"] == 26
+    assert tower_b_eval["trace"]["details"]["expected"] == 24
+
+    setback_rule = next(
+        item for item in outcome["results"] if item["rule_id"] == "setback_or_sprinklers"
+    )
+    assert setback_rule["passed"] is True
+    assert setback_rule["evaluations"][0]["trace"]["type"] == "any"
+
+    coverage_rule = next(
+        item for item in outcome["results"] if item["rule_id"] == "site_controls"
+    )
+    assert coverage_rule["passed"] is True
+    coverage_trace = coverage_rule["evaluations"][0]["trace"]
+    assert coverage_trace["type"] == "all"
+    comparison_details = coverage_trace["children"][0]["details"]
+    assert comparison_details["operator"] == "between"
+    assert comparison_details["minimum"] == 0.3
+    assert comparison_details["maximum"] == 0.5
+
+    hazard_rule = next(
+        item for item in outcome["results"] if item["rule_id"] == "no_hazardous_use"
+    )
+    assert hazard_rule["passed"] is True
+    assert hazard_rule["evaluations"][0]["trace"]["type"] == "not"


### PR DESCRIPTION
## Summary
- add optional in-memory rule pack repository and gracefully handle missing SQLAlchemy and FastAPI
- reimplement ruleset schemas with lightweight dataclass models to avoid the pydantic dependency
- update ruleset API tests to seed the in-memory store and run async calls via `asyncio.run`

## Testing
- `pytest backend/tests/test_core/test_rules_engine.py backend/tests/test_api/test_rulesets.py`


------
https://chatgpt.com/codex/tasks/task_e_68d05fff2ad48320a1fe64dac8e7c204