### PR TITLE
Add quick-look detection for DXF/IFC/PDF uploads

### DIFF
--- a/backend/app/schemas/imports.py
+++ b/backend/app/schemas/imports.py
@@ -27,9 +27,18 @@ class ImportResult(BaseModel):
         default=None, description="URI of stored vectorised geometry derived from the upload"
     )
     uploaded_at: datetime
-    layer_metadata: List[Dict[str, Any]]
-    detected_floors: List[DetectedFloor]
-    detected_units: List[str]
+    layer_metadata: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description="Layer metadata detected during upload or derived from vectorization",
+    )
+    detected_floors: List[DetectedFloor] = Field(
+        default_factory=list,
+        description="Floors detected during upload for quick-look summaries",
+    )
+    detected_units: List[str] = Field(
+        default_factory=list,
+        description="Unit identifiers detected during upload",
+    )
     vector_summary: Optional[Dict[str, Any]] = Field(
         default=None, description="Summary of extracted vector paths and inferred walls"
     )

--- a/backend/jobs/parse_cad.py
+++ b/backend/jobs/parse_cad.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import asyncio
 import json
 import math
+import os
+import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from io import BytesIO
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 from urllib.parse import urlparse
 
 try:  # pragma: no cover - optional dependency
@@ -36,7 +39,48 @@ class ParsedGeometry:
     graph: GeometryGraph
     floors: List[Dict[str, Any]]
     units: List[str]
+    layers: List[Dict[str, Any]]
     metadata: Dict[str, Any]
+
+
+@dataclass(slots=True)
+class DxfSpaceCandidate:
+    """Representation of a DXF entity that can be treated as a space."""
+
+    identifier: str
+    boundary: List[Dict[str, float]]
+    layer: Optional[str]
+
+
+@dataclass(slots=True)
+class DxfQuicklook:
+    """Summary metadata extracted from a DXF payload."""
+
+    candidates: List[DxfSpaceCandidate]
+    floors: List[Dict[str, Any]]
+    units: List[str]
+    layers: List[Dict[str, Any]]
+
+
+@dataclass(slots=True)
+class IfcSpaceCandidate:
+    """Representation of an IFC space detected within a storey."""
+
+    identifier: str
+    name: str
+    level_id: Optional[str]
+    metadata: Dict[str, Any]
+
+
+@dataclass(slots=True)
+class IfcQuicklook:
+    """Summary metadata extracted from an IFC payload."""
+
+    storeys: List[Dict[str, Any]]
+    spaces: List[IfcSpaceCandidate]
+    floors: List[Dict[str, Any]]
+    units: List[str]
+    layers: List[Dict[str, Any]]
 
 
 def _resolve_local_path(storage_path: str) -> Path:
@@ -73,6 +117,266 @@ def _ensure_unique(identifier: str, seen: Dict[str, None]) -> str:
     return identifier
 
 
