### PR TITLE
Provide pytest_asyncio stub module for offline tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -38,11 +38,12 @@ if _MISSING_DEPS:  # pragma: no cover - offline test fallback
 try:  # pragma: no cover - exercised indirectly via tests
     import pytest_asyncio
 except ModuleNotFoundError:  # pragma: no cover - fallback stub for offline testing
-    class _PytestAsyncioStub:
-        def fixture(self, *args: Any, **kwargs: Any):
-            return pytest.fixture(*args, **kwargs)
+    from types import ModuleType
 
-    pytest_asyncio = _PytestAsyncioStub()  # type: ignore[assignment]
+    _pytest_asyncio_stub = ModuleType("pytest_asyncio")
+    _pytest_asyncio_stub.fixture = pytest.fixture  # type: ignore[attr-defined]
+    sys.modules.setdefault("pytest_asyncio", _pytest_asyncio_stub)
+    pytest_asyncio = _pytest_asyncio_stub  # type: ignore[assignment]
 
 try:  # pragma: no cover - optional dependency for API tests
     from httpx import AsyncClient


### PR DESCRIPTION
## Summary
- register a lightweight pytest_asyncio stub module when the dependency is unavailable
- expose pytest.fixture via the stub so API tests can import pytest_asyncio without the real package

## Testing
- pytest backend/tests/test_api/test_overlay.py

------
https://chatgpt.com/codex/tasks/task_e_68d081ea3f2c8320bac586955789c0bd