### PR TITLE
Add Prefect flows for reference fetching and parsing

### DIFF
--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -9,6 +9,9 @@ from . import (  # noqa: F401
     overlay_ingest,
     products,
     pwp,
+    reference_parsers,
+    reference_sources,
+    reference_storage,
     standards,
     storage,
 )
@@ -22,6 +25,9 @@ __all__ = [
     "overlay_ingest",
     "products",
     "pwp",
+    "reference_parsers",
+    "reference_sources",
+    "reference_storage",
     "standards",
     "storage",
 ]

--- a/backend/app/services/reference_parsers.py
+++ b/backend/app/services/reference_parsers.py
@@ -1,0 +1,176 @@
+"""Parsing helpers for reference documents."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from typing import Iterable, List, Optional
+
+
+@dataclass(slots=True)
+class ParsedClause:
+    """Structured clause extracted from a reference document."""
+
+    clause_ref: str
+    heading: str
+    text: str
+    page_from: int
+    page_to: int
+    quality: str = "high"
+
+
+class ClauseParser:
+    """Extract clauses from PDF or HTML payloads."""
+
+    def parse(self, kind: str, payload: bytes) -> List[ParsedClause]:
+        kind_lower = (kind or "").lower()
+        if kind_lower == "pdf":
+            text = self._decode(payload)
+            return self._parse_text_clauses(text)
+        if kind_lower in {"html", "sitemap"}:
+            sections = self._parse_html_sections(payload)
+            return self._build_clauses_from_sections(sections)
+        text = self._decode(payload)
+        return self._parse_text_clauses(text)
+
+    def _decode(self, payload: bytes) -> str:
+        return payload.decode("utf-8", errors="ignore")
+
+    def _parse_text_clauses(self, text: str) -> List[ParsedClause]:
+        pattern = re.compile(
+            r"^(?:Section\s+)?(?P<ref>\d+(?:\.\d+)*(?:[A-Za-z])?)"
+            r"(?:\s*[:\-.]\s+|\s+)(?P<title>.*)$",
+            re.IGNORECASE,
+        )
+        clauses: List[ParsedClause] = []
+        current_ref: Optional[str] = None
+        current_heading: str = ""
+        buffer: List[str] = []
+
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            match = pattern.match(stripped)
+            if match:
+                if current_ref is not None:
+                    clauses.append(
+                        ParsedClause(
+                            clause_ref=current_ref,
+                            heading=current_heading or current_ref,
+                            text=" ".join(buffer).strip(),
+                            page_from=len(clauses) + 1,
+                            page_to=len(clauses) + 1,
+                        )
+                    )
+                current_ref = match.group("ref")
+                heading = match.group("title").strip()
+                current_heading = heading or stripped
+                buffer = []
+            else:
+                buffer.append(stripped)
+
+        if current_ref is not None:
+            clauses.append(
+                ParsedClause(
+                    clause_ref=current_ref,
+                    heading=current_heading or current_ref,
+                    text=" ".join(buffer).strip(),
+                    page_from=len(clauses) + 1,
+                    page_to=len(clauses) + 1,
+                )
+            )
+
+        return [clause for clause in clauses if clause.text or clause.heading]
+
+    def _parse_html_sections(self, payload: bytes) -> List[tuple[str, str]]:
+        parser = _HTMLSectionParser()
+        parser.feed(self._decode(payload))
+        parser.close()
+        return parser.sections
+
+    def _build_clauses_from_sections(
+        self,
+        sections: Iterable[tuple[str, str]],
+    ) -> List[ParsedClause]:
+        clauses: List[ParsedClause] = []
+        seen_refs: set[str] = set()
+        for index, (heading, body) in enumerate(sections, start=1):
+            clause_ref = self._extract_clause_ref(heading) or self._extract_clause_ref(body)
+            if not clause_ref or clause_ref in seen_refs:
+                continue
+            seen_refs.add(clause_ref)
+            clauses.append(
+                ParsedClause(
+                    clause_ref=clause_ref,
+                    heading=heading.strip() or clause_ref,
+                    text=" ".join(body.split()),
+                    page_from=index,
+                    page_to=index,
+                )
+            )
+        return clauses
+
+    def _extract_clause_ref(self, text: str) -> Optional[str]:
+        match = re.search(r"(\d+(?:\.\d+)*(?:[A-Za-z])?)", text or "")
+        return match.group(1) if match else None
+
+
+class _HTMLSectionParser(HTMLParser):
+    """Collect heading/text pairs from HTML documents."""
+
+    HEADING_TAGS = {"h1", "h2", "h3", "h4", "h5", "h6"}
+    TEXT_TAGS = {"p", "div", "li", "span"}
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.sections: List[tuple[str, str]] = []
+        self._heading_parts: List[str] = []
+        self._text_parts: List[str] = []
+        self._in_heading = False
+        self._in_text = False
+
+    def handle_starttag(self, tag: str, attrs):  # type: ignore[override]
+        tag_lower = tag.lower()
+        if tag_lower in self.HEADING_TAGS:
+            self._flush_section()
+            self._in_heading = True
+            self._in_text = False
+        elif tag_lower in self.TEXT_TAGS:
+            self._in_text = True
+        elif tag_lower == "br":
+            self._text_parts.append("\n")
+
+    def handle_endtag(self, tag: str):  # type: ignore[override]
+        tag_lower = tag.lower()
+        if tag_lower in self.HEADING_TAGS:
+            self._in_heading = False
+        elif tag_lower in self.TEXT_TAGS:
+            self._in_text = False
+
+    def handle_data(self, data: str):  # type: ignore[override]
+        stripped = data.strip()
+        if not stripped:
+            return
+        if self._in_heading:
+            self._heading_parts.append(stripped)
+        elif self._in_text:
+            self._text_parts.append(stripped)
+
+    def close(self) -> None:  # type: ignore[override]
+        self._flush_section()
+        super().close()
+
+    def _flush_section(self) -> None:
+        heading = " ".join(self._heading_parts).strip()
+        body = " ".join(part for part in self._text_parts if part.strip()).strip()
+        if heading or body:
+            self.sections.append((heading, body))
+        self._heading_parts = []
+        self._text_parts = []
+        self._in_heading = False
+        self._in_text = False
+
+
+__all__ = ["ClauseParser", "ParsedClause"]

--- a/backend/app/services/reference_sources.py
+++ b/backend/app/services/reference_sources.py
@@ -1,0 +1,154 @@
+"""Helpers for fetching reference source documents."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Mapping, MutableMapping, Optional
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from app.models.rkp import RefDocument, RefSource
+
+
+@dataclass(slots=True)
+class HTTPResponse:
+    """Simplified HTTP response payload."""
+
+    status_code: int
+    headers: Mapping[str, str]
+    content: bytes
+
+
+class SimpleHTTPClient:
+    """Minimal HTTP client using ``urllib`` for asynchronous flows."""
+
+    async def head(self, url: str, headers: Optional[Mapping[str, str]] = None) -> HTTPResponse:
+        return await self._request("HEAD", url, headers=headers)
+
+    async def get(self, url: str, headers: Optional[Mapping[str, str]] = None) -> HTTPResponse:
+        return await self._request("GET", url, headers=headers)
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> HTTPResponse:
+        def _perform_request() -> HTTPResponse:
+            request = Request(url, method=method, headers=dict(headers or {}))
+            try:
+                with urlopen(request) as response:  # nosec B310 - used for controlled fetches
+                    payload = b"" if method == "HEAD" else response.read()
+                    return HTTPResponse(response.status, dict(response.headers.items()), payload)
+            except HTTPError as exc:  # pragma: no cover - network errors exercised in tests
+                payload = exc.read() if hasattr(exc, "read") else b""
+                return HTTPResponse(exc.code, dict(getattr(exc, "headers", {}) or {}), payload)
+
+        return await asyncio.to_thread(_perform_request)
+
+
+@dataclass(slots=True)
+class FetchedDocument:
+    """Result of fetching a reference document."""
+
+    content: bytes
+    etag: Optional[str]
+    last_modified: Optional[str]
+    content_type: Optional[str]
+
+
+class ReferenceSourceFetcher:
+    """Fetch reference sources with conditional requests."""
+
+    def __init__(self, http_client: Optional[SimpleHTTPClient] = None) -> None:
+        self._http = http_client or SimpleHTTPClient()
+
+    async def fetch(
+        self,
+        source: RefSource,
+        existing: Optional[RefDocument] = None,
+    ) -> Optional[FetchedDocument]:
+        """Fetch ``source`` if it has been updated since ``existing``."""
+
+        conditional_headers = self._conditional_headers(existing)
+        head_response: Optional[HTTPResponse] = None
+        if source.fetch_kind == "pdf":
+            head_response = await self._safe_head(source.landing_url, headers=conditional_headers)
+            if head_response and self._is_not_modified(head_response, existing):
+                return None
+        else:
+            head_response = await self._safe_head(source.landing_url, headers=conditional_headers)
+            if head_response and head_response.status_code == 304:
+                return None
+
+        response = await self._http.get(source.landing_url, headers=conditional_headers or None)
+        if response.status_code == 304:
+            return None
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"Failed to fetch reference source {source.id}: HTTP {response.status_code}"
+            )
+
+        headers: MutableMapping[str, str] = {}
+        if head_response:
+            headers.update({k.lower(): v for k, v in head_response.headers.items()})
+        headers.update({k.lower(): v for k, v in response.headers.items()})
+
+        return FetchedDocument(
+            content=response.content,
+            etag=headers.get("etag"),
+            last_modified=headers.get("last-modified"),
+            content_type=headers.get("content-type"),
+        )
+
+    async def _safe_head(
+        self,
+        url: str,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> Optional[HTTPResponse]:
+        try:
+            response = await self._http.head(url, headers=headers or None)
+        except Exception:  # pragma: no cover - defensive fallback for unsupported HEAD
+            return None
+        if response.status_code in {405, 501}:
+            return None
+        return response
+
+    def _conditional_headers(self, existing: Optional[RefDocument]) -> Mapping[str, str]:
+        headers: dict[str, str] = {}
+        if existing and existing.http_etag:
+            headers["If-None-Match"] = existing.http_etag
+        if existing and existing.http_last_modified:
+            headers["If-Modified-Since"] = existing.http_last_modified
+        return headers
+
+    def _is_not_modified(
+        self,
+        response: HTTPResponse,
+        existing: Optional[RefDocument],
+    ) -> bool:
+        if response.status_code == 304:
+            return True
+        if not existing:
+            return False
+        etag = _get_header(response.headers, "etag")
+        if etag and existing.http_etag and etag == existing.http_etag:
+            return True
+        last_modified = _get_header(response.headers, "last-modified")
+        if last_modified and existing.http_last_modified and last_modified == existing.http_last_modified:
+            return True
+        return False
+
+
+def _get_header(headers: Mapping[str, str], key: str) -> Optional[str]:
+    key_lower = key.lower()
+    for header, value in headers.items():
+        if header.lower() == key_lower:
+            return value
+    return None
+
+
+__all__ = ["FetchedDocument", "HTTPResponse", "ReferenceSourceFetcher", "SimpleHTTPClient"]

--- a/backend/app/services/reference_storage.py
+++ b/backend/app/services/reference_storage.py
@@ -1,0 +1,82 @@
+"""Storage helpers for reference source documents."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(slots=True)
+class ReferenceStorageResult:
+    """Metadata about a persisted reference document."""
+
+    storage_path: str
+    uri: str
+    bytes_written: int
+
+
+class ReferenceStorage:
+    """Persist reference documents to a filesystem/S3 compatible backend."""
+
+    def __init__(
+        self,
+        *,
+        base_path: Optional[Path] = None,
+        bucket: Optional[str] = None,
+        prefix: str = "ref-documents",
+        endpoint_url: Optional[str] = None,
+    ) -> None:
+        self.base_path = base_path or self._resolve_base_path()
+        self.base_path.mkdir(parents=True, exist_ok=True)
+        self.bucket = bucket if bucket is not None else os.getenv("REF_STORAGE_BUCKET", os.getenv("STORAGE_BUCKET", ""))
+        self.prefix = prefix.strip("/")
+        self.endpoint_url = endpoint_url or os.getenv("REF_STORAGE_ENDPOINT_URL", os.getenv("STORAGE_ENDPOINT_URL"))
+
+    @staticmethod
+    def _resolve_base_path() -> Path:
+        base = os.getenv("REF_STORAGE_LOCAL_PATH") or os.getenv("STORAGE_LOCAL_PATH") or ".storage"
+        return Path(base)
+
+    async def write_document(self, *, source_id: int, payload: bytes, suffix: str) -> ReferenceStorageResult:
+        """Persist ``payload`` for ``source_id`` using a content derived key."""
+
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        digest = hashlib.sha256(payload).hexdigest()[:12]
+        filename = f"{timestamp}-{digest}{suffix}"
+        key_parts = [part for part in (self.prefix, f"source-{source_id}", filename) if part]
+        storage_key = "/".join(key_parts)
+        file_path = self.base_path / storage_key
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(file_path.write_bytes, payload)
+        uri = self._to_uri(storage_key)
+        return ReferenceStorageResult(storage_path=storage_key, uri=uri, bytes_written=len(payload))
+
+    async def read_document(self, storage_path: str) -> bytes:
+        """Retrieve the raw bytes for ``storage_path``."""
+
+        file_path = self.base_path / storage_path
+        return await asyncio.to_thread(file_path.read_bytes)
+
+    def resolve_path(self, storage_path: str) -> Path:
+        """Return the absolute path for ``storage_path`` without reading it."""
+
+        return self.base_path / storage_path
+
+    def _to_uri(self, storage_key: str) -> str:
+        key = storage_key.replace(os.sep, "/")
+        if self.endpoint_url:
+            base = self.endpoint_url.rstrip("/")
+            if self.bucket:
+                return f"{base}/{self.bucket}/{key}"
+            return f"{base}/{key}"
+        if self.bucket:
+            return f"s3://{self.bucket}/{key}"
+        return key
+
+
+__all__ = ["ReferenceStorage", "ReferenceStorageResult"]

--- a/backend/flows/__init__.py
+++ b/backend/flows/__init__.py
@@ -1,1 +1,14 @@
 """Prefect flows for backend orchestration."""
+
+from .ergonomics import fetch_seeded_metrics, seed_ergonomics_metrics
+from .parse_segment import parse_reference_documents
+from .products import sync_vendor_products
+from .watch_fetch import watch_reference_sources
+
+__all__ = [
+    "fetch_seeded_metrics",
+    "parse_reference_documents",
+    "seed_ergonomics_metrics",
+    "sync_vendor_products",
+    "watch_reference_sources",
+]

--- a/backend/flows/parse_segment.py
+++ b/backend/flows/parse_segment.py
@@ -1,0 +1,92 @@
+"""Prefect flow that parses stored reference documents into clauses."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from prefect import flow
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import selectinload
+
+from app.models.rkp import RefClause, RefDocument, RefSource
+from app.services.reference_parsers import ClauseParser, ParsedClause
+from app.services.reference_storage import ReferenceStorage
+
+
+@flow(name="parse-reference-documents")
+async def parse_reference_documents(
+    session_factory: "async_sessionmaker[AsyncSession]",
+    *,
+    storage: Optional[ReferenceStorage] = None,
+    parser: Optional[ClauseParser] = None,
+) -> List[int]:
+    """Parse pending ``RefDocument`` records into ``RefClause`` entries."""
+
+    storage = storage or ReferenceStorage()
+    parser = parser or ClauseParser()
+    processed: List[int] = []
+
+    async with session_factory() as session:
+        documents = (
+            await session.execute(
+                select(RefDocument)
+                .options(selectinload(RefDocument.source))
+                .where(RefDocument.suspected_update.is_(True))
+                .order_by(RefDocument.id)
+            )
+        ).scalars().all()
+
+        for document in documents:
+            payload = await storage.read_document(document.storage_path)
+            fetch_kind = await _resolve_fetch_kind(session, document)
+            clauses = parser.parse(fetch_kind, payload)
+            await _replace_clauses(session, document, clauses)
+            document.suspected_update = False
+            processed.append(document.id)
+
+        await session.commit()
+
+    return processed
+
+
+async def _replace_clauses(
+    session: AsyncSession,
+    document: RefDocument,
+    clauses: List[ParsedClause],
+) -> None:
+    existing = (
+        await session.execute(select(RefClause).where(RefClause.document_id == document.id))
+    ).scalars().all()
+    for clause_row in existing:
+        await session.delete(clause_row)
+    for clause in clauses:
+        session.add(
+            RefClause(
+                document_id=document.id,
+                clause_ref=clause.clause_ref,
+                section_heading=clause.heading,
+                text_span=clause.text,
+                page_from=clause.page_from,
+                page_to=clause.page_to,
+                extraction_quality=clause.quality,
+            )
+        )
+    await session.flush()
+
+
+async def _resolve_fetch_kind(session: AsyncSession, document: RefDocument) -> str:
+    source = getattr(document, "source", None)
+    kind = getattr(source, "fetch_kind", None)
+    if isinstance(kind, str) and kind:
+        return kind
+    result = await session.execute(
+        select(RefSource).where(RefSource.id == document.source_id).limit(1)
+    )
+    source_row = result.scalar_one_or_none()
+    if source_row and getattr(source_row, "fetch_kind", None):
+        return source_row.fetch_kind
+    return "pdf"
+
+
+__all__ = ["parse_reference_documents"]

--- a/backend/flows/watch_fetch.py
+++ b/backend/flows/watch_fetch.py
@@ -1,0 +1,128 @@
+"""Prefect flow that monitors reference sources and fetches updated documents."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Dict, List, Optional
+
+from prefect import flow
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models.rkp import RefDocument, RefSource
+from app.services.reference_sources import FetchedDocument, ReferenceSourceFetcher
+from app.services.reference_storage import ReferenceStorage
+
+
+@flow(name="watch-reference-sources")
+async def watch_reference_sources(
+    session_factory: "async_sessionmaker[AsyncSession]",
+    *,
+    fetcher: Optional[ReferenceSourceFetcher] = None,
+    storage: Optional[ReferenceStorage] = None,
+) -> List[Dict[str, Any]]:
+    """Iterate active ``RefSource`` entries and persist changed documents."""
+
+    fetcher = fetcher or ReferenceSourceFetcher()
+    storage = storage or ReferenceStorage()
+    results: List[Dict[str, Any]] = []
+
+    async with session_factory() as session:
+        sources = (
+            await session.execute(
+                select(RefSource).where(RefSource.is_active.is_(True)).order_by(RefSource.id)
+            )
+        ).scalars().all()
+
+        for source in sources:
+            latest = await _latest_document(session, source.id)
+            fetched = await fetcher.fetch(source, latest)
+            if fetched is None:
+                continue
+
+            file_hash = hashlib.sha256(fetched.content).hexdigest()
+            duplicate = await _document_by_hash(session, source.id, file_hash)
+            if duplicate:
+                duplicate.http_etag = fetched.etag or duplicate.http_etag
+                duplicate.http_last_modified = fetched.last_modified or duplicate.http_last_modified
+                duplicate.suspected_update = False
+                await session.flush()
+                continue
+
+            suffix = _determine_suffix(source.fetch_kind, fetched)
+            location = await storage.write_document(
+                source_id=source.id,
+                payload=fetched.content,
+                suffix=suffix,
+            )
+            document = RefDocument(
+                source_id=source.id,
+                version_label=_derive_version_label(fetched, file_hash),
+                storage_path=location.storage_path,
+                file_hash=file_hash,
+                http_etag=fetched.etag,
+                http_last_modified=fetched.last_modified,
+                suspected_update=True,
+            )
+            session.add(document)
+            await session.flush()
+            results.append(
+                {
+                    "document_id": document.id,
+                    "source_id": source.id,
+                    "storage_path": document.storage_path,
+                    "uri": location.uri,
+                }
+            )
+
+        await session.commit()
+
+    return results
+
+
+async def _latest_document(session: AsyncSession, source_id: int) -> Optional[RefDocument]:
+    stmt = (
+        select(RefDocument)
+        .where(RefDocument.source_id == source_id)
+        .order_by(RefDocument.id.desc())
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+async def _document_by_hash(
+    session: AsyncSession,
+    source_id: int,
+    file_hash: str,
+) -> Optional[RefDocument]:
+    stmt = (
+        select(RefDocument)
+        .where(RefDocument.source_id == source_id)
+        .where(RefDocument.file_hash == file_hash)
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+def _determine_suffix(fetch_kind: Optional[str], fetched: FetchedDocument) -> str:
+    kind = (fetch_kind or "").lower()
+    if kind == "pdf":
+        return ".pdf"
+    if kind in {"html", "sitemap"}:
+        return ".html"
+    content_type = (fetched.content_type or "").lower()
+    if "pdf" in content_type:
+        return ".pdf"
+    if "html" in content_type or "xml" in content_type:
+        return ".html"
+    return ".bin"
+
+
+def _derive_version_label(fetched: FetchedDocument, file_hash: str) -> str:
+    for candidate in (fetched.last_modified, fetched.etag):
+        if candidate:
+            return candidate
+    return file_hash[:12]
+
+
+__all__ = ["watch_reference_sources"]

--- a/backend/tests/test_flows/test_parse_segment_flow.py
+++ b/backend/tests/test_flows/test_parse_segment_flow.py
@@ -1,0 +1,134 @@
+"""Tests for the reference document parsing flow."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from sqlalchemy import select
+
+from app.models.rkp import RefClause, RefDocument, RefSource
+from app.services.reference_storage import ReferenceStorage
+from flows.parse_segment import parse_reference_documents
+
+
+@pytest.mark.asyncio
+async def test_parse_reference_documents_from_pdf(async_session_factory, tmp_path) -> None:
+    storage = ReferenceStorage(base_path=tmp_path, bucket="")
+    payload = b"1.1 Scope\nThe scope clause describes the coverage.\n\n1.2 Requirements\nAll exits must remain unobstructed."
+
+    async with async_session_factory() as session:
+        source = RefSource(
+            jurisdiction="SG",
+            authority="BCA",
+            topic="fire",
+            doc_title="Fire Code",
+            landing_url="https://example.com/fire.pdf",
+            fetch_kind="pdf",
+            is_active=True,
+        )
+        session.add(source)
+        await session.flush()
+        location = await storage.write_document(source_id=source.id, payload=payload, suffix=".pdf")
+        assert storage.resolve_path(location.storage_path).exists()
+        assert await storage.read_document(location.storage_path) == payload
+        document = RefDocument(
+            source_id=source.id,
+            version_label="v1",
+            storage_path=location.storage_path,
+            file_hash=hashlib.sha256(payload).hexdigest(),
+            http_etag="etag-v1",
+            http_last_modified="Wed, 01 Jan 2024 00:00:00 GMT",
+            suspected_update=True,
+        )
+        session.add(document)
+        await session.commit()
+        document_id = document.id
+
+    # Ensure the persisted file remains accessible after the session closes.
+    assert await storage.read_document(location.storage_path) == payload
+
+    processed = await parse_reference_documents(async_session_factory, storage=storage)
+    assert processed == [document_id]
+
+    async with async_session_factory() as session:
+        document = await session.get(RefDocument, document_id)
+        assert document is not None
+        assert document.suspected_update is False
+        clauses = (
+            await session.execute(
+                select(RefClause).where(RefClause.document_id == document_id).order_by(RefClause.clause_ref)
+            )
+        ).scalars().all()
+        assert len(clauses) == 2
+        assert clauses[0].clause_ref == "1.1"
+        assert "scope" in clauses[0].section_heading.lower()
+        assert "coverage" in clauses[0].text_span.lower()
+        assert clauses[1].clause_ref == "1.2"
+        assert "exits" in clauses[1].text_span.lower()
+
+
+@pytest.mark.asyncio
+async def test_parse_reference_documents_from_html(async_session_factory, tmp_path) -> None:
+    storage = ReferenceStorage(base_path=tmp_path, bucket="")
+    html_payload = (
+        b"<html><body>"
+        b"<h2>Clause 2.1 Fire Resistance</h2>"
+        b"<p>Walls must achieve a two hour rating.</p>"
+        b"<p>Doors shall be self-closing.</p>"
+        b"<h2>2.2 Means of Escape</h2>"
+        b"<p>Paths must remain clear at all times.</p>"
+        b"</body></html>"
+    )
+
+    async with async_session_factory() as session:
+        source = RefSource(
+            jurisdiction="SG",
+            authority="BCA",
+            topic="fire",
+            doc_title="Fire Code",
+            landing_url="https://example.com/fire.html",
+            fetch_kind="html",
+            is_active=True,
+        )
+        session.add(source)
+        await session.flush()
+        location = await storage.write_document(source_id=source.id, payload=html_payload, suffix=".html")
+        assert storage.resolve_path(location.storage_path).exists()
+        assert await storage.read_document(location.storage_path) == html_payload
+        document = RefDocument(
+            source_id=source.id,
+            version_label="html-v1",
+            storage_path=location.storage_path,
+            file_hash=hashlib.sha256(html_payload).hexdigest(),
+            http_etag="etag-html",
+            http_last_modified="Thu, 02 Jan 2024 00:00:00 GMT",
+            suspected_update=True,
+        )
+        session.add(document)
+        await session.commit()
+        document_id = document.id
+
+    assert await storage.read_document(location.storage_path) == html_payload
+
+    processed = await parse_reference_documents(async_session_factory, storage=storage)
+    assert processed == [document_id]
+
+    async with async_session_factory() as session:
+        document = await session.get(RefDocument, document_id)
+        assert document is not None
+        assert document.suspected_update is False
+        clauses = (
+            await session.execute(
+                select(RefClause).where(RefClause.document_id == document_id).order_by(RefClause.clause_ref)
+            )
+        ).scalars().all()
+        assert len(clauses) == 2
+        assert clauses[0].clause_ref == "2.1"
+        assert "fire resistance" in clauses[0].section_heading.lower()
+        assert "two hour rating" in clauses[0].text_span.lower()
+        assert clauses[1].clause_ref == "2.2"
+        assert "paths" in clauses[1].text_span.lower()

--- a/backend/tests/test_flows/test_watch_fetch_flow.py
+++ b/backend/tests/test_flows/test_watch_fetch_flow.py
@@ -1,0 +1,153 @@
+"""Tests for the reference source watch flow."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Mapping
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from sqlalchemy import select
+
+from app.models.rkp import RefDocument, RefSource
+from app.services.reference_sources import HTTPResponse, ReferenceSourceFetcher
+from app.services.reference_storage import ReferenceStorage
+from flows.watch_fetch import watch_reference_sources
+
+
+class FakeHTTPClient:
+    """Stub HTTP client that returns preconfigured responses."""
+
+    def __init__(
+        self,
+        *,
+        head_response: HTTPResponse,
+        get_response: HTTPResponse,
+    ) -> None:
+        self._head_response = head_response
+        self._get_response = get_response
+        self.head_calls: list[tuple[str, Mapping[str, str]]] = []
+        self.get_calls: list[tuple[str, Mapping[str, str]]] = []
+
+    async def head(self, url: str, headers=None) -> HTTPResponse:
+        mapping = dict(headers or {})
+        self.head_calls.append((url, mapping))
+        return self._head_response
+
+    async def get(self, url: str, headers=None) -> HTTPResponse:
+        mapping = dict(headers or {})
+        self.get_calls.append((url, mapping))
+        return self._get_response
+
+
+@pytest.mark.asyncio
+async def test_watch_fetch_records_new_document(async_session_factory, tmp_path) -> None:
+    storage = ReferenceStorage(base_path=tmp_path, bucket="")
+
+    async with async_session_factory() as session:
+        source = RefSource(
+            jurisdiction="SG",
+            authority="BCA",
+            topic="fire",
+            doc_title="Fire Code",
+            landing_url="https://example.com/fire-v1.pdf",
+            fetch_kind="pdf",
+            is_active=True,
+        )
+        session.add(source)
+        await session.commit()
+        source_id = source.id
+
+    head_response = HTTPResponse(
+        status_code=200,
+        headers={"ETag": "etag-v1", "Last-Modified": "Wed, 01 Jan 2024 00:00:00 GMT"},
+        content=b"",
+    )
+    get_payload = b"%PDF-1.4\nSample payload"
+    get_response = HTTPResponse(
+        status_code=200,
+        headers={"Content-Type": "application/pdf", "ETag": "etag-v1"},
+        content=get_payload,
+    )
+    fake_client = FakeHTTPClient(head_response=head_response, get_response=get_response)
+    fetcher = ReferenceSourceFetcher(http_client=fake_client)
+
+    results = await watch_reference_sources(async_session_factory, fetcher=fetcher, storage=storage)
+    assert len(results) == 1
+    document_id = results[0]["document_id"]
+
+    async with async_session_factory() as session:
+        document = await session.get(RefDocument, document_id)
+        assert document is not None
+        assert document.source_id == source_id
+        assert document.suspected_update is True
+        assert document.http_etag == "etag-v1"
+        assert document.http_last_modified == "Wed, 01 Jan 2024 00:00:00 GMT"
+        stored = await storage.read_document(document.storage_path)
+        assert stored == get_payload
+
+        # Reset the flag to avoid affecting downstream parsing tests.
+        document.suspected_update = False
+        await session.commit()
+
+    assert fake_client.head_calls
+    assert fake_client.get_calls
+
+
+@pytest.mark.asyncio
+async def test_watch_fetch_skips_when_not_modified(async_session_factory, tmp_path) -> None:
+    storage = ReferenceStorage(base_path=tmp_path, bucket="")
+    existing_payload = b"Existing PDF payload"
+
+    async with async_session_factory() as session:
+        source = RefSource(
+            jurisdiction="SG",
+            authority="BCA",
+            topic="fire",
+            doc_title="Fire Code",
+            landing_url="https://example.com/fire-latest.pdf",
+            fetch_kind="pdf",
+            is_active=True,
+        )
+        session.add(source)
+        await session.flush()
+        location = await storage.write_document(source_id=source.id, payload=existing_payload, suffix=".pdf")
+        document = RefDocument(
+            source_id=source.id,
+            version_label="v1",
+            storage_path=location.storage_path,
+            file_hash=hashlib.sha256(existing_payload).hexdigest(),
+            http_etag="etag-existing",
+            http_last_modified="Wed, 01 Jan 2024 00:00:00 GMT",
+            suspected_update=False,
+        )
+        session.add(document)
+        await session.commit()
+        document_id = document.id
+
+    head_response = HTTPResponse(status_code=304, headers={}, content=b"")
+    get_response = HTTPResponse(status_code=304, headers={}, content=b"")
+    fake_client = FakeHTTPClient(head_response=head_response, get_response=get_response)
+    fetcher = ReferenceSourceFetcher(http_client=fake_client)
+
+    results = await watch_reference_sources(async_session_factory, fetcher=fetcher, storage=storage)
+    assert results == []
+    assert len(fake_client.get_calls) == 0
+    assert fake_client.head_calls
+    matching_headers = [
+        headers
+        for url, headers in fake_client.head_calls
+        if "fire-latest.pdf" in url
+    ]
+    assert matching_headers, "expected HEAD call for the updated source"
+    assert matching_headers[0].get("If-None-Match") == "etag-existing"
+
+    async with async_session_factory() as session:
+        updated = await session.get(RefDocument, document_id)
+        assert updated is not None
+        documents = (
+            await session.execute(select(RefDocument).where(RefDocument.source_id == updated.source_id))
+        ).scalars().all()
+        assert len(documents) == 1


### PR DESCRIPTION
## Summary
- add dedicated services for fetching remote reference sources, storing documents, and parsing clauses
- implement new Prefect flows to watch active reference sources and parse updated documents into clauses
- cover the flows with unit tests that exercise conditional fetching logic and clause extraction behaviour

## Testing
- pytest backend/tests/test_flows/test_watch_fetch_flow.py backend/tests/test_flows/test_parse_segment_flow.py


------
https://chatgpt.com/codex/tasks/task_e_68d1100c6f8c83208c243a117b741b89