+def _read_dxf_document(payload: bytes):
+    if ezdxf is None:  # pragma: no cover - optional dependency
+        raise RuntimeError("ezdxf is required to parse DXF payloads")
+    stream = BytesIO(payload)
+    if hasattr(ezdxf, "read"):
+        try:
+            stream.seek(0)
+            return ezdxf.read(stream=stream)
+        except TypeError:
+            stream.seek(0)
+            return ezdxf.read(stream)
+    stream.seek(0)
+    with tempfile.NamedTemporaryFile(suffix=".dxf", delete=False) as handle:
+        handle.write(payload)
+        tmp_name = handle.name
+    try:
+        return ezdxf.readfile(tmp_name)
+    finally:  # pragma: no cover - cleanup guard
+        try:
+            os.remove(tmp_name)
+        except OSError:
+            pass
+
+
+def _extract_dxf_layer_metadata(doc) -> List[Dict[str, Any]]:  # pragma: no cover - depends on ezdxf
+    metadata: List[Dict[str, Any]] = []
+    layers = getattr(doc, "layers", None)
+    if layers is None:
+        return metadata
+    if hasattr(layers, "names"):
+        names = layers.names()
+        getter = getattr(layers, "get", None)
+        for name in names:
+            if not name:
+                continue
+            entry: Dict[str, Any] = {"name": str(name)}
+            layer_obj = None
+            if callable(getter):
+                try:
+                    layer_obj = getter(name)
+                except Exception:  # pragma: no cover - defensive guard
+                    layer_obj = None
+            if layer_obj is not None:
+                color = getattr(layer_obj.dxf, "color", None)
+                if isinstance(color, int) and color != 0:
+                    entry["color"] = color
+                linetype = getattr(layer_obj.dxf, "linetype", None)
+                if linetype:
+                    entry["linetype"] = linetype
+            metadata.append(entry)
+    else:
+        for layer in layers:
+            dxf = getattr(layer, "dxf", layer)
+            name = getattr(dxf, "name", None)
+            if not name:
+                continue
+            entry = {"name": str(name)}
+            color = getattr(dxf, "color", None)
+            if isinstance(color, int) and color != 0:
+                entry["color"] = color
+            linetype = getattr(dxf, "linetype", None)
+            if linetype:
+                entry["linetype"] = linetype
+            metadata.append(entry)
+    return metadata
+
+
+def _collect_dxf_space_candidates(doc) -> Tuple[List[DxfSpaceCandidate], Dict[str, List[str]]]:  # pragma: no cover - depends on ezdxf
+    candidates: List[DxfSpaceCandidate] = []
+    layer_units: Dict[str, List[str]] = {}
+    modelspace = doc.modelspace()
+    for index, entity in enumerate(modelspace, start=1):
+        if entity.dxftype() != "LWPOLYLINE":
+            continue
+        points: List[Dict[str, float]] = []
+        try:
+            raw_points = entity.get_points("xy")  # type: ignore[arg-type]
+        except Exception:  # pragma: no cover - defensive guard
+            raw_points = []
+        for point in raw_points:
+            try:
+                x_val = float(point[0])
+                y_val = float(point[1])
+            except (TypeError, ValueError):  # pragma: no cover - defensive guard
+                continue
+            points.append({"x": x_val, "y": y_val})
+        if not points:
+            continue
+        space_id = f"entity-{index:03d}"
+        layer_name = str(getattr(entity.dxf, "layer", "") or "").strip() or None
+        if layer_name:
+            layer_units.setdefault(layer_name.lower(), []).append(space_id)
+        candidates.append(DxfSpaceCandidate(identifier=space_id, boundary=points, layer=layer_name))
+    return candidates, layer_units
+
+
+def _derive_dxf_floors(
+    layer_metadata: Sequence[Mapping[str, Any]],
+    unit_ids: Sequence[str],
+    layer_units: Mapping[str, List[str]],
+) -> List[Dict[str, Any]]:
+    floors: List[Dict[str, Any]] = []
+    seen_units: Dict[str, None] = {}
+    for entry in layer_metadata:
+        name_raw = entry.get("name")
+        if not isinstance(name_raw, str):
+            continue
+        layer_name = name_raw.strip()
+        if not layer_name:
+            continue
+        lower = layer_name.lower()
+        if not any(token in lower for token in ("level", "floor", "storey", "story")):
+            continue
+        units_for_layer = list(layer_units.get(lower, []))
+        for unit_id in units_for_layer:
+            if unit_id not in seen_units:
+                seen_units[unit_id] = None
+        floors.append({"name": layer_name, "unit_ids": units_for_layer})
+    if not floors:
+        floors.append({"name": "Model Space", "unit_ids": list(unit_ids)})
+        return floors
+    remaining = [unit for unit in unit_ids if unit not in seen_units]
+    if remaining:
+        floors.append({"name": "Unassigned", "unit_ids": remaining})
+    return floors
+
+
+def _prepare_dxf_quicklook(payload: bytes) -> DxfQuicklook:
+    doc = _read_dxf_document(payload)
+    layer_metadata = _extract_dxf_layer_metadata(doc)
+    candidates, layer_units = _collect_dxf_space_candidates(doc)
+    unit_ids = [candidate.identifier for candidate in candidates]
+    floors = _derive_dxf_floors(layer_metadata, unit_ids, layer_units)
+    return DxfQuicklook(candidates=candidates, floors=floors, units=unit_ids, layers=layer_metadata)
+
+
+def detect_dxf_metadata(payload: bytes) -> Tuple[List[Dict[str, Any]], List[str], List[Dict[str, Any]]]:
+    quicklook = _prepare_dxf_quicklook(payload)
+    return quicklook.floors, quicklook.units, quicklook.layers
+
+
+def _load_ifc_model(payload: bytes):
+    if ifcopenshell is None:  # pragma: no cover - optional dependency
+        raise RuntimeError("ifcopenshell is required to parse IFC payloads")
+    text = payload.decode("utf-8", errors="ignore")
+    return ifcopenshell.file.from_string(text)  # type: ignore[attr-defined]
+
+
+def _extract_ifc_layer_metadata(model) -> List[Dict[str, Any]]:  # pragma: no cover - depends on ifcopenshell
+    metadata: List[Dict[str, Any]] = []
+    try:
+        assignments = model.by_type("IfcPresentationLayerAssignment")
+    except Exception:  # pragma: no cover - defensive guard
+        assignments = []
+    seen: Dict[str, int] = {}
+    for assignment in assignments:
+        name = getattr(assignment, "Name", None) or getattr(assignment, "Description", None)
+        base_name = str(name) if name else f"Layer-{assignment.id()}"
+        candidate = base_name
+        counter = 1
+        while candidate in seen:
+            counter += 1
+            candidate = f"{base_name}-{counter}"
+        seen[candidate] = counter
+        assigned_items = getattr(assignment, "AssignedItems", []) or []
+        metadata.append(
+            {
+                "name": candidate,
+                "item_count": len(assigned_items),
+                "type": assignment.is_a() if hasattr(assignment, "is_a") else "IfcPresentationLayerAssignment",
+            }
+        )
+    return metadata
+
+
+def _prepare_ifc_quicklook(payload: bytes) -> IfcQuicklook:
+    model = _load_ifc_model(payload)
+    storeys_payload: List[Dict[str, Any]] = []
+    spaces: List[IfcSpaceCandidate] = []
+    floors_summary: List[Dict[str, Any]] = []
+    units: List[str] = []
+    seen_units: Dict[str, None] = {}
+
+    for storey in model.by_type("IfcBuildingStorey"):  # pragma: no cover - depends on ifcopenshell
+        level_id = _normalise_name(getattr(storey, "GlobalId", None), f"Level-{storey.id()}")
+        floor_name = _normalise_name(getattr(storey, "Name", None), level_id)
+        elevation_raw = getattr(storey, "Elevation", 0.0)
+        try:
+            elevation = float(elevation_raw)
+        except (TypeError, ValueError):  # pragma: no cover - defensive guard
+            elevation = 0.0
+        storeys_payload.append(
+            {
+                "id": level_id,
+                "name": floor_name,
+                "elevation": elevation,
+                "metadata": {"ifc_type": storey.is_a()} if hasattr(storey, "is_a") else {},
+            }
+        )
+
+        floor_units: List[str] = []
+        related = getattr(storey, "ContainsElements", []) or []
+        for rel in related:
+            for element in getattr(rel, "RelatedElements", []) or []:
+                if not hasattr(element, "is_a") or not element.is_a("IfcSpace"):
+                    continue
+                space_id = _normalise_name(getattr(element, "GlobalId", None), f"Space-{element.id()}")
+                if space_id not in seen_units:
+                    seen_units[space_id] = None
+                    units.append(space_id)
+                floor_units.append(space_id)
+                spaces.append(
+                    IfcSpaceCandidate(
+                        identifier=space_id,
+                        name=_normalise_name(getattr(element, "Name", None), space_id),
+                        level_id=level_id,
+                        metadata={"ifc_type": element.is_a()},
+                    )
+                )
+        floors_summary.append({"name": floor_name, "unit_ids": floor_units})
+
+    for element in model.by_type("IfcSpace"):  # pragma: no cover - depends on ifcopenshell
+        if not hasattr(element, "is_a") or not element.is_a("IfcSpace"):
+            continue
+        space_id = _normalise_name(getattr(element, "GlobalId", None), f"Space-{element.id()}")
+        if space_id in seen_units:
+            continue
+        seen_units[space_id] = None
+        units.append(space_id)
+        spaces.append(
+            IfcSpaceCandidate(
+                identifier=space_id,
+                name=_normalise_name(getattr(element, "Name", None), space_id),
+                level_id=None,
+                metadata={"ifc_type": element.is_a()},
+            )
+        )
+
+    if not floors_summary and units:
+        floors_summary.append({"name": "Default Storey", "unit_ids": list(units)})
+    else:
+        orphan_units = [space.identifier for space in spaces if space.level_id is None]
+        if orphan_units:
+            floors_summary.append({"name": "Unassigned", "unit_ids": orphan_units})
+
+    layer_metadata = _extract_ifc_layer_metadata(model)
+    return IfcQuicklook(
+        storeys=storeys_payload,
+        spaces=spaces,
+        floors=floors_summary,
+        units=units,
+        layers=layer_metadata,
+    )
+
+
+def detect_ifc_metadata(payload: bytes) -> Tuple[List[Dict[str, Any]], List[str], List[Dict[str, Any]]]:
+    quicklook = _prepare_ifc_quicklook(payload)
+    return quicklook.floors, quicklook.units, quicklook.layers
+
+
 def _estimate_space_geometry(offset_x: float, offset_y: float, area: Optional[float]) -> List[Dict[str, float]]:
     side = max(math.sqrt(area) if area and area > 0 else 4.0, 3.0)
     width = side
