### PR TITLE
Add configurable buildable defaults and metrics

### DIFF
--- a/backend/app/api/v1/screen.py
+++ b/backend/app/api/v1/screen.py
@@ -2,24 +2,55 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.database import get_session
 from app.models.rkp import RefGeocodeCache, RefParcel, RefZoningLayer
+from app.services.buildable import BuildableMetrics, calculate_buildable_metrics
 
 
 router = APIRouter(prefix="/screen")
 
 
+DEFAULT_PLOT_RATIO = 3.5
+
+
+@dataclass(slots=True)
+class SiteContext:
+    """Resolved parcel and geometry context for buildable calculations."""
+
+    zone_code: Optional[str]
+    site_area_sqm: Optional[float]
+    floorplate_sqm: Optional[float]
+    max_height_m: Optional[float]
+    plot_ratio: Optional[float]
+
 class BuildableRequest(BaseModel):
     address: Optional[str] = None
     geometry: Optional[Dict[str, object]] = None
     project_type: Optional[str] = None
+    typ_floor_to_floor_m: float = Field(
+        default_factory=lambda: settings.BUILDABLE_TYP_FLOOR_TO_FLOOR_M
+    )
+    efficiency_ratio: float = Field(
+        default_factory=lambda: settings.BUILDABLE_EFFICIENCY_RATIO
+    )
+
+    @model_validator(mode="before")
+    def _populate_metric_defaults(cls, data: object) -> object:
+        if isinstance(data, dict):
+            if data.get("typ_floor_to_floor_m") is None:
+                data["typ_floor_to_floor_m"] = settings.BUILDABLE_TYP_FLOOR_TO_FLOOR_M
+            if data.get("efficiency_ratio") is None:
+                data["efficiency_ratio"] = settings.BUILDABLE_EFFICIENCY_RATIO
+        return data
 
     @model_validator(mode="after")
     def _validate_payload(cls, values: "BuildableRequest") -> "BuildableRequest":
@@ -33,42 +64,112 @@ async def screen_buildable(
     payload: BuildableRequest,
     session: AsyncSession = Depends(get_session),
 ) -> Dict[str, object]:
-    zone_code = await _resolve_zone_code(session, payload)
+    context = await _resolve_site_context(session, payload)
+    zone_code = context.zone_code
     overlays: List[str] = []
     hints: List[str] = []
+    zoning_layers: List[RefZoningLayer] = []
     if zone_code:
-        zoning_lookup = await _load_layers_for_zone(session, zone_code)
-        for layer in zoning_lookup:
+        zoning_layers = await _load_layers_for_zone(session, zone_code)
+        for layer in zoning_layers:
             attributes = layer.attributes or {}
             overlays.extend(attributes.get("overlays", []))
             hints.extend(attributes.get("advisory_hints", []))
     overlays = list(dict.fromkeys(filter(None, overlays)))
     hints = list(dict.fromkeys(filter(None, hints)))
+
+    plot_ratio = context.plot_ratio
+    if plot_ratio is None:
+        plot_ratio = _determine_plot_ratio(zoning_layers) or DEFAULT_PLOT_RATIO
+
+    buildable_metrics: Optional[BuildableMetrics] = None
+    if context.site_area_sqm and context.site_area_sqm > 0:
+        buildable_metrics = calculate_buildable_metrics(
+            site_area_sqm=context.site_area_sqm,
+            plot_ratio=plot_ratio,
+            typ_floor_to_floor_m=payload.typ_floor_to_floor_m,
+            efficiency_ratio=payload.efficiency_ratio,
+            floorplate_sqm=context.floorplate_sqm,
+            max_height_m=context.max_height_m,
+        )
+
     return {
         "input_kind": "address" if payload.address else "geometry",
         "zone_code": zone_code,
         "overlays": overlays,
         "advisory_hints": hints,
+        "buildable_metrics": buildable_metrics.as_dict() if buildable_metrics else None,
     }
 
 
-async def _resolve_zone_code(
+async def _resolve_site_context(
     session: AsyncSession, payload: BuildableRequest
-) -> Optional[str]:
+) -> SiteContext:
+    zone_code: Optional[str] = None
+    site_area: Optional[float] = None
+    floorplate: Optional[float] = None
+    max_height: Optional[float] = None
+    plot_ratio: Optional[float] = None
+
     if payload.address:
         stmt = select(RefGeocodeCache).where(RefGeocodeCache.address == payload.address)
         geocode = (await session.execute(stmt)).scalar_one_or_none()
         if geocode and geocode.parcel_id:
             parcel = await session.get(RefParcel, geocode.parcel_id)
             if parcel and isinstance(parcel.bounds_json, dict):
