### PR TITLE
Add SG zoning normalization templates and ref sources

### DIFF
--- a/backend/tests/test_scripts/test_seed_screening.py
+++ b/backend/tests/test_scripts/test_seed_screening.py
@@ -1,0 +1,30 @@
+"""Tests for the screening seed script."""
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from sqlalchemy import select
+
+from app.models.rkp import RefSource
+from scripts.seed_screening import seed_screening_sample_data
+
+
+def test_seed_screening_populates_reference_sources(async_session_factory) -> None:
+    async def _run():
+        async with async_session_factory() as session:
+            summary = await seed_screening_sample_data(session, commit=False)
+            result = await session.execute(select(RefSource))
+            sources = result.scalars().all()
+        return summary, sources
+
+    summary, sources = asyncio.run(_run())
+
+    assert summary.sources == len(sources)
+    authorities = {source.authority for source in sources}
+    assert {"URA", "BCA", "SCDF", "PUB"} <= authorities
+    assert all(source.jurisdiction == "SG" for source in sources)
+    assert all(source.doc_title for source in sources)
+    assert all(source.landing_url.startswith("http") for source in sources)

--- a/backend/tests/test_services/test_normalize.py
+++ b/backend/tests/test_services/test_normalize.py
@@ -6,7 +6,7 @@ import pytest
 
 pytest.importorskip("sqlalchemy")
 
-from app.services.normalize import RuleNormalizer
+from app.services.normalize import NormalizedRule, RuleNormalizer
 
 
 def test_rule_normalizer_extracts_parking_and_slope() -> None:
@@ -32,3 +32,40 @@ def test_apply_overlays_merges_unique_values() -> None:
     normalizer = RuleNormalizer()
     updated = normalizer.apply_overlays(attributes, ["coastal", "noise"])
     assert updated["overlays"] == ["heritage", "coastal", "noise"]
+
+
+def test_rule_normalizer_extracts_sg_zoning_metrics() -> None:
+    normalizer = RuleNormalizer()
+    text = (
+        "The URA Master Plan specifies a maximum gross plot ratio of 3.5. "
+        "Building height shall not exceed 120 metres within the precinct. "
+        "Site coverage must not exceed 0.65 for new developments. "
+        "A minimum front setback of 7.5m is required along arterial roads."
+    )
+    matches = normalizer.normalize(text)
+
+    def _find(parameter_key: str) -> NormalizedRule:
+        for match in matches:
+            if match.parameter_key == parameter_key:
+                return match
+        raise AssertionError(f"Expected rule for {parameter_key!r} not found")
+
+    far_rule = _find("zoning.max_far")
+    assert far_rule.value == approx(3.5)
+    assert far_rule.unit == "ratio"
+    assert any("plot ratio" in hint.lower() for hint in far_rule.hints)
+
+    height_rule = _find("zoning.max_building_height_m")
+    assert height_rule.value == approx(120)
+    assert height_rule.unit == "m"
+    assert any("height" in hint.lower() for hint in height_rule.hints)
+
+    site_coverage_rule = _find("zoning.site_coverage.max_percent")
+    assert site_coverage_rule.value == approx(65.0)
+    assert site_coverage_rule.unit == "percent"
+    assert any("site coverage" in hint.lower() for hint in site_coverage_rule.hints)
+
+    setback_rule = _find("zoning.setback.front_min_m")
+    assert setback_rule.value == approx(7.5)
+    assert setback_rule.unit == "m"
+    assert any("setback" in hint.lower() for hint in setback_rule.hints)


### PR DESCRIPTION
## Summary
- add normalization templates for Singapore zoning controls covering FAR, building height, site coverage, and front setbacks with contextual hints
- extend rule normalizer tests to confirm the new zoning templates emit the expected NormalizedRule payloads
- seed canonical URA/BCA/SCDF/PUB reference sources and cover the seeding logic with a targeted unit test

## Testing
- pytest backend/tests/test_services/test_normalize.py backend/tests/test_scripts/test_seed_screening.py

------
https://chatgpt.com/codex/tasks/task_e_68d12bcfbb588320afc4d3f6669be1b2