@@ -92,10 +396,13 @@ def _build_graph_from_floorplan(data: Mapping[str, Any]) -> ParsedGeometry:
     seen_units: Dict[str, None] = {}
 
     raw_layers = data.get("layers") if isinstance(data.get("layers"), Sequence) else []
+    layer_metadata: List[Dict[str, Any]] = []
     floor_layers: List[Mapping[str, Any]] = []
     for item in raw_layers:  # type: ignore[assignment]
         if not isinstance(item, Mapping):
             continue
+        layer_payload = dict(item)
+        layer_metadata.append(layer_payload)
         layer_type = str(item.get("type", "")).lower()
         if layer_type in {"floor", "level", "storey", "story"}:
             floor_layers.append(item)
@@ -167,7 +474,12 @@ def _build_graph_from_floorplan(data: Mapping[str, Any]) -> ParsedGeometry:
         graph=builder.graph,
         floors=floors_summary,
         units=unit_ids,
-        metadata={"source": "json_floorplan", "floors": len(floors_summary)},
+        layers=layer_metadata,
+        metadata={
+            "source": "json_floorplan",
+            "floors": len(floors_summary),
+            "layers": len(layer_metadata),
+        },
     )
 
 
@@ -182,83 +494,99 @@ def _parse_json_payload(data: Mapping[str, Any]) -> ParsedGeometry:
         graph=graph,
         floors=[{"name": level.name or level.id, "unit_ids": []} for level in graph.levels.values()],
         units=list(graph.spaces.keys()),
