### PR TITLE
Enable floorplan raster vectorization during imports

### DIFF
--- a/backend/app/models/imports.py
+++ b/backend/app/models/imports.py
@@ -26,6 +26,8 @@ class ImportRecord(BaseModel):
     layer_metadata = Column(FlexibleJSONB, default=list)
     detected_floors = Column(FlexibleJSONB, default=list)
     detected_units = Column(FlexibleJSONB, default=list)
+    vector_storage_path = Column(Text)
+    vector_summary = Column(FlexibleJSONB)
 
     parse_status = Column(String(32), nullable=False, default="pending")
     parse_requested_at = Column(DateTime(timezone=True))

--- a/backend/app/schemas/imports.py
+++ b/backend/app/schemas/imports.py
@@ -23,10 +23,16 @@ class ImportResult(BaseModel):
     content_type: Optional[str]
     size_bytes: int
     storage_path: str
+    vector_storage_path: Optional[str] = Field(
+        default=None, description="URI of stored vectorised geometry derived from the upload"
+    )
     uploaded_at: datetime
     layer_metadata: List[Dict[str, Any]]
     detected_floors: List[DetectedFloor]
     detected_units: List[str]
+    vector_summary: Optional[Dict[str, Any]] = Field(
+        default=None, description="Summary of extracted vector paths and inferred walls"
+    )
     parse_status: str
 
     class Config:

--- a/backend/jobs/raster_vector.py
+++ b/backend/jobs/raster_vector.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-import math
 import asyncio
-from dataclasses import dataclass
-from typing import List, Optional, Sequence, Tuple
+import math
+import re
+from dataclasses import dataclass, field
+from itertools import chain
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 from xml.etree import ElementTree as ET
 
 try:  # pragma: no cover - optional dependency
@@ -27,15 +29,41 @@ class VectorPath:
     layer: Optional[str] = None
     stroke_width: Optional[float] = None
 
+    def to_payload(self) -> Dict[str, Any]:
+        return {
+            "points": [[float(x), float(y)] for x, y in self.points],
+            "layer": self.layer,
+            "stroke_width": self.stroke_width,
+        }
+
 
 @dataclass(slots=True)
 class WallCandidate:
-    """A baseline wall approximation extracted from vector data."""
+    """A baseline wall approximation extracted from vector or bitmap data."""
 
     start: Point
     end: Point
     thickness: float
     confidence: float
+    source: str = "vector"
+
+    def to_payload(self) -> Dict[str, Any]:
+        return {
+            "start": [float(self.start[0]), float(self.start[1])],
+            "end": [float(self.end[0]), float(self.end[1])],
+            "thickness": float(self.thickness),
+            "confidence": float(self.confidence),
+            "source": self.source,
+        }
+
+
+@dataclass(slots=True)
+class RasterVectorOptions:
+    """Configuration toggles for raster to vector processing."""
+
+    infer_walls: bool = False
+    minimum_wall_length: float = 1.0
+    bitmap_threshold: float = 0.65
 
 
 @dataclass(slots=True)
@@ -44,6 +72,41 @@ class RasterVectorResult:
 
     paths: List[VectorPath]
     walls: List[WallCandidate]
+    bounds: Optional[Tuple[float, float]]
+    source: str
+    options: RasterVectorOptions = field(default_factory=RasterVectorOptions)
+
+    def to_payload(self) -> Dict[str, Any]:
+        bounds_payload: Optional[Dict[str, float]] = None
+        if self.bounds is not None:
+            bounds_payload = {"width": float(self.bounds[0]), "height": float(self.bounds[1])}
+        return {
+            "source": self.source,
+            "paths": [path.to_payload() for path in self.paths],
+            "walls": [wall.to_payload() for wall in self.walls],
+            "bounds": bounds_payload,
+            "options": {
+                "infer_walls": self.options.infer_walls,
+                "minimum_wall_length": self.options.minimum_wall_length,
+                "bitmap_threshold": self.options.bitmap_threshold,
+                "bitmap_walls": any(wall.source == "bitmap" for wall in self.walls),
+            },
+        }
+
+
+def _parse_svg_length(raw: Optional[str]) -> Optional[float]:
+    if raw is None:
+        return None
+    token = raw.strip()
+    if not token:
+        return None
+    match = re.match(r"[-+]?[0-9]*\.?[0-9]+", token)
+    if match is None:
+        return None
+    try:
+        return float(match.group(0))
+    except ValueError:  # pragma: no cover - defensive guard
+        return None
 
 
 def _parse_svg_points(raw: str) -> List[Point]:
