### PR TITLE
Add dedicated review notes for rule reviews

### DIFF
--- a/backend/app/api/v1/rules.py
+++ b/backend/app/api/v1/rules.py
@@ -66,6 +66,7 @@ def _serialise_rule(
         "authority": rule.authority,
         "topic": rule.topic,
         "review_status": rule.review_status,
+        "review_notes": rule.review_notes,
         "is_published": rule.is_published,
         "overlays": overlays,
         "advisory_hints": hints,
@@ -130,8 +131,8 @@ async def review_rule(
 
     if payload.reviewer:
         rule.reviewer = payload.reviewer
-    if payload.notes:
-        rule.notes = payload.notes
+    if payload.notes is not None:
+        rule.review_notes = payload.notes
 
     await session.commit()
     await session.refresh(rule)

--- a/backend/app/models/rkp.py
+++ b/backend/app/models/rkp.py
@@ -136,6 +136,7 @@ class RefRule(BaseModel):
     reviewer = Column(String(100))
     reviewed_at = Column(DateTime(timezone=True))
     notes = Column(Text)
+    review_notes = Column(Text)
     is_published = Column(Boolean, default=False, index=True)
     published_at = Column(DateTime(timezone=True))
 

--- a/backend/migrations/versions/20240626_000002_add_review_notes_to_ref_rules.py
+++ b/backend/migrations/versions/20240626_000002_add_review_notes_to_ref_rules.py
@@ -1,0 +1,25 @@
+"""Add review notes column to ref_rules."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "20240626_000002"
+down_revision = "20240115_000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+
+    op.add_column("ref_rules", sa.Column("review_notes", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Revert the migration."""
+
+    op.drop_column("ref_rules", "review_notes")

--- a/backend/tests/test_api/test_rules.py
+++ b/backend/tests/test_api/test_rules.py
@@ -157,3 +157,19 @@ async def test_rule_review_publish_action(client: AsyncClient, async_session_fac
     assert response.status_code == 200
     item = response.json()["item"]
     assert item["is_published"] is True
+    assert item["review_notes"] == "Ready"
+
+    # The review notes are exposed via the list endpoint without altering the canonical text.
+    list_response = await client.get("/api/v1/rules")
+    assert list_response.status_code == 200
+    list_payload = list_response.json()
+    assert list_payload["items"][0]["review_notes"] == "Ready"
+
+    async with async_session_factory() as session:
+        rule = await session.get(RefRule, rule_id)
+        assert rule is not None
+        assert (
+            rule.notes
+            == "Provide 1.5 parking spaces per unit; maximum ramp slope 1:12"
+        )
+        assert rule.review_notes == "Ready"


### PR DESCRIPTION
## Summary
- add a `review_notes` column to `RefRule` with an Alembic migration
- update the rule review endpoint to persist reviewer feedback separately from canonical notes and return it in responses, even when the review note is empty
- extend the rule API test to ensure review notes are stored independently of the rule text and surfaced via the listing endpoint

## Testing
- pytest backend/tests/test_api/test_rules.py *(skipped: fastapi missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d081a268fc8320a1b34e36ba2af3e6