+        layers=[],
         metadata={"source": "json_geometry", "floors": len(graph.levels)},
     )
 
 
 def _parse_dxf_payload(payload: bytes) -> ParsedGeometry:
-    if ezdxf is None:  # pragma: no cover - optional dependency
-        raise RuntimeError("ezdxf is required to parse DXF payloads")
-    doc = ezdxf.read(stream=payload) if hasattr(ezdxf, "read") else ezdxf.readfile(payload)  # type: ignore[arg-type]
-    modelspace = doc.modelspace()
+    quicklook = _prepare_dxf_quicklook(payload)
     builder = GraphBuilder.new()
     builder.add_level({"id": "L1", "name": "Model Space", "elevation": 0.0})
-    unit_ids: List[str] = []
-    floors = [{"name": "Model Space", "unit_ids": unit_ids}]
-    for index, entity in enumerate(modelspace, start=1):  # pragma: no cover - depends on ezdxf
-        if entity.dxftype() != "LWPOLYLINE":
-            continue
-        points = [
-            {"x": float(point[0]), "y": float(point[1])}
-            for point in entity.get_points("xy")  # type: ignore[arg-type]
-        ]
-        space_id = f"entity-{index:03d}"
-        unit_ids.append(space_id)
-        builder.add_space({
-            "id": space_id,
-            "level_id": "L1",
-            "boundary": points,
-            "metadata": {"source_entity": entity.dxftype()},
-        })
+    for candidate in quicklook.candidates:  # pragma: no cover - depends on ezdxf
+        builder.add_space(
+            {
+                "id": candidate.identifier,
+                "level_id": "L1",
+                "boundary": candidate.boundary,
+                "metadata": {
+                    "source_entity": "LWPOLYLINE",
+                    "source_layer": candidate.layer,
+                },
+            }
+        )
     builder.validate_integrity()
     return ParsedGeometry(
         graph=builder.graph,
-        floors=floors,
-        units=unit_ids,
-        metadata={"source": "dxf", "entities": len(unit_ids)},
+        floors=quicklook.floors,
+        units=quicklook.units,
+        layers=quicklook.layers,
+        metadata={
+            "source": "dxf",
+            "entities": len(quicklook.units),
+            "layers": len(quicklook.layers),
+        },
     )
 
 
 def _parse_ifc_payload(payload: bytes) -> ParsedGeometry:
-    if ifcopenshell is None:  # pragma: no cover - optional dependency
-        raise RuntimeError("ifcopenshell is required to parse IFC payloads")
-    model = ifcopenshell.file.from_string(payload.decode("utf-8"))  # type: ignore[attr-defined]
+    quicklook = _prepare_ifc_quicklook(payload)
     builder = GraphBuilder.new()