@@ -88,13 +151,22 @@ def _parse_svg_path_d(raw: str) -> List[Point]:
                 break
             current = (current[0], y)
             points.append(current)
+        elif cmd == "C":
+            try:
+                next(iterator)
+                next(iterator)
+                x = float(next(iterator))
+                y = float(next(iterator))
+            except (StopIteration, ValueError):  # pragma: no cover - defensive guard
+                break
+            current = (x, y)
+            points.append(current)
         elif cmd == "Z" and points:
             points.append(points[0])
     return points
 
 
-def _extract_svg_paths(svg_payload: str) -> List[VectorPath]:
-    root = ET.fromstring(svg_payload)
+def _extract_svg_paths(root: ET.Element) -> List[VectorPath]:
     paths: List[VectorPath] = []
     for element in root.iter():
         tag = element.tag.split("}")[-1]
@@ -133,23 +205,28 @@ def _extract_svg_paths(svg_payload: str) -> List[VectorPath]:
     return paths
 
 
-def _extract_pdf_paths(pdf_payload: bytes) -> List[VectorPath]:
-    if fitz is None:  # pragma: no cover - optional dependency
-        raise RuntimeError("PDF vectorization requires PyMuPDF (fitz)")
-    paths: List[VectorPath] = []
-    document = fitz.open(stream=pdf_payload, filetype="pdf")  # type: ignore[arg-type]
-    for page in document:  # pragma: no cover - depends on pymupdf
-        for item in page.get_drawings():
-            points: List[Point] = []
-            for path in item["items"]:
-                if path[0] == "l":
-                    points.append((float(path[1][0]), float(path[1][1])))
-            if points:
-                paths.append(VectorPath(points=points, layer=str(page.number)))
-    return paths
+def _parse_svg_bounds(root: ET.Element) -> Optional[Tuple[float, float]]:
+    width = _parse_svg_length(root.attrib.get("width"))
+    height = _parse_svg_length(root.attrib.get("height"))
+    if width is not None and height is not None:
+        return float(width), float(height)
+    view_box = root.attrib.get("viewBox")
+    if view_box:
+        parts = [part for part in view_box.replace(",", " ").split(" ") if part]
+        if len(parts) >= 4:
+            try:
+                return float(parts[2]), float(parts[3])
+            except ValueError:  # pragma: no cover - defensive guard
+                return None
+    return None
 
 
-def detect_baseline_walls(paths: Sequence[VectorPath]) -> List[WallCandidate]:
+def detect_baseline_walls(
+    paths: Sequence[VectorPath],
+    *,
+    minimum_length: float = 0.5,
+    source: str = "vector",
+) -> List[WallCandidate]:
     """Detect baseline walls from vector paths."""
 
     walls: List[WallCandidate] = []
@@ -160,46 +237,281 @@ def detect_baseline_walls(paths: Sequence[VectorPath]) -> List[WallCandidate]:
             dx = end[0] - start[0]
             dy = end[1] - start[1]
             length = math.hypot(dx, dy)
-            if length < 0.5:
+            if length < minimum_length:
                 continue
             thickness = path.stroke_width or 0.2
-            confidence = min(1.0, max(thickness / 0.5, length / 10.0))
+            confidence = min(1.0, max(thickness / max(minimum_length, 0.1), length / max(minimum_length * 3.0, 1.0)))
             walls.append(
                 WallCandidate(
                     start=start,
                     end=end,
-                    thickness=thickness,
+                    thickness=float(thickness),
                     confidence=round(confidence, 3),
+                    source=source,
                 )
             )
     return walls
 
 
