### PR TITLE
Add background job infrastructure and CAD parsing pipeline

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -6,6 +6,7 @@ from . import (
     costs,
     ergonomics,
     export,
+    imports,
     overlay,
     products,
     review,
@@ -26,5 +27,6 @@ api_router.include_router(costs.router)
 api_router.include_router(overlay.router)
 api_router.include_router(export.router)
 api_router.include_router(roi.router)
+api_router.include_router(imports.router)
 
 __all__ = ["api_router"]

--- a/backend/app/schemas/imports.py
+++ b/backend/app/schemas/imports.py
@@ -44,6 +44,7 @@ class ParseStatusResponse(BaseModel):
     completed_at: Optional[datetime]
     result: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
+    job_id: Optional[str] = None
 
     class Config:
         """Model configuration."""

--- a/backend/jobs/__init__.py
+++ b/backend/jobs/__init__.py
@@ -1,3 +1,272 @@
-"""Background jobs for synchronous execution in tests."""
+"""Background job infrastructure and helpers."""
 
-__all__ = []
+from __future__ import annotations
+
+import asyncio
+import inspect
+import os
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, Mapping, Optional, Tuple
+
+try:  # pragma: no cover - optional dependency, available in some deployments
+    from celery import Celery  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - keep inline fallback working
+    Celery = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency, available in some deployments
+    from redis import Redis  # type: ignore
+    from rq import Queue  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - keep inline fallback working
+    Redis = None  # type: ignore[assignment]
+    Queue = None  # type: ignore[assignment]
+
+from app.core.config import settings
+
+
+JobFunc = Callable[..., Awaitable[Any] | Any]
+
+
+@dataclass(slots=True)
+class JobDispatch:
+    """Metadata describing a scheduled job."""
+
+    backend: str
+    job_name: str
+    queue: Optional[str]
+    status: str
+    task_id: Optional[str] = None
+    result: Any | None = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return a JSON serialisable representation."""
+
+        payload: Dict[str, Any] = {
+            "backend": self.backend,
+            "job_name": self.job_name,
+            "queue": self.queue,
+            "status": self.status,
+        }
+        if self.task_id:
+            payload["task_id"] = self.task_id
+        if self.result is not None:
+            payload["result"] = self.result
+        return payload
+
+
+class _BaseBackend:
+    """Protocol implemented by queue backends."""
+
+    name: str
+
+    def register(self, func: JobFunc, name: str, queue: Optional[str]) -> JobFunc:
+        raise NotImplementedError
+
+    async def enqueue(
+        self,
+        name: str,
+        queue: Optional[str],
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> JobDispatch:
+        raise NotImplementedError
+
+
+class _InlineBackend(_BaseBackend):
+    """Execute jobs synchronously in the current event loop."""
+
+    name = "inline"
+
+    def __init__(self) -> None:
+        self._registry: Dict[str, Tuple[JobFunc, Optional[str]]] = {}
+
+    def register(self, func: JobFunc, name: str, queue: Optional[str]) -> JobFunc:
+        self._registry[name] = (func, queue)
+        return func
+
+    async def enqueue(
+        self,
+        name: str,
+        queue: Optional[str],
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> JobDispatch:
+        if name not in self._registry:
+            raise KeyError(f"Job '{name}' is not registered")
+        func, registered_queue = self._registry[name]
+        result = func(*args, **kwargs)
+        if inspect.isawaitable(result):
+            result = await result  # type: ignore[assignment]
+        return JobDispatch(
+            backend=self.name,
+            job_name=name,
+            queue=registered_queue or queue,
+            status="completed",
+            result=result,
+        )
+
+
+class _CeleryBackend(_BaseBackend):  # pragma: no cover - executed when celery is installed
+    name = "celery"
+
+    def __init__(self) -> None:
+        if Celery is None:  # pragma: no cover - defensive guard
+            raise RuntimeError("Celery backend requested but celery is not installed")
+        self.app = Celery(
+            "optimal_build_jobs",
+            broker=settings.CELERY_BROKER_URL,
+            backend=settings.CELERY_RESULT_BACKEND,
+        )
+        self._registry: Dict[str, Tuple[JobFunc, Optional[str]]] = {}
+
+    def register(self, func: JobFunc, name: str, queue: Optional[str]) -> JobFunc:
+        task = self.app.task(name=name, bind=False)(func)
+        self._registry[name] = (task, queue)
+        return task
+
+    async def enqueue(
+        self,
+        name: str,
+        queue: Optional[str],
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> JobDispatch:
+        if name not in self._registry:
+            raise KeyError(f"Job '{name}' is not registered")
+        _, registered_queue = self._registry[name]
+        selected_queue = queue or registered_queue
+        async_result = await asyncio.to_thread(
+            self.app.send_task,
+            name,
+            args=args,
+            kwargs=dict(kwargs),
+            queue=selected_queue,
+        )
+        return JobDispatch(
+            backend=self.name,
+            job_name=name,
+            queue=selected_queue,
+            status="queued",
+            task_id=getattr(async_result, "id", None),
+        )
+
+
+class _RQBackend(_BaseBackend):  # pragma: no cover - executed when rq/redis are installed
+    name = "rq"
+
+    def __init__(self) -> None:
+        if Queue is None or Redis is None:  # pragma: no cover - defensive guard
+            raise RuntimeError("RQ backend requested but rq/redis are not installed")
+        self.redis = Redis.from_url(settings.RQ_REDIS_URL)
+        self._queues: Dict[str, Queue] = {}
+        self._registry: Dict[str, Tuple[JobFunc, Optional[str]]] = {}
+
+    def _get_queue(self, queue_name: Optional[str]) -> Queue:
+        name = queue_name or "default"
+        if name not in self._queues:
+            self._queues[name] = Queue(name, connection=self.redis)
+        return self._queues[name]
+
+    def register(self, func: JobFunc, name: str, queue: Optional[str]) -> JobFunc:
+        self._registry[name] = (func, queue)
+        return func
+
+    async def enqueue(
+        self,
+        name: str,
+        queue: Optional[str],
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> JobDispatch:
+        if name not in self._registry:
+            raise KeyError(f"Job '{name}' is not registered")
+        func, registered_queue = self._registry[name]
+        target_queue = self._get_queue(queue or registered_queue)
+        job = await asyncio.to_thread(target_queue.enqueue, func, *args, **dict(kwargs))
+        return JobDispatch(
+            backend=self.name,
+            job_name=name,
+            queue=target_queue.name,
+            status="queued",
+            task_id=getattr(job, "id", None),
+        )
+
+
+def _select_backend() -> _BaseBackend:
+    """Choose a backend based on configuration and installed libraries."""
+
+    preferred = os.getenv("JOB_QUEUE_BACKEND", "").strip().lower()
+    if preferred == "celery" and Celery is not None:
+        return _CeleryBackend()
+    if preferred == "rq" and Queue is not None and Redis is not None:
+        return _RQBackend()
+    if Celery is not None:
+        try:
+            return _CeleryBackend()
+        except Exception:  # pragma: no cover - celery misconfiguration fallback
+            pass
+    if Queue is not None and Redis is not None:
+        try:
+            return _RQBackend()
+        except Exception:  # pragma: no cover - rq misconfiguration fallback
+            pass
+    return _InlineBackend()
+
+
+class JobQueue:
+    """Facade encapsulating dispatch to the configured backend."""
+
+    def __init__(self) -> None:
+        self._backend = _select_backend()
+        self._queues: Dict[str, Optional[str]] = {}
+
+    @property
+    def backend_name(self) -> str:
+        """Return the name of the active backend."""
+
+        return self._backend.name
+
+    def register(self, func: JobFunc, name: str, queue: Optional[str]) -> JobFunc:
+        """Register a function with the backend."""
+
+        registered = self._backend.register(func, name, queue)
+        self._queues[name] = queue
+        return registered
+
+    async def enqueue(
+        self,
+        job: str | JobFunc,
+        *args: Any,
+        queue: Optional[str] = None,
+        **kwargs: Any,
+    ) -> JobDispatch:
+        """Enqueue a job identified by name or by callable."""
+
+        if callable(job):
+            job_name = getattr(job, "job_name", None)
+            if not job_name:
+                job_name = f"{job.__module__}.{job.__qualname__}"
+        else:
+            job_name = job
+        return await self._backend.enqueue(job_name, queue or self._queues.get(job_name), args, kwargs)
+
+
+job_queue = JobQueue()
+
+
+def job(name: Optional[str] = None, *, queue: Optional[str] = None) -> Callable[[JobFunc], JobFunc]:
+    """Decorator used to register job functions with the active backend."""
+
+    def decorator(func: JobFunc) -> JobFunc:
+        task_name = name or f"{func.__module__}.{func.__qualname__}"
+        registered = job_queue.register(func, task_name, queue)
+        setattr(registered, "job_name", task_name)
+        setattr(registered, "job_queue", job_queue)
+        return registered
+
+    return decorator
+
+
+celery_app = job_queue._backend.app if isinstance(job_queue._backend, _CeleryBackend) else None
+
+
+__all__ = ["JobDispatch", "JobQueue", "job", "job_queue", "celery_app"]

--- a/backend/jobs/parse_cad.py
+++ b/backend/jobs/parse_cad.py
@@ -1,0 +1,319 @@
+"""CAD and BIM parsing jobs."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+from urllib.parse import urlparse
+
+try:  # pragma: no cover - optional dependency
+    import ezdxf  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - available in production environments
+    ezdxf = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    import ifcopenshell  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - available in production environments
+    ifcopenshell = None  # type: ignore[assignment]
+
+from app.core.database import AsyncSessionLocal
+from app.core.geometry import GeometrySerializer, GraphBuilder
+from app.core.models.geometry import GeometryGraph
+from app.models.imports import ImportRecord
+from app.services.storage import get_storage_service
+from jobs import job
+
+
+@dataclass(slots=True)
+class ParsedGeometry:
+    """Result emitted by the parsing pipeline."""
+
+    graph: GeometryGraph
+    floors: List[Dict[str, Any]]
+    units: List[str]
+    metadata: Dict[str, Any]
+
+
+def _resolve_local_path(storage_path: str) -> Path:
+    storage_service = get_storage_service()
+    parsed = urlparse(storage_path)
+    if parsed.scheme in {"", "file"}:
+        path = Path(parsed.path)
+        return path if path.is_absolute() else storage_service.local_base_path / path
+    if parsed.scheme == "s3":
+        key = parsed.path.lstrip("/")
+        return storage_service.local_base_path / key
+    # Fall back to treating the value as a relative path beneath the storage root
+    return storage_service.local_base_path / storage_path
+
+
+async def _load_payload(record: ImportRecord) -> bytes:
+    path = _resolve_local_path(record.storage_path)
+    return await asyncio.to_thread(path.read_bytes)
+
+
+def _normalise_name(value: Any, fallback: str) -> str:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return fallback
+
+
+def _ensure_unique(identifier: str, seen: Dict[str, None]) -> str:
+    base = identifier
+    counter = 1
+    while identifier in seen:
+        counter += 1
+        identifier = f"{base}-{counter}"
+    seen[identifier] = None
+    return identifier
+
+
+def _estimate_space_geometry(offset_x: float, offset_y: float, area: Optional[float]) -> List[Dict[str, float]]:
+    side = max(math.sqrt(area) if area and area > 0 else 4.0, 3.0)
+    width = side
+    height = max(area / width if area else side, 3.0)
+    return [
+        {"x": offset_x, "y": offset_y},
+        {"x": offset_x + width, "y": offset_y},
+        {"x": offset_x + width, "y": offset_y + height},
+        {"x": offset_x, "y": offset_y + height},
+    ]
+
+
+def _build_graph_from_floorplan(data: Mapping[str, Any]) -> ParsedGeometry:
+    builder = GraphBuilder.new()
+    floors_summary: List[Dict[str, Any]] = []
+    unit_ids: List[str] = []
+    seen_units: Dict[str, None] = {}
+
+    raw_layers = data.get("layers") if isinstance(data.get("layers"), Sequence) else []
+    floor_layers: List[Mapping[str, Any]] = []
+    for item in raw_layers:  # type: ignore[assignment]
+        if not isinstance(item, Mapping):
+            continue
+        layer_type = str(item.get("type", "")).lower()
+        if layer_type in {"floor", "level", "storey", "story"}:
+            floor_layers.append(item)
+
+    entries: List[Mapping[str, Any]] = list(floor_layers)
+    extra_floors = data.get("floors") if isinstance(data.get("floors"), Sequence) else []
+    for item in extra_floors:  # type: ignore[assignment]
+        if isinstance(item, Mapping):
+            entries.append(item)
+
+    offset_y = 0.0
+    for index, entry in enumerate(entries, start=1):
+        floor_name = _normalise_name(entry.get("name"), f"Floor {index}")
+        level_id = _normalise_name(entry.get("id") or floor_name, f"L{index:02d}")
+        level_payload = {
+            "id": level_id,
+            "name": floor_name,
+            "elevation": float(entry.get("metadata", {}).get("elevation", (index - 1) * 3.5)),
+            "metadata": dict(entry.get("metadata", {})),
+        }
+        builder.add_level(level_payload)
+
+        floor_units: Iterable[Any] = entry.get("units", []) if isinstance(entry.get("units"), Iterable) else []
+        floor_summary_units: List[str] = []
+        offset_x = 0.0
+        for raw_unit in floor_units:
+            if isinstance(raw_unit, Mapping):
+                unit_identifier = raw_unit.get("id") or raw_unit.get("name") or raw_unit.get("label")
+                area_value = raw_unit.get("area_m2") or raw_unit.get("area")
+            else:
+                unit_identifier = raw_unit
+                area_value = None
+            unit_id = _ensure_unique(_normalise_name(unit_identifier, f"{level_id}-unit-{len(unit_ids) + 1}"), seen_units)
+            unit_ids.append(unit_id)
+            floor_summary_units.append(unit_id)
+
+            try:
+                area_float = float(area_value) if area_value is not None else None
+            except (TypeError, ValueError):
+                area_float = None
+
+            boundary = _estimate_space_geometry(offset_x, offset_y, area_float)
+            space_payload = {
+                "id": unit_id,
+                "name": unit_id,
+                "level_id": level_id,
+                "boundary": boundary,
+                "metadata": {
+                    "source_floor": floor_name,
+                    "area_sqm": area_float,
+                },
+            }
+            builder.add_space(space_payload)
+            builder.add_relationship(
+                {
+                    "type": "contains",
+                    "source_id": level_id,
+                    "target_id": unit_id,
+                    "attributes": {"relationship": "unit"},
+                }
+            )
+            offset_x += max(boundary[1]["x"] - boundary[0]["x"], 3.0) + 1.5
+
+        floors_summary.append({"name": floor_name, "unit_ids": floor_summary_units})
+        offset_y += 6.5
+
+    builder.validate_integrity()
+    return ParsedGeometry(
+        graph=builder.graph,
+        floors=floors_summary,
+        units=unit_ids,
+        metadata={"source": "json_floorplan", "floors": len(floors_summary)},
+    )
+
+
+def _parse_json_payload(data: Mapping[str, Any]) -> ParsedGeometry:
+    if "layers" in data or "floors" in data:
+        return _build_graph_from_floorplan(data)
+    builder = GraphBuilder.new()
+    builder.build_from_payload(data)
+    builder.validate_integrity()
+    graph = builder.graph
+    return ParsedGeometry(
+        graph=graph,
+        floors=[{"name": level.name or level.id, "unit_ids": []} for level in graph.levels.values()],
+        units=list(graph.spaces.keys()),
+        metadata={"source": "json_geometry", "floors": len(graph.levels)},
+    )
+
+
+def _parse_dxf_payload(payload: bytes) -> ParsedGeometry:
+    if ezdxf is None:  # pragma: no cover - optional dependency
+        raise RuntimeError("ezdxf is required to parse DXF payloads")
+    doc = ezdxf.read(stream=payload) if hasattr(ezdxf, "read") else ezdxf.readfile(payload)  # type: ignore[arg-type]
+    modelspace = doc.modelspace()
+    builder = GraphBuilder.new()
+    builder.add_level({"id": "L1", "name": "Model Space", "elevation": 0.0})
+    unit_ids: List[str] = []
+    floors = [{"name": "Model Space", "unit_ids": unit_ids}]
+    for index, entity in enumerate(modelspace, start=1):  # pragma: no cover - depends on ezdxf
+        if entity.dxftype() != "LWPOLYLINE":
+            continue
+        points = [
+            {"x": float(point[0]), "y": float(point[1])}
+            for point in entity.get_points("xy")  # type: ignore[arg-type]
+        ]
+        space_id = f"entity-{index:03d}"
+        unit_ids.append(space_id)
+        builder.add_space({
+            "id": space_id,
+            "level_id": "L1",
+            "boundary": points,
+            "metadata": {"source_entity": entity.dxftype()},
+        })
+    builder.validate_integrity()
+    return ParsedGeometry(
+        graph=builder.graph,
+        floors=floors,
+        units=unit_ids,
+        metadata={"source": "dxf", "entities": len(unit_ids)},
+    )
+
+
+def _parse_ifc_payload(payload: bytes) -> ParsedGeometry:
+    if ifcopenshell is None:  # pragma: no cover - optional dependency
+        raise RuntimeError("ifcopenshell is required to parse IFC payloads")
+    model = ifcopenshell.file.from_string(payload.decode("utf-8"))  # type: ignore[attr-defined]
+    builder = GraphBuilder.new()
+    unit_ids: List[str] = []
+    floors_summary: List[Dict[str, Any]] = []
+    for storey in model.by_type("IfcBuildingStorey"):  # pragma: no cover - depends on ifcopenshell
+        level_id = _normalise_name(storey.GlobalId, f"Level-{storey.id()}")
+        builder.add_level(
+            {
+                "id": level_id,
+                "name": getattr(storey, "Name", level_id),
+                "elevation": float(getattr(storey, "Elevation", 0.0)),
+            }
+        )
+        floor_units: List[str] = []
+        related = getattr(storey, "ContainsElements", [])
+        for rel in related:
+            for element in getattr(rel, "RelatedElements", []):
+                if element.is_a("IfcSpace"):
+                    space_id = _normalise_name(element.GlobalId, f"Space-{element.id()}")
+                    unit_ids.append(space_id)
+                    floor_units.append(space_id)
+                    builder.add_space(
+                        {
+                            "id": space_id,
+                            "name": getattr(element, "Name", space_id),
+                            "level_id": level_id,
+                            "boundary": [],
+                            "metadata": {"ifc_type": element.is_a()},
+                        }
+                    )
+        floors_summary.append({"name": getattr(storey, "Name", level_id), "unit_ids": floor_units})
+    builder.validate_integrity()
+    return ParsedGeometry(
+        graph=builder.graph,
+        floors=floors_summary,
+        units=unit_ids,
+        metadata={"source": "ifc", "floors": len(floors_summary)},
+    )
+
+
+def _parse_payload(record: ImportRecord, payload: bytes) -> ParsedGeometry:
+    filename = (record.filename or "").lower()
+    content_type = (record.content_type or "").lower()
+    if filename.endswith(".json") or content_type == "application/json":
+        data = json.loads(payload.decode("utf-8"))
+        return _parse_json_payload(data)
+    if filename.endswith(".dxf") or "dxf" in content_type:
+        return _parse_dxf_payload(payload)
+    if filename.endswith(".ifc") or "ifc" in content_type:
+        return _parse_ifc_payload(payload)
+    raise RuntimeError(f"Unsupported import format for '{record.filename}'")
+
+
+async def _persist_result(session, record: ImportRecord, parsed: ParsedGeometry) -> Dict[str, Any]:
+    graph_payload = GeometrySerializer.to_export(parsed.graph)
+    record.parse_status = "completed"
+    record.parse_result = {
+        "floors": len(parsed.floors),
+        "units": len(parsed.units),
+        "detected_floors": parsed.floors,
+        "detected_units": parsed.units,
+        "graph": graph_payload,
+        "metadata": parsed.metadata,
+    }
+    record.parse_error = None
+    record.parse_completed_at = datetime.now(timezone.utc)
+    await session.commit()
+    await session.refresh(record)
+    return record.parse_result or {}
+
+
+@job(name="jobs.parse_cad.parse_import", queue="imports:parse")
+async def parse_import_job(import_id: str) -> Dict[str, Any]:
+    """Parse an uploaded import payload and persist the resulting geometry."""
+
+    async with AsyncSessionLocal() as session:
+        record = await session.get(ImportRecord, import_id)
+        if record is None:
+            raise RuntimeError(f"Import '{import_id}' not found")
+        record.parse_status = "running"
+        await session.commit()
+
+        try:
+            payload = await _load_payload(record)
+            parsed = await asyncio.to_thread(_parse_payload, record, payload)
+            return await _persist_result(session, record, parsed)
+        except Exception as exc:  # pragma: no cover - defensive logging surface
+            record.parse_status = "failed"
+            record.parse_error = str(exc)
+            record.parse_completed_at = datetime.now(timezone.utc)
+            await session.commit()
+            raise
+
+
+__all__ = ["parse_import_job", "ParsedGeometry"]

--- a/backend/jobs/raster_vector.py
+++ b/backend/jobs/raster_vector.py
@@ -1,0 +1,208 @@
+"""Utilities for vectorising raster or vector floorplans."""
+
+from __future__ import annotations
+
+import math
+import asyncio
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+from xml.etree import ElementTree as ET
+
+try:  # pragma: no cover - optional dependency
+    import fitz  # type: ignore  # PyMuPDF
+except ModuleNotFoundError:  # pragma: no cover - available in production environments
+    fitz = None  # type: ignore[assignment]
+
+from jobs import job
+
+
+Point = Tuple[float, float]
+
+
+@dataclass(slots=True)
+class VectorPath:
+    """A vectorised path consisting of ordered coordinates."""
+
+    points: List[Point]
+    layer: Optional[str] = None
+    stroke_width: Optional[float] = None
+
+
+@dataclass(slots=True)
+class WallCandidate:
+    """A baseline wall approximation extracted from vector data."""
+
+    start: Point
+    end: Point
+    thickness: float
+    confidence: float
+
+
+@dataclass(slots=True)
+class RasterVectorResult:
+    """Result produced by :func:`vectorize_floorplan`."""
+
+    paths: List[VectorPath]
+    walls: List[WallCandidate]
+
+
+def _parse_svg_points(raw: str) -> List[Point]:
+    points: List[Point] = []
+    tokens = [token.strip() for token in raw.replace("\n", " ").split(" ") if token.strip()]
+    for token in tokens:
+        if "," in token:
+            x_str, y_str = token.split(",", 1)
+            try:
+                points.append((float(x_str), float(y_str)))
+            except ValueError:  # pragma: no cover - defensive guard
+                continue
+    return points
+
+
+def _parse_svg_path_d(raw: str) -> List[Point]:
+    commands = raw.replace(",", " ").split()
+    points: List[Point] = []
+    iterator = iter(commands)
+    current: Optional[Point] = None
+    for token in iterator:
+        cmd = token.upper()
+        if cmd in {"M", "L"}:
+            try:
+                x = float(next(iterator))
+                y = float(next(iterator))
+            except (StopIteration, ValueError):  # pragma: no cover - defensive guard
+                break
+            current = (x, y)
+            points.append(current)
+        elif cmd == "H" and current is not None:
+            try:
+                x = float(next(iterator))
+            except (StopIteration, ValueError):
+                break
+            current = (x, current[1])
+            points.append(current)
+        elif cmd == "V" and current is not None:
+            try:
+                y = float(next(iterator))
+            except (StopIteration, ValueError):
+                break
+            current = (current[0], y)
+            points.append(current)
+        elif cmd == "Z" and points:
+            points.append(points[0])
+    return points
+
+
+def _extract_svg_paths(svg_payload: str) -> List[VectorPath]:
+    root = ET.fromstring(svg_payload)
+    paths: List[VectorPath] = []
+    for element in root.iter():
+        tag = element.tag.split("}")[-1]
+        if tag == "path" and element.attrib.get("d"):
+            points = _parse_svg_path_d(element.attrib["d"])
+            if points:
+                stroke_raw = element.attrib.get("stroke-width", "1")
+                try:
+                    stroke = float(stroke_raw)
+                except ValueError:  # pragma: no cover - defensive guard
+                    stroke = 1.0
+                paths.append(
+                    VectorPath(
+                        points=points,
+                        layer=element.attrib.get("id"),
+                        stroke_width=stroke,
+                    )
+                )
+        elif tag in {"polyline", "polygon"} and element.attrib.get("points"):
+            points = _parse_svg_points(element.attrib["points"])
+            if tag == "polygon" and points and points[0] != points[-1]:
+                points.append(points[0])
+            if points:
+                stroke_raw = element.attrib.get("stroke-width", "1")
+                try:
+                    stroke = float(stroke_raw)
+                except ValueError:  # pragma: no cover - defensive guard
+                    stroke = 1.0
+                paths.append(
+                    VectorPath(
+                        points=points,
+                        layer=element.attrib.get("id"),
+                        stroke_width=stroke,
+                    )
+                )
+    return paths
+
+
+def _extract_pdf_paths(pdf_payload: bytes) -> List[VectorPath]:
+    if fitz is None:  # pragma: no cover - optional dependency
+        raise RuntimeError("PDF vectorization requires PyMuPDF (fitz)")
+    paths: List[VectorPath] = []
+    document = fitz.open(stream=pdf_payload, filetype="pdf")  # type: ignore[arg-type]
+    for page in document:  # pragma: no cover - depends on pymupdf
+        for item in page.get_drawings():
+            points: List[Point] = []
+            for path in item["items"]:
+                if path[0] == "l":
+                    points.append((float(path[1][0]), float(path[1][1])))
+            if points:
+                paths.append(VectorPath(points=points, layer=str(page.number)))
+    return paths
+
+
+def detect_baseline_walls(paths: Sequence[VectorPath]) -> List[WallCandidate]:
+    """Detect baseline walls from vector paths."""
+
+    walls: List[WallCandidate] = []
+    for path in paths:
+        if len(path.points) < 2:
+            continue
+        for start, end in zip(path.points, path.points[1:]):
+            dx = end[0] - start[0]
+            dy = end[1] - start[1]
+            length = math.hypot(dx, dy)
+            if length < 0.5:
+                continue
+            thickness = path.stroke_width or 0.2
+            confidence = min(1.0, max(thickness / 0.5, length / 10.0))
+            walls.append(
+                WallCandidate(
+                    start=start,
+                    end=end,
+                    thickness=thickness,
+                    confidence=round(confidence, 3),
+                )
+            )
+    return walls
+
+
+def _vectorize_svg(svg_payload: bytes) -> RasterVectorResult:
+    content = svg_payload.decode("utf-8")
+    paths = _extract_svg_paths(content)
+    return RasterVectorResult(paths=paths, walls=detect_baseline_walls(paths))
+
+
+def _vectorize_pdf(pdf_payload: bytes) -> RasterVectorResult:
+    paths = _extract_pdf_paths(pdf_payload)
+    return RasterVectorResult(paths=paths, walls=detect_baseline_walls(paths))
+
+
+@job(name="jobs.raster_vector.vectorize_floorplan", queue="imports:vector")
+async def vectorize_floorplan(payload: bytes, *, content_type: str, filename: Optional[str] = None) -> RasterVectorResult:
+    """Convert a PDF/SVG payload into vector paths and baseline walls."""
+
+    content_type = content_type.lower()
+    name = (filename or "").lower()
+    if content_type == "image/svg+xml" or name.endswith(".svg"):
+        return await asyncio.get_running_loop().run_in_executor(None, _vectorize_svg, payload)
+    if content_type == "application/pdf" or name.endswith(".pdf"):
+        return await asyncio.get_running_loop().run_in_executor(None, _vectorize_pdf, payload)
+    raise RuntimeError("Unsupported floorplan media type")
+
+
+__all__ = [
+    "RasterVectorResult",
+    "VectorPath",
+    "WallCandidate",
+    "detect_baseline_walls",
+    "vectorize_floorplan",
+]

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -1,0 +1,25 @@
+"""Background worker entrypoint.
+
+The module ensures all job definitions are imported so that Celery or RQ
+workers discover them automatically. When Celery is installed the
+``celery_app`` attribute can be used as the application reference, e.g.:
+
+.. code-block:: bash
+
+    celery -A backend.worker:celery_app worker
+
+For environments that rely on the inline queue the module still exposes the
+``job_queue`` allowing management commands or tests to introspect the active
+backend.
+"""
+
+from __future__ import annotations
+
+from jobs import celery_app, job_queue  # noqa: F401  (re-exported for workers)
+
+# Import job modules to register tasks with the configured backend.
+from jobs import overlay_run as _overlay_run  # noqa: F401
+from jobs import parse_cad as _parse_cad  # noqa: F401
+from jobs import raster_vector as _raster_vector  # noqa: F401
+
+__all__ = ["celery_app", "job_queue"]


### PR DESCRIPTION
## Summary
- add a queue-aware jobs package with Celery/RQ/inline adapters and worker entrypoint
- implement CAD parsing and raster/vector conversion jobs that emit normalized geometry graphs
- wire overlay and import APIs through the job dispatcher and extend API tests to assert scheduling hooks

## Testing
- pytest backend/tests/test_api/test_imports.py backend/tests/test_api/test_overlay.py

------
https://chatgpt.com/codex/tasks/task_e_68d073bdd3ac8320a00376fe03e0cbf7