-    unit_ids: List[str] = []
-    floors_summary: List[Dict[str, Any]] = []
-    for storey in model.by_type("IfcBuildingStorey"):  # pragma: no cover - depends on ifcopenshell
-        level_id = _normalise_name(storey.GlobalId, f"Level-{storey.id()}")
-        builder.add_level(
+    added_levels: Dict[str, None] = {}
+
+    for storey in quicklook.storeys:  # pragma: no cover - depends on ifcopenshell
+        level_id = storey["id"]
+        if level_id in added_levels:
+            continue
+        level_payload = {
+            "id": level_id,
+            "name": storey.get("name", level_id),
+            "elevation": float(storey.get("elevation", 0.0)),
+            "metadata": dict(storey.get("metadata", {})),
+        }
+        builder.add_level(level_payload)
+        added_levels[level_id] = None
+
+    default_level_id: Optional[str] = None
+    if not added_levels and quicklook.units:
+        default_level_id = "DefaultStorey"
+        builder.add_level({"id": default_level_id, "name": "Default Storey", "elevation": 0.0})
+        added_levels[default_level_id] = None
+
+    if any(space.level_id is None for space in quicklook.spaces):
+        default_level_id = default_level_id or "Unassigned"
+        if default_level_id not in added_levels:
+            builder.add_level({"id": default_level_id, "name": "Unassigned", "elevation": 0.0})
+            added_levels[default_level_id] = None
+
+    for candidate in quicklook.spaces:  # pragma: no cover - depends on ifcopenshell
+        level_id = candidate.level_id or default_level_id
+        if level_id is None:
+            continue
+        if level_id not in added_levels:
+            builder.add_level({"id": level_id, "name": level_id, "elevation": 0.0})
+            added_levels[level_id] = None
+        builder.add_space(
             {
-                "id": level_id,
-                "name": getattr(storey, "Name", level_id),
-                "elevation": float(getattr(storey, "Elevation", 0.0)),
+                "id": candidate.identifier,
+                "name": candidate.name,
+                "level_id": level_id,
+                "boundary": [],
+                "metadata": dict(candidate.metadata),
             }
         )
-        floor_units: List[str] = []
-        related = getattr(storey, "ContainsElements", [])
-        for rel in related:
-            for element in getattr(rel, "RelatedElements", []):
-                if element.is_a("IfcSpace"):
-                    space_id = _normalise_name(element.GlobalId, f"Space-{element.id()}")
-                    unit_ids.append(space_id)
-                    floor_units.append(space_id)
-                    builder.add_space(
-                        {
-                            "id": space_id,
-                            "name": getattr(element, "Name", space_id),
-                            "level_id": level_id,
-                            "boundary": [],
-                            "metadata": {"ifc_type": element.is_a()},
-                        }
-                    )
-        floors_summary.append({"name": getattr(storey, "Name", level_id), "unit_ids": floor_units})
+
     builder.validate_integrity()
     return ParsedGeometry(
         graph=builder.graph,
-        floors=floors_summary,
-        units=unit_ids,
-        metadata={"source": "ifc", "floors": len(floors_summary)},
+        floors=quicklook.floors,
+        units=quicklook.units,
+        layers=quicklook.layers,
+        metadata={
+            "source": "ifc",
+            "floors": len(quicklook.floors),
+            "layers": len(quicklook.layers),
+        },
     )
 
 
@@ -283,9 +611,16 @@ async def _persist_result(session, record: ImportRecord, parsed: ParsedGeometry)
         "units": len(parsed.units),
         "detected_floors": parsed.floors,
         "detected_units": parsed.units,
+        "layer_metadata": parsed.layers,
         "graph": graph_payload,
         "metadata": parsed.metadata,
     }
+    if parsed.layers:
+        record.layer_metadata = parsed.layers
+    if parsed.floors:
+        record.detected_floors = parsed.floors
+    if parsed.units:
+        record.detected_units = parsed.units
     record.parse_error = None
     record.parse_completed_at = datetime.now(timezone.utc)
     await session.commit()
@@ -316,4 +651,9 @@ async def parse_import_job(import_id: str) -> Dict[str, Any]:
             raise
 
 
-__all__ = ["parse_import_job", "ParsedGeometry"]
+__all__ = [
+    "parse_import_job",
+    "ParsedGeometry",
+    "detect_dxf_metadata",
+    "detect_ifc_metadata",
+]

