### PR TITLE
Filter buildable rules to approved publications

### DIFF
--- a/backend/app/services/buildable.py
+++ b/backend/app/services/buildable.py
@@ -107,7 +107,10 @@ async def _load_rules_for_zone(
     if not zone_code:
         return [], _RuleOverrides()
 
-    stmt = select(RefRule).where(RefRule.review_status == "approved")
+    stmt = select(RefRule).where(
+        RefRule.review_status == "approved",
+        RefRule.is_published.is_(True),
+    )
     result = await session.execute(stmt)
 
     overrides = _RuleOverrides()

--- a/backend/tests/pwp/test_buildable_golden.py
+++ b/backend/tests/pwp/test_buildable_golden.py
@@ -192,8 +192,11 @@ async def test_buildable_golden_addresses(buildable_client):
         rules = body["rules"]
         if expected["zone_code"] == "R2":
             assert rules, "Expected R2 buildable screening to include zoning rules"
-            first_rule = rules[0]
-            assert first_rule["parameter_key"] == context["rule_parameter_key"]
-            assert first_rule["provenance"] == context["provenance"]
+            matching = next(
+                (rule for rule in rules if rule["provenance"] == context["provenance"]),
+                None,
+            )
+            assert matching is not None, "Expected seeded R2 rule to be present"
+            assert matching["parameter_key"] == context["rule_parameter_key"]
         else:
             assert rules == []

--- a/backend/tests/test_api/test_rules.py
+++ b/backend/tests/test_api/test_rules.py
@@ -64,6 +64,7 @@ async def _seed_reference_data(async_session_factory) -> None:
             applicability={"zone_code": "R2"},
             notes="Provide 1.5 parking spaces per unit; maximum ramp slope 1:12",
             review_status="approved",
+            is_published=True,
         )
         session.add(rule)
 

--- a/backend/tests/test_services/test_buildable.py
+++ b/backend/tests/test_services/test_buildable.py
@@ -88,6 +88,7 @@ async def test_calculate_buildable_applies_rule_overrides(session) -> None:
             value="4.2",
             applicability={"zone_code": "R-OVR"},
             review_status="approved",
+            is_published=True,
         ),
         RefRule(
             jurisdiction="SG",
@@ -99,6 +100,7 @@ async def test_calculate_buildable_applies_rule_overrides(session) -> None:
             unit="percent",
             applicability={"zone_code": "R-OVR"},
             review_status="approved",
+            is_published=True,
         ),
         RefRule(
             jurisdiction="SG",
@@ -110,6 +112,7 @@ async def test_calculate_buildable_applies_rule_overrides(session) -> None:
             unit="m",
             applicability={"zone_code": "R-OVR"},
             review_status="approved",
+            is_published=True,
         ),
         RefRule(
             jurisdiction="SG",
@@ -121,6 +124,7 @@ async def test_calculate_buildable_applies_rule_overrides(session) -> None:
             unit="storeys",
             applicability={"zone_code": "R-OVR"},
             review_status="approved",
+            is_published=True,
         ),
         RefRule(
             jurisdiction="SG",
@@ -132,6 +136,7 @@ async def test_calculate_buildable_applies_rule_overrides(session) -> None:
             unit="m",
             applicability={"zone_code": "R-OVR"},
             review_status="approved",
+            is_published=True,
         ),
     ]
 
@@ -182,9 +187,21 @@ async def test_calculate_buildable_ignores_unapproved_rules(session) -> None:
         value="4.5",
         applicability={"zone_code": "R-NOAPP"},
         review_status="needs_review",
+        is_published=False,
+    )
+    unpublished_rule = RefRule(
+        jurisdiction="SG",
+        authority="URA",
+        topic="zoning",
+        parameter_key="zoning.site_coverage.max_percent",
+        operator="<=",
+        value="70%",
+        applicability={"zone_code": "R-NOAPP"},
+        review_status="approved",
+        is_published=False,
     )
 
-    session.add(pending_rule)
+    session.add_all([pending_rule, unpublished_rule])
     await session.flush()
 
     calculation = await calculate_buildable(session, resolved, defaults)


### PR DESCRIPTION
## Summary
- ensure buildable rule queries only load approved and published records before zone filtering
- update service tests to require published flags and cover unpublished exclusions
- adjust API and golden tests to mark sample rules as published and look for the seeded rule in responses

## Testing
- pytest backend/tests/test_services/test_buildable.py backend/tests/test_api/test_rules.py backend/tests/pwp/test_buildable_golden.py

------
https://chatgpt.com/codex/tasks/task_e_68d10944eddc8320968232af20eae56c