### PR TITLE
Apply approved zoning rule overrides in buildable metrics

### DIFF
--- a/backend/tests/test_api/test_rules.py
+++ b/backend/tests/test_api/test_rules.py
@@ -63,6 +63,7 @@ async def _seed_reference_data(async_session_factory) -> None:
             unit="spaces_per_unit",
             applicability={"zone_code": "R2"},
             notes="Provide 1.5 parking spaces per unit; maximum ramp slope 1:12",
+            review_status="approved",
         )
         session.add(rule)
 

--- a/backend/tests/test_services/test_buildable.py
+++ b/backend/tests/test_services/test_buildable.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-pytest.importorskip("sqlalchemy")
-pytest.importorskip("pytest_asyncio")
-
+from app.models.rkp import RefRule
 from app.schemas.buildable import BuildableDefaults
 from app.services.buildable import ResolvedZone, calculate_buildable
+
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("pytest_asyncio")
 
 
 class _LayerStub:
@@ -50,3 +51,147 @@ async def test_calculate_buildable_honours_overrides(async_session_factory) -> N
         )
         assert overrides.metrics.floors_max == 6
         assert overrides.metrics.nsa_est_m2 == 1463
+
+
+@pytest.mark.asyncio
+async def test_calculate_buildable_applies_rule_overrides(session) -> None:
+    defaults = BuildableDefaults(
+        plot_ratio=2.0,
+        site_area_m2=800.0,
+        site_coverage=0.3,
+        floor_height_m=3.5,
+        efficiency_factor=0.7,
+    )
+    resolved = ResolvedZone(
+        zone_code="R-OVR",
+        parcel=None,
+        zone_layers=[
+            _LayerStub(
+                {
+                    "plot_ratio": 1.8,
+                    "site_coverage_percent": 40,
+                    "height_m": 12.0,
+                    "floors_max": 4,
+                }
+            )
+        ],
+        input_kind="geometry",
+    )
+
+    approved_rules = [
+        RefRule(
+            jurisdiction="SG",
+            authority="URA",
+            topic="zoning",
+            parameter_key="zoning.max_far",
+            operator="<=",
+            value="4.2",
+            applicability={"zone_code": "R-OVR"},
+            review_status="approved",
+        ),
+        RefRule(
+            jurisdiction="SG",
+            authority="URA",
+            topic="zoning",
+            parameter_key="zoning.site_coverage.max_percent",
+            operator="<=",
+            value="65%",
+            unit="percent",
+            applicability={"zone_code": "R-OVR"},
+            review_status="approved",
+        ),
+        RefRule(
+            jurisdiction="SG",
+            authority="URA",
+            topic="zoning",
+            parameter_key="zoning.max_building_height_m",
+            operator="<=",
+            value="24",
+            unit="m",
+            applicability={"zone_code": "R-OVR"},
+            review_status="approved",
+        ),
+        RefRule(
+            jurisdiction="SG",
+            authority="URA",
+            topic="zoning",
+            parameter_key="zoning.max_building_height_m",
+            operator="<=",
+            value="8",
+            unit="storeys",
+            applicability={"zone_code": "R-OVR"},
+            review_status="approved",
+        ),
+        RefRule(
+            jurisdiction="SG",
+            authority="URA",
+            topic="zoning",
+            parameter_key="zoning.setback.front_min_m",
+            operator=">=",
+            value="7.5",
+            unit="m",
+            applicability={"zone_code": "R-OVR"},
+            review_status="approved",
+        ),
+    ]
+
+    session.add_all(approved_rules)
+    await session.flush()
+
+    calculation = await calculate_buildable(session, resolved, defaults)
+
+    metrics = calculation.metrics
+    assert metrics.gfa_cap_m2 == 3360
+    assert metrics.footprint_m2 == 520
+    assert metrics.floors_max == 6
+    assert metrics.nsa_est_m2 == 2352
+    assert len(calculation.rules) == len(approved_rules)
+
+
+@pytest.mark.asyncio
+async def test_calculate_buildable_ignores_unapproved_rules(session) -> None:
+    defaults = BuildableDefaults(
+        plot_ratio=2.2,
+        site_area_m2=1000.0,
+        site_coverage=0.4,
+        floor_height_m=3.0,
+        efficiency_factor=0.75,
+    )
+    resolved = ResolvedZone(
+        zone_code="R-NOAPP",
+        parcel=None,
+        zone_layers=[
+            _LayerStub(
+                {
+                    "plot_ratio": 1.8,
+                    "site_coverage_percent": 55,
+                    "height_m": 12.0,
+                    "floors_max": 6,
+                }
+            )
+        ],
+        input_kind="geometry",
+    )
+
+    pending_rule = RefRule(
+        jurisdiction="SG",
+        authority="URA",
+        topic="zoning",
+        parameter_key="zoning.max_far",
+        operator="<=",
+        value="4.5",
+        applicability={"zone_code": "R-NOAPP"},
+        review_status="needs_review",
+    )
+
+    session.add(pending_rule)
+    await session.flush()
+
+    calculation = await calculate_buildable(session, resolved, defaults)
+
+    metrics = calculation.metrics
+    assert metrics.gfa_cap_m2 == 1800
+    assert metrics.footprint_m2 == 550
+    assert metrics.floors_max == 4
+    assert metrics.nsa_est_m2 == 1350
+    assert not calculation.rules


### PR DESCRIPTION
## Summary
- apply approved zoning rule overrides to FAR, site coverage, and height inputs before falling back to zoning attributes or defaults
- normalise rule units (percentages, metres, storeys) when deriving overrides and only surface approved rules in buildable calculations
- extend buildable service tests for override/no-override scenarios and mark sample API rule as approved

## Testing
- pytest backend/tests/test_services/test_buildable.py backend/tests/test_api/test_rules.py

------
https://chatgpt.com/codex/tasks/task_e_68d102188e4483208232785b25deb3ab