### PR TITLE
Seed baseline reference sources with idempotent script updates

### DIFF
--- a/backend/scripts/seed_screening.py
+++ b/backend/scripts/seed_screening.py
@@ -42,7 +42,7 @@ _SAMPLE_REF_SOURCES: Sequence[Dict[str, object]] = (
         "topic": "zoning",
         "doc_title": "URA Master Plan Planning Parameters",
         "landing_url": "https://www.ura.gov.sg/Corporate/Planning/Master-Plan",
-        "fetch_kind": "pdf",
+        "fetch_kind": "html",
         "update_freq_hint": "biennial",
     },
     {
@@ -262,7 +262,6 @@ async def _upsert_ref_sources(session: AsyncSession) -> List[RefSource]:
             RefSource.jurisdiction == payload["jurisdiction"],
             RefSource.authority == payload["authority"],
             RefSource.topic == payload["topic"],
-            RefSource.doc_title == payload["doc_title"],
         )
         existing = (await session.execute(stmt)).scalar_one_or_none()
         if existing:

--- a/backend/tests/test_api/test_rules.py
+++ b/backend/tests/test_api/test_rules.py
@@ -23,15 +23,14 @@ async def _seed_reference_data(async_session_factory) -> None:
     async with async_session_factory() as session:
         await seed_screening_sample_data(session, commit=False)
 
-        source = RefSource(
-            jurisdiction="SG",
-            authority="URA",
-            topic="zoning",
-            doc_title="Urban Redevelopment Authority",
-            landing_url="https://example.com/ura",
-        )
-        session.add(source)
-        await session.flush()
+        source = (
+            await session.execute(
+                select(RefSource)
+                .where(RefSource.jurisdiction == "SG")
+                .where(RefSource.authority == "URA")
+                .where(RefSource.topic == "zoning")
+            )
+        ).scalar_one()
 
         document = RefDocument(
             source_id=source.id,

--- a/backend/tests/test_scripts/test_seed_screening.py
+++ b/backend/tests/test_scripts/test_seed_screening.py
@@ -9,22 +9,62 @@ pytest.importorskip("sqlalchemy")
 from sqlalchemy import select
 
 from app.models.rkp import RefSource
-from scripts.seed_screening import seed_screening_sample_data
+from scripts.seed_screening import SeedSummary, seed_screening_sample_data
 
 
 def test_seed_screening_populates_reference_sources(async_session_factory) -> None:
-    async def _run():
+    expected_sources = {
+        ("SG", "URA", "zoning"): {
+            "landing_url": "https://www.ura.gov.sg/Corporate/Planning/Master-Plan",
+            "fetch_kind": "html",
+        },
+        ("SG", "BCA", "building"): {
+            "landing_url": "https://www1.bca.gov.sg/buildsg/bca-codes/building-control-act",
+            "fetch_kind": "pdf",
+        },
+        ("SG", "SCDF", "fire"): {
+            "landing_url": "https://www.scdf.gov.sg/home/fire-safety/fire-code",
+            "fetch_kind": "pdf",
+        },
+        ("SG", "PUB", "drainage"): {
+            "landing_url": "https://www.pub.gov.sg/Documents/COP_SurfaceWaterDrainage.pdf",
+            "fetch_kind": "pdf",
+        },
+    }
+
+    async def _seed_once() -> SeedSummary:
         async with async_session_factory() as session:
-            summary = await seed_screening_sample_data(session, commit=False)
-            result = await session.execute(select(RefSource))
-            sources = result.scalars().all()
-        return summary, sources
+            return await seed_screening_sample_data(session, commit=True)
 
-    summary, sources = asyncio.run(_run())
+    async def _fetch_sources() -> list[RefSource]:
+        async with async_session_factory() as session:
+            result = await session.execute(
+                select(RefSource).order_by(RefSource.authority, RefSource.topic)
+            )
+            return result.scalars().all()
 
-    assert summary.sources == len(sources)
-    authorities = {source.authority for source in sources}
-    assert {"URA", "BCA", "SCDF", "PUB"} <= authorities
-    assert all(source.jurisdiction == "SG" for source in sources)
-    assert all(source.doc_title for source in sources)
-    assert all(source.landing_url.startswith("http") for source in sources)
+    first_summary = asyncio.run(_seed_once())
+    first_sources = asyncio.run(_fetch_sources())
+
+    assert first_summary.sources == len(first_sources) == len(expected_sources)
+    identifiers = {}
+    for source in first_sources:
+        key = (source.jurisdiction, source.authority, source.topic)
+        assert key in expected_sources
+        identifiers[key] = source.id
+        expected = expected_sources[key]
+        assert source.landing_url == expected["landing_url"]
+        assert source.fetch_kind == expected["fetch_kind"]
+        assert source.doc_title
+        assert source.is_active is True
+
+    second_summary = asyncio.run(_seed_once())
+    second_sources = asyncio.run(_fetch_sources())
+
+    assert second_summary.sources == len(second_sources) == len(expected_sources)
+    for source in second_sources:
+        key = (source.jurisdiction, source.authority, source.topic)
+        assert key in expected_sources
+        assert identifiers[key] == source.id
+        assert source.landing_url == expected_sources[key]["landing_url"]
+        assert source.fetch_kind == expected_sources[key]["fetch_kind"]


### PR DESCRIPTION
## Summary
- ensure `scripts.seed_screening` upserts the baseline URA, BCA, SCDF, and PUB sources with the expected metadata while remaining idempotent
- extend script coverage to assert seeded source fields and reuse the baseline URA source in API/buildable tests so seeded rules link back to it

## Testing
- pytest tests/test_scripts/test_seed_screening.py tests/test_api/test_rules.py tests/pwp/test_buildable_golden.py

------
https://chatgpt.com/codex/tasks/task_e_68d13164d82c8320b69d56dd444c7ff4