-def _vectorize_svg(svg_payload: bytes) -> RasterVectorResult:
+def _normalise_segment(start: Point, end: Point) -> Tuple[Point, Point]:
+    if (start[0], start[1]) <= (end[0], end[1]):
+        return start, end
+    return end, start
+
+
+def _merge_walls(*collections: Iterable[WallCandidate]) -> List[WallCandidate]:
+    dedup: Dict[Tuple[float, float, float, float], WallCandidate] = {}
+    for candidate in chain.from_iterable(collections):
+        ordered_start, ordered_end = _normalise_segment(candidate.start, candidate.end)
+        key = (
+            round(ordered_start[0], 1),
+            round(ordered_start[1], 1),
+            round(ordered_end[0], 1),
+            round(ordered_end[1], 1),
+        )
+        if key not in dedup or candidate.confidence > dedup[key].confidence:
+            dedup[key] = WallCandidate(
+                start=ordered_start,
+                end=ordered_end,
+                thickness=candidate.thickness,
+                confidence=candidate.confidence,
+                source=candidate.source,
+            )
+    return list(dedup.values())
+
+
+def _iter_runs(values: Sequence[bool]) -> Iterable[Tuple[int, int]]:
+    start: Optional[int] = None
+    for index, flag in enumerate(values):
+        if flag:
+            if start is None:
+                start = index
+        elif start is not None:
+            yield start, index
+            start = None
+    if start is not None:
+        yield start, len(values)
+
+
+def _detect_walls_from_binary(
+    binary: Sequence[Sequence[bool]],
+    width: float,
+    height: float,
+    options: RasterVectorOptions,
+) -> List[WallCandidate]:
+    if not binary:
+        return []
+    pixel_height = len(binary)
+    pixel_width = len(binary[0]) if binary[0] else 0
+    if pixel_width == 0 or pixel_height == 0:
+        return []
+
+    scale_x = width / pixel_width if pixel_width else 1.0
+    scale_y = height / pixel_height if pixel_height else 1.0
+    min_horizontal = max(3, int(math.ceil(options.minimum_wall_length / max(scale_x, 1e-6))))
+    min_vertical = max(3, int(math.ceil(options.minimum_wall_length / max(scale_y, 1e-6))))
+
+    def make_candidate(start_point: Point, end_point: Point, length_units: float) -> WallCandidate:
+        confidence = min(1.0, length_units / max(options.minimum_wall_length * 4.0, max(width, height)))
+        thickness = max(scale_x, scale_y)
+        ordered_start, ordered_end = _normalise_segment(start_point, end_point)
+        return WallCandidate(
+            start=ordered_start,
+            end=ordered_end,
+            thickness=float(thickness),
+            confidence=round(confidence, 3),
+            source="bitmap",
+        )
+
+    dedup: Dict[Tuple[float, float, float, float], WallCandidate] = {}
+
+    for y, row in enumerate(binary):
+        for start, end in _iter_runs(row):
+            length = end - start
+            if length < min_horizontal:
+                continue
+            x0 = start * scale_x
+            x1 = (end - 1) * scale_x
+            y_center = height - (y + 0.5) * scale_y
+            candidate = make_candidate((x0, y_center), (x1, y_center), length * scale_x)
+            key = (
+                round(candidate.start[0], 1),
+                round(candidate.start[1], 1),
+                round(candidate.end[0], 1),
+                round(candidate.end[1], 1),
+            )
+            existing = dedup.get(key)
+            if existing is None or candidate.confidence > existing.confidence:
+                dedup[key] = candidate
+
+    for x in range(pixel_width):
+        column = [binary[y][x] for y in range(pixel_height)]
+        for start, end in _iter_runs(column):
+            length = end - start
+            if length < min_vertical:
+                continue
+            x_center = (x + 0.5) * scale_x
+            y0 = height - (start + 0.5) * scale_y
+            y1 = height - (end - 0.5) * scale_y
+            candidate = make_candidate((x_center, y0), (x_center, y1), length * scale_y)
+            key = (
+                round(candidate.start[0], 1),
+                round(candidate.start[1], 1),
+                round(candidate.end[0], 1),
+                round(candidate.end[1], 1),
+            )
+            existing = dedup.get(key)
+            if existing is None or candidate.confidence > existing.confidence:
+                dedup[key] = candidate
+
+    return list(dedup.values())
+
+
+def _detect_bitmap_walls(page: "fitz.Page", options: RasterVectorOptions) -> List[WallCandidate]:
+    try:
+        pixmap = page.get_pixmap(alpha=False)
+    except Exception:  # pragma: no cover - defensive guard
+        return []
+    if pixmap.width <= 0 or pixmap.height <= 0:
+        return []
+
+    samples = memoryview(pixmap.samples)
+    components = pixmap.n
+    threshold = int(255 * options.bitmap_threshold)
+    binary: List[List[bool]] = []
+    for y in range(pixmap.height):
+        row: List[bool] = []
+        offset = y * pixmap.width * components
+        for x in range(pixmap.width):
+            index = offset + x * components
+            r = samples[index]
+            if components == 1:
+                luminance = r
+            else:
+                g = samples[index + 1]
+                b = samples[index + 2]
+                luminance = int(0.299 * r + 0.587 * g + 0.114 * b)
+            row.append(luminance <= threshold)
+        binary.append(row)
+
+    rect = page.rect
+    return _detect_walls_from_binary(binary, rect.width, rect.height, options)
+
+
+def _extract_pdf_page_paths(page: "fitz.Page", page_index: int) -> List[VectorPath]:
+    paths: List[VectorPath] = []
+    layer = f"page-{page_index + 1}"
+    for drawing in page.get_drawings():  # pragma: no cover - depends on pymupdf
+        stroke_raw = drawing.get("width")
+        stroke_width = float(stroke_raw) if isinstance(stroke_raw, (int, float)) else None
+        segments: List[List[Point]] = []
+        current: List[Point] = []
+        for command in drawing["items"]:
+            operator = command[0]
+            if operator == "m":
+                if current:
+                    segments.append(current)
+                    current = []
+                point = command[1]
+                current.append((float(point[0]), float(point[1])))
+            elif operator == "l":
+                point = command[1]
+                current.append((float(point[0]), float(point[1])))
+            elif operator == "c":
+                point = command[3]
+                current.append((float(point[0]), float(point[1])))
+            elif operator == "re":
+                x0, y0, x1, y1 = map(float, command[1])
+                if current:
+                    segments.append(current)
+                current = []
+                segments.append([(x0, y0), (x1, y0), (x1, y1), (x0, y1), (x0, y0)])
+            elif operator == "h" and current:
+                current.append(current[0])
+            elif operator == "n":
+                if current:
+                    segments.append(current)
+                    current = []
+        if current:
+            segments.append(current)
+        for segment in segments:
+            if len(segment) >= 2:
+                paths.append(
+                    VectorPath(
+                        points=segment,
+                        layer=layer,
+                        stroke_width=stroke_width,
+                    )
+                )
+    return paths
+
+
+def _extract_pdf_paths(pdf_payload: bytes, options: RasterVectorOptions) -> RasterVectorResult:
+    if fitz is None:  # pragma: no cover - optional dependency
+        raise RuntimeError("PDF vectorization requires PyMuPDF (fitz)")
+    document = fitz.open(stream=pdf_payload, filetype="pdf")  # type: ignore[arg-type]
+    paths: List[VectorPath] = []
+    vector_walls: List[WallCandidate] = []
+    bitmap_walls: List[WallCandidate] = []
+    bounds: Optional[Tuple[float, float]] = None
+    for index, page in enumerate(document):  # pragma: no cover - depends on pymupdf
+        page_paths = _extract_pdf_page_paths(page, index)
+        paths.extend(page_paths)
+        vector_walls.extend(
+            detect_baseline_walls(page_paths, minimum_length=options.minimum_wall_length, source="vector")
+        )
+        if options.infer_walls:
+            bitmap_walls.extend(_detect_bitmap_walls(page, options))
+        if bounds is None:
+            rect = page.rect
+            bounds = (float(rect.width), float(rect.height))
+    merged_walls = _merge_walls(vector_walls, bitmap_walls)
+    return RasterVectorResult(paths=paths, walls=merged_walls, bounds=bounds, source="pdf", options=options)
+
+
+def _extract_svg_result(svg_payload: bytes, options: RasterVectorOptions) -> RasterVectorResult:
     content = svg_payload.decode("utf-8")
