### PR TITLE
Add AEC workflow tests and CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,36 @@ jobs:
 
       - name: Run Playwright tests
         run: npm run test:e2e
+
+  aec-tests:
+    name: AEC Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: backend/requirements-dev.txt
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements-dev.txt
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Run AEC test suite
+        run: make test-aec

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,12 @@ lint: ## Run linting
 	cd frontend && npm run lint
 
 test: ## Run tests
-	cd backend && pytest
-	cd frontend && npm test
+        cd backend && pytest
+        cd frontend && npm test
+
+test-aec: ## Run AEC backend and frontend test suites
+        cd backend && pytest tests/test_workflows/test_aec_pipeline.py
+        cd frontend && npm test
 
 test-cov: ## Run tests with coverage
 	cd backend && pytest --cov=app --cov-report=html

--- a/backend/app/core/models/__init__.py
+++ b/backend/app/core/models/__init__.py
@@ -1,10 +1,12 @@
 """Core models used by geometry helpers."""
 
 from .geometry import (
+    CanonicalGeometry,
     Door,
     Fixture,
     GeometryEntity,
     GeometryGraph,
+    GeometryNode,
     Level,
     Relationship,
     SourceReference,
@@ -13,10 +15,12 @@ from .geometry import (
 )
 
 __all__ = [
+    "CanonicalGeometry",
     "Door",
     "Fixture",
     "GeometryEntity",
     "GeometryGraph",
+    "GeometryNode",
     "Level",
     "Relationship",
     "SourceReference",

--- a/backend/tests/samples/golden_export_manifest.json
+++ b/backend/tests/samples/golden_export_manifest.json
@@ -1,0 +1,140 @@
+{
+  "format": "dwg",
+  "renderer": "fallback",
+  "options": {
+    "include_source": true,
+    "include_approved_overlays": true,
+    "include_pending_overlays": true,
+    "include_rejected_overlays": false
+  },
+  "layers": {
+    "SITE": [
+      {
+        "layer": "SITE",
+        "id": "site-root",
+        "kind": "site",
+        "properties": {
+          "project": "Mock Tower",
+          "elements": 5,
+          "heritage_zone": true,
+          "flood_zone": "coastal",
+          "site_area_sqm": 12500,
+          "advisory_hints": [
+            "Submit heritage impact assessment"
+          ],
+          "overlays": [
+            "heritage_conservation",
+            "coastal_protection"
+          ]
+        }
+      }
+    ],
+    "A-FLOOR": [
+      {
+        "layer": "A-FLOOR",
+        "id": "L01",
+        "kind": "floor",
+        "properties": {
+          "name": "Level 01 - Floor Plan",
+          "unit_count": 2,
+          "elevation": 0.0
+        }
+      },
+      {
+        "layer": "A-FLOOR",
+        "id": "L02",
+        "kind": "floor",
+        "properties": {
+          "name": "Level 02 - Floor Plan",
+          "unit_count": 1,
+          "elevation": 3.2
+        }
+      }
+    ],
+    "UNIT": [
+      {
+        "layer": "UNIT",
+        "id": "L01-U01",
+        "kind": "unit",
+        "properties": {
+          "label": "01-01",
+          "area_m2": 45.0,
+          "status": "pending",
+          "height_m": 52.5
+        }
+      },
+      {
+        "layer": "UNIT",
+        "id": "L01-U02",
+        "kind": "unit",
+        "properties": {
+          "label": "01-02",
+          "area_m2": 42.5,
+          "status": "approved"
+        }
+      },
+      {
+        "layer": "UNIT",
+        "id": "L02-U01",
+        "kind": "unit",
+        "properties": {
+          "label": "02-01",
+          "area_m2": 47.3,
+          "status": "pending"
+        }
+      }
+    ]
+  },
+  "overlays": {
+    "A-OVER-HERITAGE": [
+      {
+        "layer": "A-OVER-HERITAGE",
+        "code": "heritage_conservation",
+        "title": "Heritage conservation review",
+        "status": "pending",
+        "severity": "high",
+        "style": {},
+        "nodes": [
+          "L01"
+        ]
+      }
+    ],
+    "A-OVER-PENDING": [
+      {
+        "layer": "A-OVER-PENDING",
+        "code": "flood_mitigation",
+        "title": "Flood mitigation measures",
+        "status": "pending",
+        "severity": "medium",
+        "style": {},
+        "nodes": [
+          "L01"
+        ]
+      },
+      {
+        "layer": "A-OVER-PENDING",
+        "code": "large_site_review",
+        "title": "Large site planning review",
+        "status": "pending",
+        "severity": "medium",
+        "style": {},
+        "nodes": [
+          "L01"
+        ]
+      },
+      {
+        "layer": "A-OVER-PENDING",
+        "code": "tall_building_review",
+        "title": "Tall building impact assessment",
+        "status": "pending",
+        "severity": "medium",
+        "style": {},
+        "nodes": [
+          "L01-U01"
+        ]
+      }
+    ]
+  },
+  "watermark": "PRELIMINARY – Pending overlay approvals",
+  "project_id": 401
+}

--- a/backend/tests/samples/sample_floorplan.json
+++ b/backend/tests/samples/sample_floorplan.json
@@ -5,8 +5,8 @@
       "name": "Level 01 - Floor Plan",
       "type": "floor",
       "units": [
-        {"id": "01-01", "area_m2": 45.0},
-        {"id": "01-02", "area_m2": 42.5}
+        {"id": "01-01", "area_m2": 45.0, "height_m": 52.5, "status": "pending"},
+        {"id": "01-02", "area_m2": 42.5, "status": "approved"}
       ],
       "metadata": {"elevation": 0.0, "discipline": "architecture"}
     },
@@ -14,14 +14,21 @@
       "name": "Level 02 - Floor Plan",
       "type": "floor",
       "units": [
-        {"id": "02-01", "area_m2": 47.3}
+        {"id": "02-01", "area_m2": 47.3, "status": "pending"}
       ],
       "metadata": {"elevation": 3.2, "discipline": "architecture"}
     },
     {
       "name": "Site Context",
       "type": "reference",
-      "metadata": {"elements": 5}
+      "metadata": {
+        "elements": 5,
+        "heritage_zone": true,
+        "flood_zone": "coastal",
+        "site_area_sqm": 12500,
+        "advisory_hints": ["Submit heritage impact assessment"],
+        "overlays": ["heritage_conservation", "coastal_protection"]
+      }
     }
   ],
   "floors": [

--- a/backend/tests/test_workflows/test_aec_pipeline.py
+++ b/backend/tests/test_workflows/test_aec_pipeline.py
@@ -1,0 +1,377 @@
+"""Comprehensive backend tests covering the AEC overlay workflow."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+import pytest
+
+pytest.importorskip('fastapi')
+pytest.importorskip('pydantic')
+pytest.importorskip('sqlalchemy')
+
+from sqlalchemy import select
+
+from app.api.v1.imports import _build_parse_summary
+from app.core.geometry.builder import GraphBuilder
+from app.core.metrics.roi import compute_project_roi
+from app.core.models.geometry import CanonicalGeometry, GeometryNode
+from app.core.export import (
+    ExportFormat,
+    ExportOptions,
+    LayerMapping,
+    LocalExportStorage,
+    generate_project_export,
+)
+from app.models.audit import AuditLog
+from app.models.imports import ImportRecord
+from app.models.overlay import OverlaySourceGeometry, OverlaySuggestion
+from app.models.rkp import RefRule, RefZoningLayer
+from jobs.overlay_run import run_overlay_for_project
+
+SAMPLE_PATH = Path(__file__).resolve().parents[1] / "samples" / "sample_floorplan.json"
+GOLDEN_MANIFEST_PATH = Path(__file__).resolve().parents[1] / "samples" / "golden_export_manifest.json"
+
+
+def _load_sample_payload() -> Dict[str, object]:
+    return json.loads(SAMPLE_PATH.read_text("utf-8"))
+
+
+def _build_geometry_from_sample(
+    sample: Dict[str, object],
+) -> Tuple[CanonicalGeometry, Dict[str, Dict[str, object]]]:
+    builder = GraphBuilder.new()
+    level_lookup: Dict[str, Dict[str, object]] = {}
+
+    for index, layer in enumerate(sample.get("layers", []), start=1):
+        if not isinstance(layer, dict):
+            continue
+        level_id = f"L{index:02d}"
+        metadata = dict(layer.get("metadata") or {})
+        metadata.setdefault("layer_type", layer.get("type"))
+        builder.add_level(
+            {
+                "id": level_id,
+                "name": layer.get("name"),
+                "elevation": metadata.get("elevation", 0.0),
+                "metadata": metadata,
+            }
+        )
+        level_lookup[level_id] = layer
+        units: Iterable[dict] = layer.get("units", [])  # type: ignore[assignment]
+        for unit_index, unit in enumerate(units, start=1):
+            if not isinstance(unit, dict):
+                continue
+            space_id = f"{level_id}-U{unit_index:02d}"
+            area = float(unit.get("area_m2", 1.0))
+            side = max(area ** 0.5, 1.0)
+            boundary = [
+                {"x": 0.0, "y": 0.0},
+                {"x": side, "y": 0.0},
+                {"x": side, "y": side},
+                {"x": 0.0, "y": side},
+            ]
+            space_metadata = {key: value for key, value in unit.items() if key != "id"}
+            space_metadata.setdefault("status", unit.get("status", "pending"))
+            builder.add_space(
+                {
+                    "id": space_id,
+                    "name": unit.get("id"),
+                    "level_id": level_id,
+                    "boundary": boundary,
+                    "metadata": space_metadata,
+                }
+            )
+            builder.add_relationship(
+                {"type": "contains", "source_id": level_id, "target_id": space_id}
+            )
+
+    graph = builder.graph
+    builder.validate_integrity()
+
+    site_layer = next(
+        (
+            layer
+            for layer in sample.get("layers", [])
+            if isinstance(layer, dict) and layer.get("type") in {"site", "reference"}
+        ),
+        None,
+    )
+    root_properties: Dict[str, object] = {"project": sample.get("project")}
+    if isinstance(site_layer, dict):
+        root_properties.update(site_layer.get("metadata", {}))
+
+    root = GeometryNode(node_id="site-root", kind="site", properties=root_properties)
+
+    for level_id, layer in level_lookup.items():
+        if not isinstance(layer, dict) or layer.get("type") != "floor":
+            continue
+        units = list(layer.get("units", []))
+        floor_metadata = {
+            "name": layer.get("name"),
+            "unit_count": len(units),
+        }
+        layer_meta = layer.get("metadata")
+        if isinstance(layer_meta, dict) and "elevation" in layer_meta:
+            floor_metadata["elevation"] = layer_meta["elevation"]
+        floor_node = root.add_child(
+            GeometryNode(node_id=level_id, kind="floor", properties=floor_metadata)
+        )
+        for unit_index, unit in enumerate(units, start=1):
+            if not isinstance(unit, dict):
+                continue
+            space_id = f"{level_id}-U{unit_index:02d}"
+            unit_properties = {
+                "label": unit.get("id"),
+                "area_m2": unit.get("area_m2"),
+                "status": unit.get("status", "pending"),
+            }
+            if "height_m" in unit:
+                unit_properties["height_m"] = unit["height_m"]
+            floor_node.add_child(
+                GeometryNode(node_id=space_id, kind="unit", properties=unit_properties)
+            )
+
+    canonical = CanonicalGeometry(
+        root=root,
+        metadata={"project": sample.get("project")},
+        graph=graph.to_dict(),
+    )
+    return canonical, level_lookup
+
+
+async def _seed_overlay_project(async_session_factory, canonical: CanonicalGeometry, *, project_id: int = 101) -> int:
+    async with async_session_factory() as session:
+        source = OverlaySourceGeometry(
+            project_id=project_id,
+            source_geometry_key="primary",
+            graph=canonical.to_dict(),
+            metadata={"source": "test-suite"},
+            checksum=canonical.fingerprint(),
+        )
+        session.add(source)
+        await session.commit()
+
+    async with async_session_factory() as session:
+        await run_overlay_for_project(session, project_id=project_id)
+        suggestions = (
+            await session.execute(
+                select(OverlaySuggestion).where(OverlaySuggestion.project_id == project_id)
+            )
+        ).scalars().all()
+        ten_minutes_ago = datetime.now(timezone.utc) - timedelta(minutes=10)
+        for suggestion in suggestions:
+            suggestion.created_at = ten_minutes_ago
+        await session.commit()
+    return project_id
+
+
+@pytest.mark.asyncio
+async def test_import_parse_summary_uses_sample_fixture(session):
+    sample = _load_sample_payload()
+    floors = [
+        {"name": layer.get("name"), "units": [unit.get("id") for unit in layer.get("units", [])]}
+        for layer in sample.get("layers", [])
+        if isinstance(layer, dict) and layer.get("type") == "floor"
+    ]
+    units = [
+        {
+            "id": unit.get("id"),
+            "floor": layer.get("name"),
+            "area_m2": unit.get("area_m2"),
+        }
+        for layer in sample.get("layers", [])
+        if isinstance(layer, dict) and layer.get("type") == "floor"
+        for unit in layer.get("units", [])
+        if isinstance(unit, dict)
+    ]
+
+    record = ImportRecord(
+        filename="mock-floorplan.dwg",
+        content_type="application/json",
+        size_bytes=4096,
+        storage_path="local://imports/mock-floorplan.dwg",
+        layer_metadata=sample.get("layers", []),
+        detected_floors=floors,
+        detected_units=units,
+    )
+    session.add(record)
+    await session.commit()
+    await session.refresh(record)
+
+    summary = _build_parse_summary(record)
+    assert summary["floors"] == len(floors)
+    assert summary["units"] == len(units)
+    assert summary["floor_breakdown"][0]["name"] == floors[0]["name"]
+
+
+@pytest.mark.asyncio
+async def test_overlay_generation_from_sample(async_session_factory):
+    sample = _load_sample_payload()
+    canonical, _ = _build_geometry_from_sample(sample)
+    project_id = await _seed_overlay_project(async_session_factory, canonical, project_id=201)
+
+    async with async_session_factory() as session:
+        suggestions = (
+            await session.execute(
+                select(OverlaySuggestion).where(OverlaySuggestion.project_id == project_id)
+            )
+        ).scalars().all()
+    codes = {suggestion.code for suggestion in suggestions}
+    assert {"heritage_conservation", "flood_mitigation", "large_site_review", "tall_building_review"}.issubset(
+        codes
+    )
+
+
+@pytest.mark.asyncio
+async def test_decision_handling_records_audit(async_session_factory, client):
+    sample = _load_sample_payload()
+    canonical, _ = _build_geometry_from_sample(sample)
+    project_id = await _seed_overlay_project(async_session_factory, canonical, project_id=301)
+
+    async with async_session_factory() as session:
+        first_suggestion = (
+            await session.execute(
+                select(OverlaySuggestion)
+                .where(OverlaySuggestion.project_id == project_id)
+                .order_by(OverlaySuggestion.id)
+            )
+        ).scalars().first()
+        assert first_suggestion is not None
+
+    payload = {
+        "suggestion_id": first_suggestion.id,
+        "decision": "approve",
+        "decided_by": "pytest",
+        "notes": "Automated approval",
+    }
+    response = await client.post(f"/api/v1/overlay/{project_id}/decision", json=payload)
+    assert response.status_code == 200
+
+    async with async_session_factory() as session:
+        refreshed = await session.get(OverlaySuggestion, first_suggestion.id)
+        assert refreshed is not None
+        assert refreshed.status == "approved"
+        logs = (
+            await session.execute(
+                select(AuditLog).where(AuditLog.project_id == project_id).order_by(AuditLog.id)
+            )
+        ).scalars().all()
+    events = {log.event_type for log in logs}
+    assert "overlay_run" in events
+    assert "overlay_decision" in events
+
+
+@pytest.mark.asyncio
+async def test_export_roundtrip_matches_golden_manifest(async_session_factory, tmp_path):
+    sample = _load_sample_payload()
+    canonical, _ = _build_geometry_from_sample(sample)
+    project_id = await _seed_overlay_project(async_session_factory, canonical, project_id=401)
+
+    async with async_session_factory() as session:
+        options = ExportOptions(
+            format=ExportFormat.DWG,
+            include_pending_overlays=True,
+            layer_mapping=LayerMapping(
+                source={"floor": "A-FLOOR"},
+                overlays={"heritage_conservation": "A-OVER-HERITAGE", "pending": "A-OVER-PENDING"},
+            ),
+        )
+        storage = LocalExportStorage(base_dir=tmp_path)
+        artifact = await generate_project_export(
+            session,
+            project_id=project_id,
+            options=options,
+            storage=storage,
+        )
+
+    manifest = dict(artifact.manifest)
+    generated_at = manifest.pop("generated_at", None)
+    assert generated_at is not None
+
+    expected_manifest = json.loads(GOLDEN_MANIFEST_PATH.read_text("utf-8"))
+    assert manifest == expected_manifest
+
+    payload_bytes = artifact.open().read()
+    payload = json.loads(payload_bytes.decode("utf-8"))
+    payload.pop("generated_at", None)
+    assert payload == expected_manifest
+
+    async with async_session_factory() as session:
+        audit_events = (
+            await session.execute(
+                select(AuditLog).where(AuditLog.project_id == project_id).order_by(AuditLog.id)
+            )
+        ).scalars().all()
+    assert any(log.event_type == "export_generated" for log in audit_events)
+
+
+@pytest.mark.asyncio
+async def test_roi_snapshot_reports_saved_hours(async_session_factory):
+    sample = _load_sample_payload()
+    canonical, _ = _build_geometry_from_sample(sample)
+    project_id = await _seed_overlay_project(async_session_factory, canonical, project_id=501)
+
+    async with async_session_factory() as session:
+        first = (
+            await session.execute(
+                select(OverlaySuggestion)
+                .where(OverlaySuggestion.project_id == project_id)
+                .order_by(OverlaySuggestion.id)
+            )
+        ).scalars().first()
+        assert first is not None
+        first.status = "approved"
+        first.decided_by = "pytest"
+        first.decided_at = datetime.now(timezone.utc)
+        await session.commit()
+
+    async with async_session_factory() as session:
+        snapshot = await compute_project_roi(session, project_id=project_id)
+    assert snapshot.total_suggestions >= 4
+    assert snapshot.decided_suggestions == 1
+    assert snapshot.acceptance_rate == 1.0
+    assert snapshot.review_hours_saved >= 0.0
+    assert snapshot.savings_percent >= 0
+
+
+@pytest.mark.asyncio
+async def test_ruleset_serialisation_includes_overlays(async_session_factory, client):
+    layer = RefZoningLayer(
+        jurisdiction="SG",
+        layer_name="MasterPlan",
+        zone_code="RA",
+        attributes={
+            "overlays": ["heritage_conservation"],
+            "advisory_hints": ["Submit heritage impact assessment"],
+        },
+    )
+    rule = RefRule(
+        jurisdiction="SG",
+        authority="URA",
+        topic="Zoning",
+        parameter_key="parking.min_car_spaces_per_unit",
+        operator=">=",
+        value="1.5",
+        unit="spaces",
+        applicability={"zone_code": "RA"},
+        notes="Provide 1.5 car spaces per dwelling unit to comply with parking minimums.",
+        review_status="needs_review",
+    )
+
+    async with async_session_factory() as session:
+        session.add_all([layer, rule])
+        await session.commit()
+
+    response = await client.get("/api/v1/rules")
+    assert response.status_code == 200
+    payload = response.json()
+    items = payload.get("items", [])
+    assert items, "Expected at least one rule to be returned"
+    overlays = items[0].get("overlays")
+    hints = items[0].get("advisory_hints")
+    assert "heritage_conservation" in overlays
+    assert any("parking spaces" in hint for hint in hints)

--- a/frontend/src/modules/cad/ExportDialog.tsx
+++ b/frontend/src/modules/cad/ExportDialog.tsx
@@ -6,13 +6,19 @@ interface ExportDialogProps {
   formats?: string[]
   onExport?: (format: string) => void
   disabled?: boolean
+  defaultOpen?: boolean
 }
 
 const DEFAULT_FORMATS = ['DXF', 'GeoJSON', 'CSV']
 
-export function ExportDialog({ formats = DEFAULT_FORMATS, onExport, disabled = false }: ExportDialogProps) {
+export function ExportDialog({
+  formats = DEFAULT_FORMATS,
+  onExport,
+  disabled = false,
+  defaultOpen = false,
+}: ExportDialogProps) {
   const { t } = useTranslation()
-  const [open, setOpen] = useState(false)
+  const [open, setOpen] = useState(defaultOpen)
 
   const handleExport = (format: string) => {
     onExport?.(format)

--- a/frontend/tests/cad-modules.test.cjs
+++ b/frontend/tests/cad-modules.test.cjs
@@ -1,0 +1,121 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('path')
+
+const React = require('react')
+const { renderToStaticMarkup } = require('react-dom/server')
+
+const { loadModule } = require('./helpers/loadModule.cjs')
+
+const { TranslationProvider } = loadModule(path.resolve(__dirname, '../src/i18n/index.tsx'))
+const { CadUploader } = loadModule(path.resolve(__dirname, '../src/modules/cad/CadUploader.tsx'))
+const { LayerTogglePanel } = loadModule(path.resolve(__dirname, '../src/modules/cad/LayerTogglePanel.tsx'))
+const { BulkReviewControls } = loadModule(path.resolve(__dirname, '../src/modules/cad/BulkReviewControls.tsx'))
+const { AuditTimelinePanel } = loadModule(path.resolve(__dirname, '../src/modules/cad/AuditTimelinePanel.tsx'))
+const { ExportDialog } = loadModule(path.resolve(__dirname, '../src/modules/cad/ExportDialog.tsx'))
+const { RoiSummary } = loadModule(path.resolve(__dirname, '../src/modules/cad/RoiSummary.tsx'))
+
+function renderWithProvider(element) {
+  return renderToStaticMarkup(React.createElement(TranslationProvider, null, element))
+}
+
+test('CadUploader renders parse status and overlay metadata', () => {
+  const status = {
+    status: 'ready',
+    overlays: ['heritage_conservation', 'coastal_protection'],
+    hints: ['Submit heritage impact assessment'],
+    zoneCode: 'RA',
+    message: 'Parse completed',
+  }
+  const html = renderWithProvider(React.createElement(CadUploader, {
+    onUpload: () => {},
+    status,
+    zoneCode: 'RA',
+  }))
+  assert.match(html, /Parse completed/)
+  assert.match(html, /heritage_conservation/)
+  assert.match(html, /Submit heritage impact assessment/)
+  assert.match(html, /<dd>RA<\/dd>/)
+})
+
+test('CadUploader falls back to dash when zone metadata missing', () => {
+  const html = renderWithProvider(React.createElement(CadUploader, {
+    onUpload: () => {},
+    status: {
+      status: 'processing',
+      overlays: [],
+      hints: [],
+      zoneCode: null,
+      message: null,
+    },
+  }))
+  assert.match(html, /—/)
+})
+
+test('LayerTogglePanel highlights active layers and respects disabled state', () => {
+  const html = renderWithProvider(React.createElement(LayerTogglePanel, {
+    activeLayers: ['source', 'approved'],
+    onToggle: () => {},
+    disabled: true,
+  }))
+  assert.match(html, /cad-layer-toggle__button--active/)
+  const disabledCount = (html.match(/disabled=""/g) || []).length
+  assert.strictEqual(disabledCount >= 4, true)
+})
+
+test('BulkReviewControls disables actions when pending count is zero or locked', () => {
+  const html = renderWithProvider(React.createElement(BulkReviewControls, {
+    pendingCount: 0,
+    onApproveAll: () => {},
+    onRejectAll: () => {},
+    disabled: true,
+  }))
+  assert.match(html, /0 Pending/)
+  const disabledMatches = html.match(/disabled=""/g) || []
+  assert.strictEqual(disabledMatches.length >= 2, true)
+})
+
+test('AuditTimelinePanel renders entries and fallback', () => {
+  const eventsHtml = renderWithProvider(React.createElement(AuditTimelinePanel, {
+    events: [
+      { ruleId: 12, baseline: 'Baseline saved', updated: '2024-01-01' },
+      { ruleId: 13, baseline: 'Decision approved', updated: '2024-02-10' },
+    ],
+  }))
+  assert.match(eventsHtml, /#12/)
+  assert.match(eventsHtml, /Decision approved/)
+
+  const emptyHtml = renderWithProvider(React.createElement(AuditTimelinePanel, {
+    events: [],
+    loading: false,
+  }))
+  assert.match(emptyHtml, /—/)
+})
+
+test('ExportDialog lists formats when opened and marks controls disabled', () => {
+  const html = renderWithProvider(React.createElement(ExportDialog, {
+    formats: ['DXF', 'PDF'],
+    defaultOpen: true,
+    disabled: true,
+  }))
+  assert.match(html, /Export options/)
+  assert.match(html, /DXF/)
+  assert.match(html, /PDF/)
+  const disabledMatches = html.match(/disabled=""/g) || []
+  assert.ok(disabledMatches.length >= 3)
+})
+
+test('RoiSummary formats percentages and durations', () => {
+  const html = renderWithProvider(React.createElement(RoiSummary, {
+    metrics: {
+      automationScore: 0.62,
+      savingsPercent: 48,
+      reviewHoursSaved: 14.5,
+      paybackWeeks: 6,
+    },
+  }))
+  assert.match(html, /62%/)
+  assert.match(html, /48%/)
+  assert.match(html, /14.5h/)
+  assert.match(html, /6 weeks/)
+})

--- a/frontend/tests/helpers/loadModule.cjs
+++ b/frontend/tests/helpers/loadModule.cjs
@@ -15,6 +15,7 @@ function loadModule(modulePath) {
     define: {
       'import.meta.env.VITE_API_BASE_URL': '""',
     },
+    external: ['react', 'react-dom', 'react/jsx-runtime'],
     loader: {
       '.ts': 'ts',
       '.tsx': 'tsx',


### PR DESCRIPTION
## Summary
- add backend workflow tests covering import parsing, overlays, decisions, exports, ROI, and rules
- add frontend unit coverage for CAD modules using the translation provider
- store a golden export manifest, expose defaultOpen on ExportDialog, and wire test-aec through CI

## Testing
- pytest tests/test_workflows/test_aec_pipeline.py  # skipped when optional dependencies unavailable
- npm test -- tests/cad-modules.test.cjs


------
https://chatgpt.com/codex/tasks/task_e_68d0718196208320a14d8b2d2fa00922