### PR TITLE
Guard router link against modified clicks

### DIFF
--- a/frontend/tests/router-link.test.cjs
+++ b/frontend/tests/router-link.test.cjs
@@ -1,0 +1,72 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const { loadModule } = require('./helpers/loadModule.cjs')
+
+const routerModule = loadModule(path.resolve(__dirname, '../src/router.tsx'))
+const { createLinkClickHandler } = routerModule
+
+function createEvent(overrides = {}) {
+  let prevented = false
+  const event = {
+    button: 0,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    defaultPrevented: false,
+    preventDefault() {
+      prevented = true
+      this.defaultPrevented = true
+    },
+    currentTarget: { target: '' },
+    ...overrides,
+  }
+
+  return { event, wasPrevented: () => prevented }
+}
+
+test('modified clicks bypass router navigation', () => {
+  const navigations = []
+  const handler = createLinkClickHandler(
+    {
+      path: '/start',
+      navigate: (to) => {
+        navigations.push(to)
+      },
+    },
+    '/destination',
+  )
+
+  for (const modifierKey of ['metaKey', 'ctrlKey']) {
+    const { event, wasPrevented } = createEvent({ [modifierKey]: true })
+    handler(event)
+    assert.equal(wasPrevented(), false, `${modifierKey} should not call preventDefault`)
+    assert.equal(
+      navigations.length,
+      0,
+      `${modifierKey} should not trigger client-side navigation`,
+    )
+  }
+})
+
+test('plain left click uses router navigation', () => {
+  const navigations = []
+  const handler = createLinkClickHandler(
+    {
+      path: '/start',
+      navigate: (to) => {
+        navigations.push(to)
+      },
+    },
+    '/destination',
+  )
+
+  const { event, wasPrevented } = createEvent()
+  handler(event)
+
+  assert.equal(wasPrevented(), true, 'preventDefault should be called for router navigation')
+  assert.equal(navigations.length, 1)
+  assert.equal(navigations[0], '/destination')
+})


### PR DESCRIPTION
## Summary
- update the router link click handler to ignore modified or non-primary clicks and respect target="_blank"
- expose the handler creation helper for easier unit testing
- add a node:test suite covering modified and plain click behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0816fe2c4832099c97f9d2641c6f0