-    paths = _extract_svg_paths(content)
-    return RasterVectorResult(paths=paths, walls=detect_baseline_walls(paths))
+    root = ET.fromstring(content)
+    paths = _extract_svg_paths(root)
+    bounds = _parse_svg_bounds(root)
+    walls = detect_baseline_walls(paths, minimum_length=options.minimum_wall_length, source="vector")
+    return RasterVectorResult(paths=paths, walls=walls, bounds=bounds, source="svg", options=options)
 
 
-def _vectorize_pdf(pdf_payload: bytes) -> RasterVectorResult:
-    paths = _extract_pdf_paths(pdf_payload)
-    return RasterVectorResult(paths=paths, walls=detect_baseline_walls(paths))
+def _vectorize_pdf(pdf_payload: bytes, options: RasterVectorOptions) -> RasterVectorResult:
+    return _extract_pdf_paths(pdf_payload, options)
+
+
+def _vectorize_svg(svg_payload: bytes, options: RasterVectorOptions) -> RasterVectorResult:
+    return _extract_svg_result(svg_payload, options)
 
 
 @job(name="jobs.raster_vector.vectorize_floorplan", queue="imports:vector")
-async def vectorize_floorplan(payload: bytes, *, content_type: str, filename: Optional[str] = None) -> RasterVectorResult:
+async def vectorize_floorplan(
+    payload: bytes,
+    *,
+    content_type: str,
+    filename: Optional[str] = None,
+    infer_walls: bool = False,
+    minimum_wall_length: float = 1.0,
+) -> Dict[str, Any]:
     """Convert a PDF/SVG payload into vector paths and baseline walls."""
 
