### PR TITLE
Add rule pack storage, validation engine, and API

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -12,6 +12,7 @@ from . import (
     review,
     roi,
     rules,
+    rulesets,
     screen,
     standards,
 )
@@ -19,6 +20,7 @@ from . import (
 api_router = APIRouter()
 api_router.include_router(review.router)
 api_router.include_router(rules.router)
+api_router.include_router(rulesets.router)
 api_router.include_router(screen.router)
 api_router.include_router(ergonomics.router)
 api_router.include_router(products.router)

--- a/backend/app/api/v1/rulesets.py
+++ b/backend/app/api/v1/rulesets.py
@@ -1,0 +1,103 @@
+"""Rule pack catalogue and validation endpoints."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_session
+from app.core.geometry import GeometrySerializer
+from app.core.rules import RulesEngine
+from app.models.rulesets import RulePack
+from app.schemas.rulesets import (
+    RuleEvaluationResult,
+    RulePackSchema,
+    RulePackSummary,
+    RulesetEvaluationSummary,
+    RulesetListResponse,
+    RulesetValidationRequest,
+    RulesetValidationResponse,
+)
+
+
+router = APIRouter()
+
+
+async def _load_ruleset(
+    session: AsyncSession, payload: RulesetValidationRequest
+) -> Optional[RulePack]:
+    """Retrieve the rule pack referenced by the validation request."""
+
+    stmt: Select[RulePack]
+    if payload.ruleset_id is not None:
+        stmt = select(RulePack).where(RulePack.id == payload.ruleset_id)
+    else:
+        stmt = select(RulePack).where(RulePack.slug == payload.ruleset_slug)
+        if payload.ruleset_version is not None:
+            stmt = stmt.where(RulePack.version == payload.ruleset_version)
+        else:
+            stmt = stmt.order_by(RulePack.version.desc()).limit(1)
+    result = await session.execute(stmt)
+    return result.scalars().first()
+
+
+@router.get("/rulesets", response_model=RulesetListResponse)
+async def list_rulesets(session: AsyncSession = Depends(get_session)) -> RulesetListResponse:
+    """Return stored rule packs ordered by slug and version."""
+
+    stmt: Select[RulePack] = select(RulePack).order_by(RulePack.slug, RulePack.version.desc())
+    result = await session.execute(stmt)
+    packs = result.scalars().all()
+    items = [RulePackSchema.model_validate(pack) for pack in packs]
+    return RulesetListResponse(items=items, count=len(items))
+
+
+@router.post("/rulesets/validate", response_model=RulesetValidationResponse)
+async def validate_ruleset(
+    payload: RulesetValidationRequest,
+    session: AsyncSession = Depends(get_session),
+) -> RulesetValidationResponse:
+    """Validate a geometry payload against the requested rule pack."""
+
+    ruleset = await _load_ruleset(session, payload)
+    if ruleset is None:
+        raise HTTPException(status_code=404, detail="Rule pack not found")
+
+    if not payload.geometry:
+        raise HTTPException(status_code=400, detail="Geometry payload is required")
+
+    try:
+        graph = GeometrySerializer.from_export(payload.geometry)
+    except Exception as exc:  # pragma: no cover - defensive guard for invalid payloads
+        raise HTTPException(status_code=400, detail=f"Invalid geometry payload: {exc}") from exc
+
+    engine = RulesEngine(ruleset.definition)
+    evaluation = engine.evaluate(graph)
+
+    results = [RuleEvaluationResult.model_validate(item) for item in evaluation.get("results", [])]
+    summary = RulesetEvaluationSummary.model_validate(evaluation.get("summary", {}))
+    ruleset_summary = RulePackSummary.model_validate(ruleset)
+
+    citations: List[Dict[str, object]] = []
+    seen: set[str] = set()
+    for item in results:
+        citation = item.citation
+        if citation:
+            key = json.dumps(citation, sort_keys=True)
+            if key not in seen:
+                seen.add(key)
+                citations.append(citation)
+
+    return RulesetValidationResponse(
+        ruleset=ruleset_summary,
+        results=results,
+        summary=summary,
+        citations=citations,
+    )
+
+
+__all__ = ["router"]

--- a/backend/app/core/rules/__init__.py
+++ b/backend/app/core/rules/__init__.py
@@ -1,0 +1,5 @@
+"""Rule evaluation utilities."""
+
+from .engine import RulesEngine
+
+__all__ = ["RulesEngine"]

--- a/backend/app/core/rules/engine.py
+++ b/backend/app/core/rules/engine.py
@@ -1,0 +1,447 @@
+"""Evaluation engine for geometry rule packs."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from app.core.models.geometry import GeometryEntity, GeometryGraph, Space
+
+
+@dataclass
+class _EvaluationContext:
+    """Shared context available during predicate evaluation."""
+
+    graph: GeometryGraph
+    rule: Mapping[str, Any]
+
+
+class RulesEngine:
+    """Evaluate rules expressed with a small predicate DSL."""
+
+    def __init__(self, pack: Mapping[str, Any]) -> None:
+        self._pack = dict(pack)
+        rules = self._pack.get("rules", [])
+        if not isinstance(rules, Sequence):
+            raise TypeError("Rule pack definition must include a sequence under 'rules'")
+        self._rules: List[Mapping[str, Any]] = [dict(rule) for rule in rules]
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def evaluate(self, graph: GeometryGraph) -> Dict[str, Any]:
+        """Evaluate the configured rules against the provided geometry graph."""
+
+        context = _EvaluationContext(graph=graph, rule={})
+        results: List[Dict[str, Any]] = []
+        total_checked = 0
+        total_violations = 0
+
+        for rule in self._rules:
+            context.rule = rule
+            evaluation = self._evaluate_rule(rule, context)
+            results.append(evaluation)
+            total_checked += int(evaluation.get("checked", 0))
+            total_violations += len(evaluation.get("violations", []))
+
+        summary = {
+            "total_rules": len(self._rules),
+            "evaluated_rules": len(results),
+            "violations": total_violations,
+            "checked_entities": total_checked,
+        }
+        return {"results": results, "summary": summary}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _evaluate_rule(
+        self, rule: Mapping[str, Any], context: _EvaluationContext
+    ) -> Dict[str, Any]:
+        predicate = rule.get("predicate")
+        if not isinstance(predicate, Mapping):
+            raise ValueError(f"Rule '{rule.get('id')}' missing predicate definition")
+
+        target = str(rule.get("target", "spaces"))
+        violations: List[Dict[str, Any]] = []
+        checked = 0
+
+        for entity in self._iter_target_entities(context.graph, target):
+            where_clause = rule.get("where")
+            if isinstance(where_clause, Mapping):
+                matches, _, _ = self._evaluate_predicate(where_clause, entity, context)
+                if not matches:
+                    continue
+            checked += 1
+
+            passed, messages, facts = self._evaluate_predicate(predicate, entity, context)
+            if not passed:
+                violation = {
+                    "entity_id": str(getattr(entity, "id", "")),
+                    "messages": messages or [f"Rule '{rule.get('id')}' was not satisfied"],
+                    "facts": facts,
+                    "attributes": self._build_violation_attributes(entity, target),
+                }
+                violations.append(violation)
+
+        return {
+            "rule_id": str(rule.get("id", "")),
+            "title": rule.get("title"),
+            "target": target,
+            "citation": rule.get("citation"),
+            "passed": not violations,
+            "checked": checked,
+            "violations": violations,
+        }
+
+    def _iter_target_entities(
+        self, graph: GeometryGraph, target: str
+    ) -> Iterable[GeometryEntity]:
+        key = target.lower()
+        if key in {"space", "spaces"}:
+            return list(graph.spaces.values())
+        if key in {"level", "levels"}:
+            return list(graph.levels.values())
+        if key in {"wall", "walls"}:
+            return list(graph.walls.values())
+        if key in {"door", "doors"}:
+            return list(graph.doors.values())
+        if key in {"fixture", "fixtures"}:
+            return list(graph.fixtures.values())
+        raise ValueError(f"Unsupported rule target: {target}")
+
+    def _evaluate_predicate(
+        self,
+        predicate: Mapping[str, Any],
+        entity: GeometryEntity,
+        context: _EvaluationContext,
+    ) -> tuple[bool, List[str], List[Dict[str, Any]]]:
+        if "all" in predicate:
+            return self._evaluate_all(predicate["all"], entity, context, predicate.get("message"))
+        if "any" in predicate:
+            return self._evaluate_any(predicate["any"], entity, context, predicate.get("message"))
+        if "not" in predicate:
+            return self._evaluate_not(predicate["not"], entity, context, predicate.get("message"))
+        if "exists" in predicate:
+            field = str(predicate["exists"])
+            value = self._resolve_field(entity, field, context)
+            if value is not None:
+                return True, [], []
+            message = predicate.get("message") or f"Expected '{field}' to be present"
+            fact = {
+                "field": field,
+                "operator": "exists",
+                "expected": True,
+                "actual": value,
+            }
+            return False, [message], [fact]
+        if "field" in predicate:
+            return self._evaluate_field_predicate(predicate, entity, context)
+        raise ValueError(f"Unsupported predicate structure: {predicate}")
+
+    def _evaluate_all(
+        self,
+        predicates: Sequence[Mapping[str, Any]],
+        entity: GeometryEntity,
+        context: _EvaluationContext,
+        message: str | None,
+    ) -> tuple[bool, List[str], List[Dict[str, Any]]]:
+        all_passed = True
+        messages: List[str] = []
+        facts: List[Dict[str, Any]] = []
+        for item in predicates:
+            passed, child_messages, child_facts = self._evaluate_predicate(item, entity, context)
+            if not passed:
+                all_passed = False
+                messages.extend(child_messages)
+                facts.extend(child_facts)
+        if all_passed:
+            return True, [], []
+        if message:
+            messages.insert(0, message)
+        return False, messages, facts
+
+    def _evaluate_any(
+        self,
+        predicates: Sequence[Mapping[str, Any]],
+        entity: GeometryEntity,
+        context: _EvaluationContext,
+        message: str | None,
+    ) -> tuple[bool, List[str], List[Dict[str, Any]]]:
+        failure_messages: List[str] = []
+        failure_facts: List[Dict[str, Any]] = []
+        for item in predicates:
+            passed, child_messages, child_facts = self._evaluate_predicate(item, entity, context)
+            if passed:
+                return True, [], []
+            failure_messages.extend(child_messages)
+            failure_facts.extend(child_facts)
+        combined_message = message or "None of the predicate options were satisfied"
+        return False, [combined_message, *failure_messages], failure_facts
+
+    def _evaluate_not(
+        self,
+        predicate: Mapping[str, Any],
+        entity: GeometryEntity,
+        context: _EvaluationContext,
+        message: str | None,
+    ) -> tuple[bool, List[str], List[Dict[str, Any]]]:
+        passed, child_messages, child_facts = self._evaluate_predicate(predicate, entity, context)
+        if passed:
+            failure_message = message or "Negated predicate evaluated to true"
+            return False, [failure_message, *child_messages], child_facts
+        return True, [], []
+
+    def _evaluate_field_predicate(
+        self,
+        predicate: Mapping[str, Any],
+        entity: GeometryEntity,
+        context: _EvaluationContext,
+    ) -> tuple[bool, List[str], List[Dict[str, Any]]]:
+        field = str(predicate.get("field"))
+        operator = str(predicate.get("operator", "=="))
+        actual = self._resolve_field(entity, field, context)
+
+        if "value_field" in predicate:
+            expected = self._resolve_field(entity, str(predicate["value_field"]), context)
+        elif "value_path" in predicate:
+            expected = self._resolve_field(entity, str(predicate["value_path"]), context)
+        else:
+            expected = predicate.get("value")
+        if isinstance(expected, str) and expected.startswith("$"):
+            expected = self._resolve_field(entity, expected[1:], context)
+
+        comparison, normalised_actual, normalised_expected, reason = self._apply_operator(
+            operator, actual, expected
+        )
+        if comparison:
+            return True, [], []
+
+        message = predicate.get("message")
+        if not message:
+            if reason:
+                message = reason
+            else:
+                message = self._format_failure_message(field, operator, normalised_expected, normalised_actual)
+        fact: Dict[str, Any] = {
+            "field": field,
+            "operator": operator,
+            "expected": normalised_expected,
+            "actual": normalised_actual,
+        }
+        if reason:
+            fact["message"] = reason
+        return False, [message], [fact]
+
+    def _apply_operator(
+        self, operator: str, actual: Any, expected: Any
+    ) -> tuple[bool, Any, Any, str | None]:
+        op = operator.lower()
+        if op in {">", ">=", "<", "<="}:
+            numeric_actual, numeric_expected, comparable = self._coerce_numeric_pair(actual, expected)
+            if not comparable:
+                reason = f"Cannot compare values using '{operator}': {actual!r} and {expected!r}"
+                return False, actual, expected, reason
+            actual = numeric_actual
+            expected = numeric_expected
+        try:
+            if op == "==":
+                return actual == expected, actual, expected, None
+            if op == "!=":
+                return actual != expected, actual, expected, None
+            if op == ">":
+                return bool(actual > expected), actual, expected, None
+            if op == ">=":
+                return bool(actual >= expected), actual, expected, None
+            if op == "<":
+                return bool(actual < expected), actual, expected, None
+            if op == "<=":
+                return bool(actual <= expected), actual, expected, None
+            if op == "in":
+                container = expected
+                if container is None:
+                    return False, actual, expected, "Expected a container for 'in' comparison"
+                if not isinstance(container, (str, bytes)) and not isinstance(container, Iterable):
+                    return False, actual, expected, "Right-hand side of 'in' must be iterable"
+                return bool(actual in container), actual, expected, None
+            if op == "not_in":
+                container = expected
+                if container is None:
+                    return False, actual, expected, "Expected a container for 'not_in' comparison"
+                if not isinstance(container, (str, bytes)) and not isinstance(container, Iterable):
+                    return False, actual, expected, "Right-hand side of 'not_in' must be iterable"
+                return bool(actual not in container), actual, expected, None
+            if op == "contains":
+                if actual is None:
+                    return False, actual, expected, "Left-hand side of 'contains' is empty"
+                if isinstance(actual, Mapping):
+                    return bool(expected in actual or expected in actual.values()), actual, expected, None
+                if isinstance(actual, (str, bytes)):
+                    return bool(str(expected) in actual), actual, expected, None
+                if isinstance(actual, Iterable):
+                    return bool(expected in actual), actual, expected, None
+                return False, actual, expected, "Left-hand side of 'contains' must be iterable"
+            if op == "not_contains":
+                if actual is None:
+                    return True, actual, expected, None
+                if isinstance(actual, Mapping):
+                    return bool(expected not in actual and expected not in actual.values()), actual, expected, None
+                if isinstance(actual, (str, bytes)):
+                    return bool(str(expected) not in actual), actual, expected, None
+                if isinstance(actual, Iterable):
+                    return bool(expected not in actual), actual, expected, None
+                return False, actual, expected, "Left-hand side of 'not_contains' must be iterable"
+            if op == "is_truthy":
+                return bool(actual), actual, expected, None
+            if op == "is_falsy":
+                return (not bool(actual)), actual, expected, None
+        except TypeError as exc:  # pragma: no cover - defensive against edge cases
+            return False, actual, expected, str(exc)
+        return False, actual, expected, f"Unsupported operator '{operator}'"
+
+    def _coerce_numeric_pair(self, left: Any, right: Any) -> tuple[Any, Any, bool]:
+        left_num = self._coerce_numeric(left)
+        right_num = self._coerce_numeric(right)
+        if left_num is None or right_num is None:
+            return left, right, False
+        return left_num, right_num, True
+
+    def _coerce_numeric(self, value: Any) -> float | None:
+        if isinstance(value, bool):  # Avoid treating booleans as numbers
+            return float(value)
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            try:
+                return float(value)
+            except ValueError:
+                return None
+        return None
+
+    def _resolve_field(
+        self, entity: GeometryEntity, path: str, context: _EvaluationContext
+    ) -> Any:
+        if not path:
+            return None
+        segments = path.split(".")
+        root: Any
+        if segments[0] == "graph":
+            root = context.graph
+            segments = segments[1:]
+        elif segments[0] == "computed":
+            return self._resolve_computed(segments[1:], entity, context)
+        else:
+            root = entity
+        value: Any = root
+        for segment in segments:
+            if value is None:
+                return None
+            if isinstance(value, Mapping):
+                value = value.get(segment)
+            else:
+                value = getattr(value, segment, None)
+        return value
+
+    def _resolve_computed(
+        self, segments: Sequence[str], entity: GeometryEntity, context: _EvaluationContext
+    ) -> Any:
+        if not segments:
+            return None
+        key = segments[0]
+        if key == "area":
+            return self._space_area(entity)
+        if key == "perimeter":
+            return self._space_perimeter(entity)
+        if key == "level":
+            level_id = getattr(entity, "level_id", None)
+            if level_id:
+                return context.graph.levels.get(level_id)
+            return None
+        return None
+
+    def _space_area(self, entity: GeometryEntity) -> float:
+        if not isinstance(entity, Space):
+            boundary = getattr(entity, "boundary", None)
+        else:
+            boundary = entity.boundary
+        if not boundary:
+            return 0.0
+        points: List[tuple[float, float]] = []
+        for point in boundary:
+            if isinstance(point, Sequence) and len(point) >= 2:
+                points.append((float(point[0]), float(point[1])))
+            elif isinstance(point, Mapping):
+                x = point.get("x")
+                y = point.get("y")
+                if x is None or y is None:
+                    continue
+                points.append((float(x), float(y)))
+        if len(points) < 3:
+            return 0.0
+        if points[0] != points[-1]:
+            points.append(points[0])
+        area = 0.0
+        for idx in range(len(points) - 1):
+            x1, y1 = points[idx]
+            x2, y2 = points[idx + 1]
+            area += x1 * y2 - x2 * y1
+        return abs(area) / 2.0
+
+    def _space_perimeter(self, entity: GeometryEntity) -> float:
+        if not isinstance(entity, Space):
+            boundary = getattr(entity, "boundary", None)
+        else:
+            boundary = entity.boundary
+        if not boundary:
+            return 0.0
+        points: List[tuple[float, float]] = []
+        for point in boundary:
+            if isinstance(point, Sequence) and len(point) >= 2:
+                points.append((float(point[0]), float(point[1])))
+            elif isinstance(point, Mapping):
+                x = point.get("x")
+                y = point.get("y")
+                if x is None or y is None:
+                    continue
+                points.append((float(x), float(y)))
+        if len(points) < 2:
+            return 0.0
+        perimeter = 0.0
+        for idx in range(len(points)):
+            x1, y1 = points[idx]
+            x2, y2 = points[(idx + 1) % len(points)]
+            perimeter += ((x2 - x1) ** 2 + (y2 - y1) ** 2) ** 0.5
+        return perimeter
+
+    def _format_failure_message(
+        self, field: str, operator: str, expected: Any, actual: Any
+    ) -> str:
+        if operator in {"in", "not_in", "contains", "not_contains"}:
+            return (
+                f"Field '{field}' with value {actual!r} failed condition "
+                f"'{operator}' against {expected!r}"
+            )
+        if operator in {"is_truthy", "is_falsy"}:
+            verb = "truthy" if operator == "is_truthy" else "falsy"
+            return f"Field '{field}' expected to be {verb} but was {actual!r}"
+        return (
+            f"Field '{field}' with value {actual!r} does not satisfy "
+            f"{operator} {expected!r}"
+        )
+
+    def _build_violation_attributes(self, entity: GeometryEntity, target: str) -> Dict[str, Any]:
+        attributes: Dict[str, Any] = {"target": target}
+        name = getattr(entity, "name", None)
+        if name:
+            attributes["name"] = name
+        level_id = getattr(entity, "level_id", None)
+        if level_id:
+            attributes["level_id"] = level_id
+        metadata = getattr(entity, "metadata", None)
+        if isinstance(metadata, MutableMapping) and metadata:
+            attributes["metadata"] = dict(metadata)
+        return attributes
+
+
+__all__ = ["RulesEngine"]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,6 +3,6 @@
 from .base import Base  # noqa: F401
 
 # Import model modules so their metadata is registered with SQLAlchemy.
-from . import audit, imports, overlay, rkp  # noqa: F401  pylint: disable=unused-import
+from . import audit, imports, overlay, rkp, rulesets  # noqa: F401  pylint: disable=unused-import
 
 __all__ = ["Base"]

--- a/backend/app/models/rulesets.py
+++ b/backend/app/models/rulesets.py
@@ -1,0 +1,45 @@
+"""Models for managing stored rule packs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.models.base import BaseModel
+from app.models.types import FlexibleJSONB
+
+
+JSONType = FlexibleJSONB
+
+
+class RulePack(BaseModel):
+    """Persisted rule pack definition with jurisdictional metadata."""
+
+    __tablename__ = "rule_packs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    slug: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text)
+    jurisdiction: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    authority: Mapped[str | None] = mapped_column(String(128))
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    definition: Mapped[dict] = mapped_column(JSONType, nullable=False)
+    metadata: Mapped[dict] = mapped_column(JSONType, default=dict)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        UniqueConstraint("slug", "version", name="uq_rule_pack_slug_version"),
+    )
+
+
+__all__ = ["RulePack"]

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -7,6 +7,17 @@ from .overlay import (  # noqa: F401
     OverlayDecisionRecord,
     OverlaySuggestion,
 )
+from .rulesets import (  # noqa: F401
+    RuleEvaluationResult,
+    RulePackSchema,
+    RulePackSummary,
+    RulesetEvaluationSummary,
+    RulesetListResponse,
+    RulesetValidationRequest,
+    RulesetValidationResponse,
+    ViolationDetail,
+    ViolationFact,
+)
 from .standards import MaterialStandard  # noqa: F401
 
 __all__ = [
@@ -18,4 +29,13 @@ __all__ = [
     "OverlayDecisionPayload",
     "OverlayDecisionRecord",
     "ParseStatusResponse",
+    "RuleEvaluationResult",
+    "RulePackSchema",
+    "RulePackSummary",
+    "RulesetEvaluationSummary",
+    "RulesetListResponse",
+    "RulesetValidationRequest",
+    "RulesetValidationResponse",
+    "ViolationDetail",
+    "ViolationFact",
 ]

--- a/backend/app/schemas/rulesets.py
+++ b/backend/app/schemas/rulesets.py
@@ -1,0 +1,131 @@
+"""Schemas for rule pack management and validation APIs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class RulePackSchema(BaseModel):
+    """Serialized representation of a stored rule pack."""
+
+    id: int
+    slug: str
+    name: str
+    description: Optional[str] = None
+    jurisdiction: str
+    authority: Optional[str] = None
+    version: int
+    definition: Dict[str, Any]
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    is_active: bool = True
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        """Pydantic configuration."""
+
+        from_attributes = True
+
+
+class RulePackSummary(BaseModel):
+    """Compact metadata about a rule pack."""
+
+    id: int
+    slug: str
+    name: str
+    jurisdiction: str
+    authority: Optional[str] = None
+    version: int
+    description: Optional[str] = None
+
+    class Config:
+        """Pydantic configuration."""
+
+        from_attributes = True
+
+
+class RulesetValidationRequest(BaseModel):
+    """Payload received when validating geometry against a rule pack."""
+
+    ruleset_id: Optional[int] = Field(default=None, ge=1)
+    ruleset_slug: Optional[str] = Field(default=None, min_length=1)
+    ruleset_version: Optional[int] = Field(default=None, ge=1)
+    geometry: Dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _check_identifier(cls, values: "RulesetValidationRequest") -> "RulesetValidationRequest":
+        if values.ruleset_id is None and not values.ruleset_slug:
+            raise ValueError("Either ruleset_id or ruleset_slug must be provided")
+        return values
+
+
+class ViolationFact(BaseModel):
+    """Individual fact captured while evaluating a predicate."""
+
+    field: str
+    operator: str
+    expected: Any = None
+    actual: Any = None
+    message: Optional[str] = None
+
+
+class ViolationDetail(BaseModel):
+    """Explainability payload describing a rule violation."""
+
+    entity_id: str
+    messages: List[str] = Field(default_factory=list)
+    facts: List[ViolationFact] = Field(default_factory=list)
+    attributes: Dict[str, Any] = Field(default_factory=dict)
+
+
+class RuleEvaluationResult(BaseModel):
+    """Outcome of evaluating a single rule against the geometry."""
+
+    rule_id: str
+    title: Optional[str] = None
+    target: Optional[str] = None
+    citation: Optional[Dict[str, Any]] = None
+    passed: bool
+    checked: int
+    violations: List[ViolationDetail] = Field(default_factory=list)
+
+
+class RulesetEvaluationSummary(BaseModel):
+    """Aggregate metrics about a validation run."""
+
+    total_rules: int
+    evaluated_rules: int
+    violations: int
+    checked_entities: int
+
+
+class RulesetValidationResponse(BaseModel):
+    """Response returned by the validation endpoint."""
+
+    ruleset: RulePackSummary
+    results: List[RuleEvaluationResult]
+    summary: RulesetEvaluationSummary
+    citations: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class RulesetListResponse(BaseModel):
+    """Paginated response for the rule pack catalogue."""
+
+    items: List[RulePackSchema]
+    count: int
+
+
+__all__ = [
+    "RulePackSchema",
+    "RulePackSummary",
+    "RulesetEvaluationSummary",
+    "RulesetListResponse",
+    "RulesetValidationRequest",
+    "RulesetValidationResponse",
+    "RuleEvaluationResult",
+    "ViolationDetail",
+    "ViolationFact",
+]

--- a/backend/tests/test_api/test_rulesets.py
+++ b/backend/tests/test_api/test_rulesets.py
@@ -1,0 +1,161 @@
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("pytest_asyncio")
+
+import pytest_asyncio
+from httpx import AsyncClient
+
+from app.core.database import get_session
+from app.core.models.geometry import Door, GeometryGraph, Level, Space
+from app.main import app
+from app.models.rulesets import RulePack
+
+
+PACK_DEFINITION = {
+    "metadata": {"jurisdiction": "SG", "version": 1},
+    "rules": [
+        {
+            "id": "min-bedroom-area",
+            "title": "Bedrooms must be at least 10 square metres",
+            "target": "spaces",
+            "where": {
+                "all": [
+                    {"field": "metadata.category", "operator": "==", "value": "bedroom"},
+                    {"field": "level_id", "operator": "==", "value": "L1"},
+                ]
+            },
+            "predicate": {
+                "field": "computed.area",
+                "operator": ">=",
+                "value": 10.0,
+                "message": "Bedroom area below minimum requirement",
+            },
+            "citation": {"code": "RES-12.4", "section": "4.2"},
+        },
+        {
+            "id": "bedroom-ventilation",
+            "title": "Bedrooms require natural light or mechanical ventilation",
+            "target": "spaces",
+            "where": {"field": "metadata.category", "operator": "==", "value": "bedroom"},
+            "predicate": {
+                "any": [
+                    {"field": "metadata.window_count", "operator": ">=", "value": 1},
+                    {
+                        "field": "metadata.has_mechanical_ventilation",
+                        "operator": "==",
+                        "value": True,
+                    },
+                ],
+                "message": "Bedroom must provide a window or mechanical ventilation",
+            },
+            "citation": {"code": "RES-12.4", "section": "4.3"},
+        },
+        {
+            "id": "door-clearance",
+            "title": "Doors must be at least one metre wide",
+            "target": "doors",
+            "predicate": {"field": "width", "operator": ">=", "value": 1.0},
+            "citation": {"code": "ACCESS-7"},
+        },
+    ],
+}
+
+
+def _geometry_payload() -> dict:
+    graph = GeometryGraph(
+        levels=[Level(id="L1", name="Level 1", elevation=0.0)],
+        spaces=[
+            Space(
+                id="S1",
+                name="Bedroom A",
+                level_id="L1",
+                boundary=[(0.0, 0.0), (3.0, 0.0), (3.0, 3.0), (0.0, 3.0)],
+                metadata={"category": "bedroom", "window_count": 0, "has_mechanical_ventilation": False},
+            ),
+            Space(
+                id="S2",
+                name="Bedroom B",
+                level_id="L1",
+                boundary=[(0.0, 0.0), (4.0, 0.0), (4.0, 3.0), (0.0, 3.0)],
+                metadata={"category": "bedroom", "window_count": 2},
+            ),
+        ],
+        doors=[
+            Door(id="D1", name="Bedroom Door", width=0.8, level_id="L1"),
+            Door(id="D2", name="Entry Door", width=1.2, level_id="L1"),
+        ],
+    )
+    return graph.to_dict()
+
+
+@pytest_asyncio.fixture
+async def ruleset_client(async_session_factory):
+    async def _override_session():
+        async with async_session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = _override_session
+    async with AsyncClient(app=app, base_url="http://testserver") as client:
+        yield client
+    app.dependency_overrides.pop(get_session, None)
+
+
+@pytest_asyncio.fixture
+async def seeded_ruleset(async_session_factory) -> dict:
+    async with async_session_factory() as session:
+        pack = RulePack(
+            slug="sg-residential",
+            name="Singapore Residential Compliance",
+            description="Minimum bedroom and door clearances",
+            jurisdiction="SG",
+            authority="URA",
+            version=1,
+            definition=PACK_DEFINITION,
+            metadata={"topics": ["space", "door"]},
+        )
+        session.add(pack)
+        await session.commit()
+        await session.refresh(pack)
+        return {"id": pack.id, "slug": pack.slug, "version": pack.version}
+
+
+@pytest.mark.asyncio
+async def test_list_rulesets_returns_catalogue(ruleset_client: AsyncClient, seeded_ruleset) -> None:
+    response = await ruleset_client.get("/api/v1/rulesets")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    item = payload["items"][0]
+    assert item["slug"] == "sg-residential"
+    assert item["jurisdiction"] == "SG"
+    assert item["version"] == 1
+    assert item["definition"]["rules"]
+
+
+@pytest.mark.asyncio
+async def test_validate_ruleset_reports_citations_and_violations(
+    ruleset_client: AsyncClient,
+    seeded_ruleset,
+) -> None:
+    geometry_payload = _geometry_payload()
+    response = await ruleset_client.post(
+        "/api/v1/rulesets/validate",
+        json={"ruleset_slug": seeded_ruleset["slug"], "geometry": geometry_payload},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["ruleset"]["slug"] == seeded_ruleset["slug"]
+    assert payload["summary"]["violations"] == 3
+    assert payload["citations"]
+    assert any(citation.get("code") == "RES-12.4" for citation in payload["citations"])
+
+    area_result = next(item for item in payload["results"] if item["rule_id"] == "min-bedroom-area")
+    assert area_result["violations"][0]["entity_id"] == "S1"
+    assert any("bedroom" in msg.lower() for msg in area_result["violations"][0]["messages"])
+
+    door_result = next(item for item in payload["results"] if item["rule_id"] == "door-clearance")
+    assert any(violation["entity_id"] == "D1" for violation in door_result["violations"])

--- a/backend/tests/test_core/test_rules_engine.py
+++ b/backend/tests/test_core/test_rules_engine.py
@@ -1,0 +1,128 @@
+import pytest
+
+from app.core.models.geometry import Door, GeometryGraph, Level, Space
+from app.core.rules.engine import RulesEngine
+
+
+RULE_PACK = {
+    "metadata": {"jurisdiction": "SG", "version": 1},
+    "rules": [
+        {
+            "id": "min-bedroom-area",
+            "title": "Bedrooms must be at least 10 square metres",
+            "target": "spaces",
+            "where": {
+                "all": [
+                    {"field": "metadata.category", "operator": "==", "value": "bedroom"},
+                    {"field": "level_id", "operator": "==", "value": "L1"},
+                ]
+            },
+            "predicate": {
+                "field": "computed.area",
+                "operator": ">=",
+                "value": 10.0,
+                "message": "Bedroom area below minimum requirement",
+            },
+            "citation": {"code": "RES-12.4", "section": "4.2"},
+        },
+        {
+            "id": "bedroom-ventilation",
+            "title": "Bedrooms require natural light or mechanical ventilation",
+            "target": "spaces",
+            "where": {"field": "metadata.category", "operator": "==", "value": "bedroom"},
+            "predicate": {
+                "any": [
+                    {"field": "metadata.window_count", "operator": ">=", "value": 1},
+                    {
+                        "field": "metadata.has_mechanical_ventilation",
+                        "operator": "==",
+                        "value": True,
+                    },
+                ],
+                "message": "Bedroom must provide a window or mechanical ventilation",
+            },
+            "citation": {"code": "RES-12.4", "section": "4.3"},
+        },
+        {
+            "id": "door-clearance",
+            "title": "Doors must be at least one metre wide",
+            "target": "doors",
+            "predicate": {"field": "width", "operator": ">=", "value": 1.0},
+            "citation": {"code": "ACCESS-7"},
+        },
+    ],
+}
+
+
+@pytest.fixture
+def geometry_graph() -> GeometryGraph:
+    return GeometryGraph(
+        levels=[Level(id="L1", name="Level 1", elevation=0.0)],
+        spaces=[
+            Space(
+                id="S1",
+                name="Bedroom A",
+                level_id="L1",
+                boundary=[(0.0, 0.0), (3.0, 0.0), (3.0, 3.0), (0.0, 3.0)],
+                metadata={"category": "bedroom", "window_count": 0, "has_mechanical_ventilation": False},
+            ),
+            Space(
+                id="S2",
+                name="Bedroom B",
+                level_id="L1",
+                boundary=[(0.0, 0.0), (4.0, 0.0), (4.0, 3.0), (0.0, 3.0)],
+                metadata={"category": "bedroom", "window_count": 2},
+            ),
+            Space(
+                id="S3",
+                name="Kitchen",
+                level_id="L1",
+                boundary=[(0.0, 0.0), (2.0, 0.0), (2.0, 3.0), (0.0, 3.0)],
+                metadata={"category": "kitchen", "window_count": 0},
+            ),
+        ],
+        doors=[
+            Door(id="D1", name="Bedroom Door", width=0.8, level_id="L1"),
+            Door(id="D2", name="Entry Door", width=1.2, level_id="L1"),
+        ],
+    )
+
+
+def test_rules_engine_reports_rule_outcomes(geometry_graph: GeometryGraph) -> None:
+    engine = RulesEngine(RULE_PACK)
+    report = engine.evaluate(geometry_graph)
+
+    assert report["summary"]["total_rules"] == 3
+    assert report["summary"]["checked_entities"] == 6
+    assert report["summary"]["violations"] == 3
+
+    results_by_id = {item["rule_id"]: item for item in report["results"]}
+    assert set(results_by_id.keys()) == {
+        "min-bedroom-area",
+        "bedroom-ventilation",
+        "door-clearance",
+    }
+
+    area_result = results_by_id["min-bedroom-area"]
+    assert area_result["checked"] == 2
+    assert area_result["violations"]
+    area_violation = area_result["violations"][0]
+    assert area_violation["entity_id"] == "S1"
+    assert any("bedroom area" in message.lower() for message in area_violation["messages"])
+    area_fact = area_violation["facts"][0]
+    assert area_fact["field"] == "computed.area"
+    assert pytest.approx(area_fact["actual"], rel=1e-6) == 9.0
+    assert pytest.approx(area_fact["expected"], rel=1e-6) == 10.0
+
+    ventilation_result = results_by_id["bedroom-ventilation"]
+    ventilation_violation = ventilation_result["violations"][0]
+    assert ventilation_violation["entity_id"] == "S1"
+    assert any("window" in message.lower() for message in ventilation_violation["messages"])
+    assert ventilation_violation["facts"]
+
+    door_result = results_by_id["door-clearance"]
+    assert door_result["checked"] == 2
+    assert door_result["violations"]
+    door_violation = door_result["violations"][0]
+    assert door_violation["entity_id"] == "D1"
+    assert any("width" in message.lower() for message in door_violation["messages"])


### PR DESCRIPTION
## Summary
- add a RulePack SQLAlchemy model for storing JSON rule packs with jurisdiction metadata
- implement a predicate-driven RulesEngine that surfaces explainable violations
- expose `/api/v1/rulesets` endpoints with Pydantic schemas and tests covering engine and API flows

## Testing
- pytest backend/tests/test_core/test_rules_engine.py backend/tests/test_api/test_rulesets.py

------
https://chatgpt.com/codex/tasks/task_e_68d086a3540c8320be67a0973becd686