### PR TITLE
Restore default rule filtering and seed cleanup

### DIFF
--- a/backend/tests/test_workflows/test_aec_pipeline.py
+++ b/backend/tests/test_workflows/test_aec_pipeline.py
@@ -372,7 +372,10 @@ async def test_ruleset_serialisation_includes_overlays(async_session_factory, cl
         session.add_all([layer, rule])
         await session.commit()
 
-    response = await client.get("/api/v1/rules")
+    response = await client.get(
+        "/api/v1/rules",
+        params={"review_status": "needs_review"},
+    )
     assert response.status_code == 200
     payload = response.json()
     items = payload.get("items", [])

--- a/sqlalchemy/ext/asyncio.py
+++ b/sqlalchemy/ext/asyncio.py
@@ -32,7 +32,7 @@ class AsyncSession:
             rows = statement._apply(self._database)
             return Result(rows)
         if isinstance(statement, DeleteStatement):
-            self._database.delete_all(statement.model)
+            self._database.delete(statement.model, statement.conditions)
             return Result(())
         if isinstance(statement, TextClause):
             return Result(())


### PR DESCRIPTION
## Summary
- default the v1 rules list endpoint to approved rules while supporting an optional review_status filter
- remove stale reference sources in the screening seed script using statement deletes compatible with the async session stub and ensure placeholder documents exist
- extend the in-repo SQLAlchemy async session stub to evaluate filtered delete statements and update the workflow test to opt into pending rules

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d1386b86608320a7104b11c1f36a8d