-                zone_code = parcel.bounds_json.get("zone_code")
-                if zone_code:
-                    return str(zone_code)
+                zone = parcel.bounds_json.get("zone_code")
+                if zone:
+                    zone_code = str(zone)
+            if parcel and parcel.area_m2 is not None:
+                try:
+                    site_area = float(parcel.area_m2)
+                    floorplate = site_area
+                except (TypeError, ValueError):
+                    site_area = None
     if payload.geometry and isinstance(payload.geometry, dict):
         properties = payload.geometry.get("properties")
-        if isinstance(properties, dict) and properties.get("zone_code"):
-            return str(properties["zone_code"])
-    return None
+        if isinstance(properties, dict):
+            if zone_code is None and properties.get("zone_code"):
+                zone_code = str(properties["zone_code"])
+            if plot_ratio is None:
+                plot_ratio = _first_numeric(
+                    properties,
+                    "plot_ratio",
+                    "gross_plot_ratio",
+                    "max_plot_ratio",
+                    "far",
+                )
+            if site_area is None:
+                site_area = _first_numeric(
+                    properties,
+                    "site_area_sqm",
+                    "site_area",
+                    "area_sqm",
+                )
+            if floorplate is None:
+                floorplate = _first_numeric(
+                    properties,
+                    "floorplate_sqm",
+                    "avg_floorplate_sqm",
+                )
+            if max_height is None:
+                max_height = _first_numeric(
+                    properties,
+                    "max_height_m",
+                    "height_limit_m",
+                    "height_m",
+                )
+
+    if floorplate is None and site_area is not None:
+        floorplate = site_area
+
+    return SiteContext(
+        zone_code=zone_code,
+        site_area_sqm=site_area,
+        floorplate_sqm=floorplate,
+        max_height_m=max_height,
+        plot_ratio=plot_ratio,
+    )
 
 
 async def _load_layers_for_zone(
@@ -77,6 +178,41 @@ async def _load_layers_for_zone(
     stmt = select(RefZoningLayer).where(RefZoningLayer.zone_code == zone_code)
     result = await session.execute(stmt)
     return list(result.scalars().all())
+
+
+def _first_numeric(data: Dict[str, object], *keys: str) -> Optional[float]:
+    for key in keys:
+        if key in data:
+            numeric = _safe_float(data.get(key))
+            if numeric is not None:
+                return numeric
+    return None
+
+
+def _safe_float(value: object) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _determine_plot_ratio(layers: List[RefZoningLayer]) -> Optional[float]:
+    for layer in layers:
+        attributes = layer.attributes or {}
+        numeric = _first_numeric(
+            attributes,
+            "plot_ratio",
+            "gross_plot_ratio",
+            "max_plot_ratio",
+            "far",
+        )
+        if numeric is not None:
+            return numeric
+    return None
 
 
 __all__ = ["router"]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -53,6 +53,18 @@ def _load_allowed_hosts() -> List[str]:
     return list(dict.fromkeys(hosts))
 
 
+def _load_float(name: str, default: float) -> float:
+    """Load a floating point configuration value from the environment."""
+
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 def _derive_redis_url(base_url: str, db: int) -> str:
     """Return ``base_url`` pointing at a specific Redis database index.
 
@@ -110,6 +122,9 @@ class Settings:
     ALLOWED_ORIGINS: List[str]
 
     LOG_LEVEL: str
+
+    BUILDABLE_TYP_FLOOR_TO_FLOOR_M: float
+    BUILDABLE_EFFICIENCY_RATIO: float
 
     def __init__(self) -> None:
         self.PROJECT_NAME = os.getenv("PROJECT_NAME", "Building Compliance Platform")
@@ -171,6 +186,13 @@ class Settings:
         self.ALLOWED_ORIGINS = _load_allowed_origins()
 
         self.LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+
+        self.BUILDABLE_TYP_FLOOR_TO_FLOOR_M = _load_float(
+            "BUILDABLE_TYP_FLOOR_TO_FLOOR_M", 3.6
+        )
+        self.BUILDABLE_EFFICIENCY_RATIO = _load_float(
+            "BUILDABLE_EFFICIENCY_RATIO", 0.82
+        )
 
 
 settings = Settings()

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -2,6 +2,7 @@
 
 from . import (  # noqa: F401
     alerts,
+    buildable,
     costs,
     ingestion,
     normalize,
@@ -14,6 +15,7 @@ from . import (  # noqa: F401
 
 __all__ = [
     "alerts",
+    "buildable",
     "costs",
     "ingestion",
     "normalize",

--- a/backend/app/services/buildable.py
+++ b/backend/app/services/buildable.py
@@ -1,0 +1,105 @@
+"""Buildable envelope calculation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Dict, Optional
+
+
+_DECIMAL_ONE = Decimal("1")
+_DECIMAL_TWO_PLACES = Decimal("0.01")
+
+
+def _round_half_up(value: float) -> int:
+    """Round positive values using the half-up strategy."""
+
+    return int(Decimal(value).quantize(_DECIMAL_ONE, rounding=ROUND_HALF_UP))
+
+
+def _round_height(value: float) -> float:
+    """Round height measurements to two decimal places."""
+
+    return float(Decimal(value).quantize(_DECIMAL_TWO_PLACES, rounding=ROUND_HALF_UP))
+
+
+@dataclass(slots=True)
+class BuildableMetrics:
+    """Summary of buildable area calculations."""
+
+    site_area_sqm: float
+    plot_ratio: float
+    assumed_floorplate_sqm: float
+    gross_floor_area_sqm: int
+    net_floor_area_sqm: int
+    estimated_storeys: int
+    estimated_height_m: float
+    efficiency_ratio: float
+    typ_floor_to_floor_m: float
+
+    def as_dict(self) -> Dict[str, float | int]:
+        """Serialise the metrics for API responses."""
+
+        return {
+            "site_area_sqm": self.site_area_sqm,
+            "plot_ratio": self.plot_ratio,
+            "assumed_floorplate_sqm": self.assumed_floorplate_sqm,
+            "gross_floor_area_sqm": self.gross_floor_area_sqm,
+            "net_floor_area_sqm": self.net_floor_area_sqm,
+            "estimated_storeys": self.estimated_storeys,
+            "estimated_height_m": self.estimated_height_m,
+            "efficiency_ratio": self.efficiency_ratio,
+            "typ_floor_to_floor_m": self.typ_floor_to_floor_m,
+        }
+
+
+def calculate_buildable_metrics(
+    *,
+    site_area_sqm: float,
+    plot_ratio: float,
+    efficiency_ratio: float,
+    typ_floor_to_floor_m: float,
+    floorplate_sqm: Optional[float] = None,
+    max_height_m: Optional[float] = None,
+) -> BuildableMetrics:
+    """Calculate buildable area metrics for the supplied parameters."""
+
+    if site_area_sqm <= 0:
+        raise ValueError("site_area_sqm must be positive")
+    if plot_ratio <= 0:
+        raise ValueError("plot_ratio must be positive")
+    if efficiency_ratio <= 0:
+        raise ValueError("efficiency_ratio must be positive")
+    if typ_floor_to_floor_m <= 0:
+        raise ValueError("typ_floor_to_floor_m must be positive")
+
+    floorplate = floorplate_sqm if floorplate_sqm and floorplate_sqm > 0 else site_area_sqm
+
+    gross_floor_area = site_area_sqm * plot_ratio
+    storeys_by_gfa = max(1, _round_half_up(gross_floor_area / floorplate))
+
+    if max_height_m is not None and max_height_m > 0:
+        height_based_storeys = max(1, int(max_height_m / typ_floor_to_floor_m))
+        estimated_storeys = min(storeys_by_gfa, height_based_storeys)
+    else:
+        estimated_storeys = storeys_by_gfa
+
+    achievable_gross = min(gross_floor_area, estimated_storeys * floorplate)
+    gross_int = _round_half_up(achievable_gross)
+    net_int = _round_half_up(achievable_gross * efficiency_ratio)
+    estimated_height = _round_height(estimated_storeys * typ_floor_to_floor_m)
+
+    return BuildableMetrics(
+        site_area_sqm=float(site_area_sqm),
+        plot_ratio=float(plot_ratio),
+        assumed_floorplate_sqm=float(floorplate),
+        gross_floor_area_sqm=gross_int,
+        net_floor_area_sqm=net_int,
+        estimated_storeys=estimated_storeys,
+        estimated_height_m=estimated_height,
+        efficiency_ratio=float(efficiency_ratio),
+        typ_floor_to_floor_m=float(typ_floor_to_floor_m),
+    )
+
+
+__all__ = ["BuildableMetrics", "calculate_buildable_metrics"]

--- a/backend/tests/test_services/test_buildable.py
+++ b/backend/tests/test_services/test_buildable.py
@@ -1,0 +1,75 @@
+"""Tests for the buildable envelope calculator."""
+
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_UP
+
+import pytest
+
+from app.core.config import settings
+from app.services.buildable import calculate_buildable_metrics
+
+
+def _round_half_up(value: float) -> int:
+    return int(Decimal(value).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+
+def test_calculator_uses_default_parameters() -> None:
+    """Default configuration values are applied when no overrides are supplied."""
+
+    metrics = calculate_buildable_metrics(
+        site_area_sqm=1250.0,
+        plot_ratio=3.5,
+        typ_floor_to_floor_m=settings.BUILDABLE_TYP_FLOOR_TO_FLOOR_M,
+        efficiency_ratio=settings.BUILDABLE_EFFICIENCY_RATIO,
+    )
+
+    expected_gross = _round_half_up(1250.0 * 3.5)
+    expected_net = _round_half_up(expected_gross * settings.BUILDABLE_EFFICIENCY_RATIO)
+
+    assert metrics.gross_floor_area_sqm == expected_gross
+    assert metrics.net_floor_area_sqm == expected_net
+    assert metrics.estimated_storeys == _round_half_up(expected_gross / 1250.0)
+    assert metrics.estimated_height_m == pytest.approx(
+        metrics.estimated_storeys * settings.BUILDABLE_TYP_FLOOR_TO_FLOOR_M
+    )
+    assert metrics.efficiency_ratio == settings.BUILDABLE_EFFICIENCY_RATIO
+    assert metrics.typ_floor_to_floor_m == settings.BUILDABLE_TYP_FLOOR_TO_FLOOR_M
+
+
+def test_calculator_honours_explicit_overrides() -> None:
+    """Explicit overrides take precedence over configuration defaults."""
+
+    metrics = calculate_buildable_metrics(
+        site_area_sqm=950.0,
+        plot_ratio=2.8,
+        typ_floor_to_floor_m=3.2,
+        efficiency_ratio=0.73,
+        floorplate_sqm=500.0,
+        max_height_m=15.0,
+    )
+
+    assert metrics.estimated_storeys == 4
+    assert metrics.gross_floor_area_sqm == 2000
+    assert metrics.net_floor_area_sqm == _round_half_up(2000 * 0.73)
+    assert metrics.estimated_height_m == pytest.approx(12.8)
+    assert metrics.typ_floor_to_floor_m == pytest.approx(3.2)
+    assert metrics.efficiency_ratio == pytest.approx(0.73)
+
+
+def test_calculator_limits_by_height() -> None:
+    """Height limits reduce achievable gross floor area when restrictive."""
+
+    metrics = calculate_buildable_metrics(
+        site_area_sqm=900.0,
+        plot_ratio=4.0,
+        typ_floor_to_floor_m=3.0,
+        efficiency_ratio=0.75,
+        floorplate_sqm=600.0,
+        max_height_m=5.0,
+    )
+
+    assert metrics.estimated_storeys == 1
+    assert metrics.gross_floor_area_sqm == 600
+    assert metrics.net_floor_area_sqm == _round_half_up(600 * 0.75)
+    assert metrics.estimated_height_m == pytest.approx(3.0)

--- a/ui-admin/src/api/client.ts
+++ b/ui-admin/src/api/client.ts
@@ -41,7 +41,13 @@ export const ReviewAPI = {
     }),
   getDiffs: (ruleId?: number) =>
     fetchJson<{ items: DiffRecord[] }>(ruleId ? `/review/diffs?rule_id=${ruleId}` : '/review/diffs'),
-  screenBuildable: (payload: { address?: string; geometry?: object }) =>
+  screenBuildable: (payload: {
+    address?: string;
+    geometry?: object;
+    project_type?: string;
+    typ_floor_to_floor_m?: number;
+    efficiency_ratio?: number;
+  }) =>
     fetchJson<BuildableScreeningResponse>('/screen/buildable', {
       method: 'POST',
       body: JSON.stringify(payload)

--- a/ui-admin/src/types.ts
+++ b/ui-admin/src/types.ts
@@ -60,6 +60,19 @@ export interface BuildableScreeningResponse {
   zone_code: string | null;
   overlays: string[];
   advisory_hints: string[];
+  buildable_metrics: BuildableMetrics | null;
+}
+
+export interface BuildableMetrics {
+  site_area_sqm: number;
+  plot_ratio: number;
+  assumed_floorplate_sqm: number;
+  gross_floor_area_sqm: number;
+  net_floor_area_sqm: number;
+  estimated_storeys: number;
+  estimated_height_m: number;
+  efficiency_ratio: number;
+  typ_floor_to_floor_m: number;
 }
 
 export interface ProductRecord {


### PR DESCRIPTION
## Summary
- add BUILDABLE_TYP_FLOOR_TO_FLOOR_M and BUILDABLE_EFFICIENCY_RATIO settings and apply them as defaults for buildable requests
- introduce a buildable calculator service and expose its metrics from the screen/buildable endpoint
- update API/client types and tests to cover the new defaults, overrides, and deterministic calculations

## Testing
- pytest backend/tests/test_services/test_buildable.py backend/tests/test_api/test_rules.py

------
https://chatgpt.com/codex/tasks/task_e_68d0fa75a3e08320a424175f7ce5a95b