### PR TITLE
Add configurable buildable calculation defaults

### DIFF
--- a/backend/app/api/v1/screen.py
+++ b/backend/app/api/v1/screen.py
@@ -51,6 +51,8 @@ async def screen_buildable(
         session=session,
         resolved=resolved,
         defaults=payload.defaults,
+        typ_floor_to_floor_m=payload.typ_floor_to_floor_m,
+        efficiency_ratio=payload.efficiency_ratio,
     )
     return BuildableResponse(
         input_kind=resolution.input_kind,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -10,6 +10,34 @@ _DEFAULT_ALLOWED_ORIGINS = ("http://localhost:3000", "http://localhost:5173")
 _DEFAULT_ALLOWED_HOSTS = ("localhost", "127.0.0.1")
 
 
+def _load_positive_float(name: str, default: float) -> float:
+    """Return a positive floating point value from the environment."""
+
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    try:
+        candidate = float(raw_value)
+    except (TypeError, ValueError):
+        return default
+    return candidate if candidate > 0 else default
+
+
+def _load_fractional_float(name: str, default: float) -> float:
+    """Return a fractional floating point value between 0 and 1."""
+
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    try:
+        candidate = float(raw_value)
+    except (TypeError, ValueError):
+        return default
+    if 0 < candidate <= 1:
+        return candidate
+    return default
+
+
 def _load_allowed_origins() -> List[str]:
     """Retrieve allowed CORS origins from the environment."""
 
@@ -111,6 +139,9 @@ class Settings:
 
     LOG_LEVEL: str
 
+    BUILDABLE_TYP_FLOOR_TO_FLOOR_M: float
+    BUILDABLE_EFFICIENCY_RATIO: float
+
     def __init__(self) -> None:
         self.PROJECT_NAME = os.getenv("PROJECT_NAME", "Building Compliance Platform")
         self.VERSION = os.getenv("PROJECT_VERSION", "1.0.0")
@@ -171,6 +202,13 @@ class Settings:
         self.ALLOWED_ORIGINS = _load_allowed_origins()
 
         self.LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+
+        self.BUILDABLE_TYP_FLOOR_TO_FLOOR_M = _load_positive_float(
+            "BUILDABLE_TYP_FLOOR_TO_FLOOR_M", 4.0
+        )
+        self.BUILDABLE_EFFICIENCY_RATIO = _load_fractional_float(
+            "BUILDABLE_EFFICIENCY_RATIO", 0.82
+        )
 
 
 settings = Settings()

--- a/backend/tests/test_api/test_rules.py
+++ b/backend/tests/test_api/test_rules.py
@@ -175,3 +175,18 @@ async def test_rule_review_publish_action(client: AsyncClient, async_session_fac
             == "Provide 1.5 parking spaces per unit; maximum ramp slope 1:12"
         )
         assert rule.review_notes == "Ready"
+
+
+@pytest.mark.asyncio
+async def test_buildable_screening_respects_efficiency_override(
+    client: AsyncClient,
+) -> None:
+    response = await client.post(
+        "/api/v1/screen/buildable",
+        json={"address": "123 Example Ave", "efficiency_ratio": 0.5},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    metrics = payload["metrics"]
+    assert metrics["gfa_cap_m2"] == 4375
+    assert metrics["nsa_est_m2"] == 2188

--- a/backend/tests/test_services/test_buildable.py
+++ b/backend/tests/test_services/test_buildable.py
@@ -1,0 +1,52 @@
+"""Tests for buildable capacity calculations."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("pytest_asyncio")
+
+from app.schemas.buildable import BuildableDefaults
+from app.services.buildable import ResolvedZone, calculate_buildable
+
+
+class _LayerStub:
+    """Lightweight stand-in for a zoning layer."""
+
+    def __init__(self, attributes: dict[str, float]) -> None:
+        self.attributes = attributes
+        self.layer_name = "TestLayer"
+        self.jurisdiction = "SG"
+
+
+@pytest.mark.asyncio
+async def test_calculate_buildable_honours_overrides(async_session_factory) -> None:
+    defaults = BuildableDefaults(
+        plot_ratio=2.5,
+        site_area_m2=900.0,
+        site_coverage=0.25,
+        floor_height_m=4.0,
+        efficiency_factor=0.8,
+    )
+    resolved = ResolvedZone(
+        zone_code=None,
+        parcel=None,
+        zone_layers=[_LayerStub({"height_m": 30.0})],
+        input_kind="geometry",
+    )
+
+    async with async_session_factory() as session:
+        baseline = await calculate_buildable(session, resolved, defaults)
+        assert baseline.metrics.floors_max == 7
+        assert baseline.metrics.nsa_est_m2 == 1800
+
+        overrides = await calculate_buildable(
+            session,
+            resolved,
+            defaults,
+            typ_floor_to_floor_m=5.0,
+            efficiency_ratio=0.65,
+        )
+        assert overrides.metrics.floors_max == 6
+        assert overrides.metrics.nsa_est_m2 == 1463


### PR DESCRIPTION
## Summary
- add configuration options for typical floor-to-floor height and efficiency ratio used by buildable screening
- extend the buildable request and service to honour explicit overrides while falling back to configured defaults
- cover the new behaviour with API and service tests

## Testing
- pytest backend/tests/test_api/test_rules.py backend/tests/test_services/test_buildable.py

------
https://chatgpt.com/codex/tasks/task_e_68d0fe6655b88320888b8b188546e442