### PR TITLE
Fix Makefile recipe indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ init-db: ## Apply Alembic migrations
 	docker-compose exec backend alembic upgrade head
 
 seed-data: ## Seed screening reference data for buildable overlays
-        docker-compose exec backend python -m scripts.seed_screening
+	docker-compose exec backend python -m scripts.seed_screening
 
 logs: ## Show application logs
 	docker-compose logs -f backend frontend


### PR DESCRIPTION
## Summary
- replace the space-indented command in the `seed-data` target with a tab so GNU Make treats it as a recipe line

## Testing
- make help

------
https://chatgpt.com/codex/tasks/task_e_68d106e6fbbc8320850e1a2b274d1cee