-    content_type = content_type.lower()
+    options = RasterVectorOptions(infer_walls=infer_walls, minimum_wall_length=minimum_wall_length)
+    content_type = (content_type or "").lower()
     name = (filename or "").lower()
+    loop = asyncio.get_running_loop()
     if content_type == "image/svg+xml" or name.endswith(".svg"):
-        return await asyncio.get_running_loop().run_in_executor(None, _vectorize_svg, payload)
+        result = await loop.run_in_executor(None, _vectorize_svg, payload, options)
+        return result.to_payload()
     if content_type == "application/pdf" or name.endswith(".pdf"):
-        return await asyncio.get_running_loop().run_in_executor(None, _vectorize_pdf, payload)
+        result = await loop.run_in_executor(None, _vectorize_pdf, payload, options)
+        return result.to_payload()
     raise RuntimeError("Unsupported floorplan media type")
 
 
 __all__ = [
+    "RasterVectorOptions",
     "RasterVectorResult",
     "VectorPath",
     "WallCandidate",

--- a/backend/tests/test_api/test_imports.py
+++ b/backend/tests/test_api/test_imports.py
@@ -42,12 +42,16 @@ async def test_upload_import_persists_metadata(
         "Podium",
     ]
     assert payload["parse_status"] == "pending"
+    assert payload["vector_storage_path"] is None
+    assert payload["vector_summary"] is None
 
     async with async_session_factory() as session:
         record = await session.get(ImportRecord, payload["import_id"])
         assert record is not None
         assert record.storage_path.startswith("s3://")
         assert len(record.layer_metadata) == 3
+        assert record.vector_storage_path is None
+        assert record.vector_summary is None
 
     storage_service = get_storage_service()
     metadata_path = (
@@ -59,6 +63,14 @@ async def test_upload_import_persists_metadata(
     assert metadata_path.exists()
     metadata = json.loads(metadata_path.read_text())
     assert metadata[0]["metadata"]["discipline"] == "architecture"
+
+    vector_path = (
+        storage_service.local_base_path
+        / "uploads"
+        / payload["import_id"]
+        / f"{payload['filename']}.vectors.json"
+    )
+    assert not vector_path.exists()
 
 
 @pytest.mark.asyncio
@@ -101,3 +113,45 @@ async def test_parse_endpoints_return_summary(
     assert poll_response.status_code == 200
     poll_payload = poll_response.json()
     assert poll_payload == parse_payload
+
+
+@pytest.mark.asyncio
+async def test_upload_pdf_vectorizes_when_enabled(
+    client: AsyncClient,
+    async_session_factory,
+) -> None:
+    pytest.importorskip("fitz")
+
+    pdf_path = Path(__file__).resolve().parents[3] / "samples" / "pdf" / "floor_simple.pdf"
+    with pdf_path.open("rb") as handle:
+        response = await client.post(
+            "/api/v1/import",
+            files={"file": (pdf_path.name, handle, "application/pdf")},
+            data={"infer_walls": "true"},
+        )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["vector_storage_path"]
+    assert payload["vector_summary"] is not None
+    assert payload["vector_summary"]["options"]["requested"] is True
+    assert payload["vector_summary"]["options"]["infer_walls"] is True
+
+    storage_service = get_storage_service()
+    vector_path = (
+        storage_service.local_base_path
+        / "uploads"
+        / payload["import_id"]
+        / f"{payload['filename']}.vectors.json"
+    )
+    assert vector_path.exists()
+    vector_payload = json.loads(vector_path.read_text())
+    assert vector_payload["paths"]
+    assert vector_payload["walls"] == payload["vector_summary"]["walls"]
+    assert payload["vector_summary"]["paths"] == len(vector_payload["paths"])
+
+    async with async_session_factory() as session:
+        record = await session.get(ImportRecord, payload["import_id"])
+        assert record is not None
+        assert record.vector_storage_path == payload["vector_storage_path"]
+        assert record.vector_summary == payload["vector_summary"]

--- a/backend/tests/test_jobs/test_raster_vector.py
+++ b/backend/tests/test_jobs/test_raster_vector.py
@@ -1,0 +1,53 @@
+"""Tests for raster to vector worker utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fitz")
+
+from jobs.raster_vector import vectorize_floorplan
+
+SAMPLE_PDF = Path(__file__).resolve().parents[3] / "samples" / "pdf" / "floor_simple.pdf"
+
+
+@pytest.mark.asyncio
+async def test_vectorize_pdf_produces_paths_and_walls() -> None:
+    payload = SAMPLE_PDF.read_bytes()
+    result = await vectorize_floorplan(
+        payload,
+        content_type="application/pdf",
+        filename="floor_simple.pdf",
+        infer_walls=True,
+    )
+
+    assert result["source"] == "pdf"
+    assert result["options"]["infer_walls"] is True
+    assert isinstance(result["paths"], list) and result["paths"]
+    assert all("points" in entry for entry in result["paths"])
+    assert isinstance(result["walls"], list)
+    json.dumps(result)
+
+
+@pytest.mark.asyncio
+async def test_wall_inference_toggle_expands_results() -> None:
+    payload = SAMPLE_PDF.read_bytes()
+    baseline = await vectorize_floorplan(
+        payload,
+        content_type="application/pdf",
+        filename="floor_simple.pdf",
+        infer_walls=False,
+    )
+    enhanced = await vectorize_floorplan(
+        payload,
+        content_type="application/pdf",
+        filename="floor_simple.pdf",
+        infer_walls=True,
+    )
+
+    assert baseline["options"]["infer_walls"] is False
+    assert enhanced["options"]["infer_walls"] is True
+    assert len(enhanced["walls"]) >= len(baseline["walls"])


### PR DESCRIPTION
## Summary
- enhance the raster vector worker to expose configuration options, bitmap wall detection, and JSON serialisable output
- persist generated vector geometry alongside uploaded imports and expose processing toggles in the import API
- extend models, schemas, and tests to cover vector storage plus add unit tests for the worker using the sample floor plan PDF

## Testing
- pytest backend/tests/test_api/test_imports.py backend/tests/test_jobs/test_raster_vector.py

------
https://chatgpt.com/codex/tasks/task_e_68d07dbda6d883209c1aa0c1b1086bf9