### PR TITLE
Fix tabs in test make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,12 @@ lint: ## Run linting
 	cd frontend && npm run lint
 
 test: ## Run tests
-        cd backend && pytest
-        cd frontend && npm test
+	cd backend && pytest
+	cd frontend && npm test
 
 test-aec: ## Run AEC backend and frontend test suites
-        cd backend && pytest tests/test_workflows/test_aec_pipeline.py
-        cd frontend && npm test
+	cd backend && pytest tests/test_workflows/test_aec_pipeline.py
+	cd frontend && npm test
 
 test-cov: ## Run tests with coverage
 	cd backend && pytest --cov=app --cov-report=html


### PR DESCRIPTION
## Summary
- replace the space-indented recipes for the `test` and `test-aec` targets with tabs so GNU Make accepts them

## Testing
- make -n test-aec

------
https://chatgpt.com/codex/tasks/task_e_68d07d6c366c8320acb8d27acff1701e