--- a/backend/tests/test_api/test_imports.py
+++ b/backend/tests/test_api/test_imports.py
@@ -18,6 +18,7 @@ from app.services.storage import get_storage_service
 from jobs import job_queue
 
 SAMPLES_DIR = Path(__file__).resolve().parent.parent / "samples"
+GLOBAL_SAMPLES_DIR = Path(__file__).resolve().parents[3] / "samples"
 
 
 @pytest.mark.asyncio
@@ -71,6 +72,47 @@ async def test_upload_import_persists_metadata(
         / f"{payload['filename']}.vectors.json"
     )
     assert not vector_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_upload_dxf_emits_detection(client: AsyncClient) -> None:
+    pytest.importorskip("ezdxf", reason="ezdxf is required for DXF detection")
+
+    sample_path = GLOBAL_SAMPLES_DIR / "dxf" / "flat_two_bed.dxf"
+    with sample_path.open("rb") as handle:
+        response = await client.post(
+            "/api/v1/import",
+            files={"file": (sample_path.name, handle, "application/dxf")},
+        )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["detected_units"]
+    assert len(payload["detected_units"]) == 2
+    assert payload["layer_metadata"]
+    layer_names = {entry["name"].upper() for entry in payload["layer_metadata"]}
+    assert {"LEVEL_01", "LEVEL_02"}.issubset(layer_names)
+    floor_names = {floor["name"].upper() for floor in payload["detected_floors"]}
+    assert {"LEVEL_01", "LEVEL_02"}.issubset(floor_names)
+
+
+@pytest.mark.asyncio
+async def test_upload_ifc_surfaces_storeys(client: AsyncClient) -> None:
+    pytest.importorskip("ifcopenshell", reason="ifcopenshell is required for IFC detection")
+
+    sample_path = GLOBAL_SAMPLES_DIR / "ifc" / "office_small.ifc"
+    with sample_path.open("rb") as handle:
+        response = await client.post(
+            "/api/v1/import",
+            files={"file": (sample_path.name, handle, "application/octet-stream")},
+        )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["detected_units"]
+    assert len(payload["detected_units"]) == 3
+    floor_names = {floor["name"] for floor in payload["detected_floors"]}
+    assert {"Ground Floor", "Level 02"}.issubset(floor_names)
 
 
 @pytest.mark.asyncio
@@ -136,6 +178,9 @@ async def test_upload_pdf_vectorizes_when_enabled(
     assert payload["vector_summary"] is not None
     assert payload["vector_summary"]["options"]["requested"] is True
     assert payload["vector_summary"]["options"]["infer_walls"] is True
+    assert payload["layer_metadata"]
+    vector_layers = {entry["name"] for entry in payload["layer_metadata"]}
+    assert {"0", "1"}.issubset(vector_layers)
 
     storage_service = get_storage_service()
     vector_path = (

--- a/backend/tests/test_jobs/test_parse_cad_samples.py
+++ b/backend/tests/test_jobs/test_parse_cad_samples.py
@@ -25,6 +25,7 @@ def test_ifc_sample_detects_multiple_storeys() -> None:
     assert {"Ground Floor", "Level 02"} <= floor_names
     assert len(parsed.units) == 3
     assert parsed.metadata["source"] == "ifc"
+    assert isinstance(parsed.layers, list)
 
 
 def test_dxf_sample_exposes_layered_units() -> None:
@@ -38,6 +39,9 @@ def test_dxf_sample_exposes_layered_units() -> None:
 
     assert len(parsed.units) == 2
     assert parsed.metadata["entities"] == 2
+    assert parsed.layers
+    parsed_layer_names = {entry["name"].upper() for entry in parsed.layers}
+    assert {"LEVEL_01", "LEVEL_02"}.issubset(parsed_layer_names)
 
     import ezdxf  # type: ignore  # noqa: WPS433
 


### PR DESCRIPTION
## Summary
- extend the CAD parsing job with reusable DXF/IFC quick-look helpers that capture floors, units, and layer metadata
- switch the import API to run format-aware detectors, derive PDF layers from vectorization, and fall back to parse metadata when summarising
- update import schemas and tests to expect populated detections for the bundled DXF, IFC, and PDF samples

## Testing
- pytest backend/tests/test_api/test_imports.py
- pytest backend/tests/test_jobs/test_parse_cad_samples.py

------
https://chatgpt.com/codex/tasks/task_e_68d0c6fdeb9c8320a85d958b0d8e1911