### PR TITLE
Add buildable screening seed data loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ build: ## Build production images
 init-db: ## Initialize database
 	docker-compose exec backend alembic upgrade head
 
-seed-data: ## Seed initial data
-	docker-compose exec backend python scripts/seed-data.py
+seed-data: ## Seed screening reference data for buildable overlays
+        docker-compose exec backend python -m scripts.seed_screening
 
 logs: ## Show application logs
 	docker-compose logs -f backend frontend

--- a/backend/scripts/__init__.py
+++ b/backend/scripts/__init__.py
@@ -1,3 +1,5 @@
 """Utility command modules for backend workflows."""
 
-__all__ = []
+from .seed_screening import SeedSummary, seed_screening_sample_data
+
+__all__ = ["SeedSummary", "seed_screening_sample_data"]


### PR DESCRIPTION
## Summary
- add a reusable `scripts.seed_screening` utility that seeds sample parcels, geocodes, and zoning layers for the buildable screening flow
- expose the seeding helper via the scripts package and wire it into the `seed-data` Makefile target for local environments
- refactor API tests to seed reference data through the shared loader and make the review test compatible with the lightweight SQLAlchemy stub

## Testing
- `cd backend && pytest tests/test_api/test_rules.py`


------
https://chatgpt.com/codex/tasks/task_e_68d0d153d038832086ca20c9a1012785