### PR TITLE
Add reference document watch and parsing flows

### DIFF
--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -9,6 +9,9 @@ from . import (  # noqa: F401
     overlay_ingest,
     products,
     pwp,
+    ref_documents,
+    ref_fetcher,
+    ref_parsers,
     standards,
     storage,
 )
@@ -22,6 +25,9 @@ __all__ = [
     "overlay_ingest",
     "products",
     "pwp",
+    "ref_documents",
+    "ref_fetcher",
+    "ref_parsers",
     "standards",
     "storage",
 ]

--- a/backend/app/services/ref_documents.py
+++ b/backend/app/services/ref_documents.py
@@ -1,0 +1,146 @@
+"""Helpers for persisting and retrieving reference documents."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from app.models.rkp import RefSource
+
+
+def _slugify(value: str) -> str:
+    """Return a filesystem friendly representation of *value*."""
+
+    value = value.strip().lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    return re.sub(r"-+", "-", value).strip("-")
+
+
+def compute_document_checksum(payload: bytes) -> str:
+    """Compute the SHA-256 checksum for the provided payload."""
+
+    return hashlib.sha256(payload).hexdigest()
+
+
+@dataclass(slots=True)
+class StoredDocument:
+    """Metadata captured after persisting a reference document."""
+
+    storage_path: str
+    uri: str
+    bytes_written: int
+
+
+class DocumentStorageService:
+    """Persist reference documents to a filesystem-backed store."""
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        prefix: str,
+        local_base_path: Path,
+        endpoint_url: Optional[str] = None,
+    ) -> None:
+        self.bucket = bucket
+        self.prefix = prefix.strip("/")
+        self.local_base_path = local_base_path
+        self.endpoint_url = endpoint_url
+        self.local_base_path.mkdir(parents=True, exist_ok=True)
+
+    def _build_relative_key(self, source: RefSource, filename: str) -> str:
+        parts: list[str] = []
+        if self.prefix:
+            parts.append(self.prefix)
+        parts.extend(
+            [
+                _slugify(source.jurisdiction or "global"),
+                _slugify(source.authority or "authority"),
+                f"source-{source.id}",
+                filename,
+            ]
+        )
+        return "/".join(filter(None, parts))
+
+    def _make_filename(self, source: RefSource, extension: str, payload: bytes) -> str:
+        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        digest = hashlib.md5(payload).hexdigest()[:10]
+        ext = extension.lstrip(".") or "bin"
+        return f"{timestamp}-{digest}.{ext}"
+
+    def _resolve_path(self, relative_key: str) -> Path:
+        return self.local_base_path / Path(relative_key)
+
+    def _to_uri(self, relative_key: str) -> str:
+        key = relative_key.replace(os.sep, "/")
+        if self.endpoint_url:
+            base = self.endpoint_url.rstrip("/")
+            if self.bucket:
+                return f"{base}/{self.bucket}/{key}"
+            return f"{base}/{key}"
+        if self.bucket:
+            return f"s3://{self.bucket}/{key}"
+        return key
+
+    async def write_document(self, *, source: RefSource, payload: bytes, extension: str) -> StoredDocument:
+        """Persist *payload* for *source* and return storage metadata."""
+
+        filename = self._make_filename(source, extension, payload)
+        relative_key = self._build_relative_key(source, filename)
+        file_path = self._resolve_path(relative_key)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(file_path.write_bytes, payload)
+        return StoredDocument(
+            storage_path=relative_key,
+            uri=self._to_uri(relative_key),
+            bytes_written=len(payload),
+        )
+
+    async def read_document(self, storage_path: str) -> bytes:
+        """Retrieve the persisted payload referenced by *storage_path*."""
+
+        file_path = self._resolve_path(storage_path)
+        return await asyncio.to_thread(file_path.read_bytes)
+
+
+_document_storage_service: DocumentStorageService | None = None
+
+
+def get_document_storage_service() -> DocumentStorageService:
+    """Return a singleton document storage service instance."""
+
+    global _document_storage_service
+    if _document_storage_service is None:
+        bucket = os.getenv("REF_STORAGE_BUCKET", "")
+        prefix = os.getenv("REF_STORAGE_PREFIX", "ref-documents")
+        base_path = Path(os.getenv("REF_STORAGE_LOCAL_PATH", ".ref-docs"))
+        endpoint_url = os.getenv("REF_STORAGE_ENDPOINT_URL")
+        _document_storage_service = DocumentStorageService(
+            bucket=bucket,
+            prefix=prefix,
+            local_base_path=base_path,
+            endpoint_url=endpoint_url,
+        )
+    return _document_storage_service
+
+
+def reset_document_storage_service() -> None:
+    """Reset the cached storage service. Intended for tests."""
+
+    global _document_storage_service
+    _document_storage_service = None
+
+
+__all__ = [
+    "DocumentStorageService",
+    "StoredDocument",
+    "compute_document_checksum",
+    "get_document_storage_service",
+    "reset_document_storage_service",
+]

--- a/backend/app/services/ref_fetcher.py
+++ b/backend/app/services/ref_fetcher.py
@@ -1,0 +1,77 @@
+"""HTTP helpers used when fetching reference source documents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Optional, Protocol
+
+
+@dataclass(slots=True)
+class FetchResponse:
+    """Lightweight container describing the result of an HTTP request."""
+
+    status_code: int
+    headers: Mapping[str, str]
+    content: bytes
+
+
+class DocumentFetcher(Protocol):
+    """Protocol describing the subset of HTTP client behaviour we rely on."""
+
+    async def head(self, url: str, headers: Optional[Mapping[str, str]] = None) -> FetchResponse:
+        ...
+
+    async def get(self, url: str, headers: Optional[Mapping[str, str]] = None) -> FetchResponse:
+        ...
+
+    async def aclose(self) -> None:  # pragma: no cover - optional clean-up hook
+        ...
+
+
+try:  # pragma: no cover - optional dependency for online environments
+    import httpx
+except ModuleNotFoundError:  # pragma: no cover - exercised in offline tests
+    httpx = None  # type: ignore[assignment]
+
+
+class HTTPXDocumentFetcher:
+    """`DocumentFetcher` implementation backed by :mod:`httpx`."""
+
+    def __init__(self, *, timeout: float = 30.0) -> None:
+        if httpx is None:  # pragma: no cover - offline test fallback
+            raise ModuleNotFoundError(
+                "httpx is required to instantiate HTTPXDocumentFetcher"
+            )
+        self._client = httpx.AsyncClient(timeout=timeout)
+
+    async def head(
+        self, url: str, headers: Optional[Mapping[str, str]] = None
+    ) -> FetchResponse:
+        response = await self._client.head(url, headers=headers)
+        return FetchResponse(
+            status_code=response.status_code,
+            headers=dict(response.headers),
+            content=response.content,
+        )
+
+    async def get(
+        self, url: str, headers: Optional[Mapping[str, str]] = None
+    ) -> FetchResponse:
+        response = await self._client.get(url, headers=headers)
+        return FetchResponse(
+            status_code=response.status_code,
+            headers=dict(response.headers),
+            content=response.content,
+        )
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+
+def get_document_fetcher(*, timeout: float = 30.0) -> DocumentFetcher:
+    """Return a default :class:`DocumentFetcher` implementation."""
+
+    return HTTPXDocumentFetcher(timeout=timeout)
+
+
+__all__ = ["DocumentFetcher", "FetchResponse", "HTTPXDocumentFetcher", "get_document_fetcher"]

--- a/backend/app/services/ref_parsers.py
+++ b/backend/app/services/ref_parsers.py
@@ -1,0 +1,177 @@
+"""Parsers for transforming reference documents into clause segments."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+@dataclass(slots=True)
+class ClauseSegment:
+    """Representation of a clause extracted from a reference document."""
+
+    clause_ref: str
+    heading: str | None
+    text_span: str
+    page_from: int | None
+    page_to: int | None
+
+
+_PAGE_PATTERN = re.compile(r"page(?:s)?\s*(\d+)(?:\s*[-–]\s*(\d+))?", re.IGNORECASE)
+_CLAUSE_HEADER_PATTERN = re.compile(
+    r"^(?:Clause|Section)?\s*([A-Za-z0-9.\-]+)\s*(?::|-)?\s*(.*)$",
+    re.IGNORECASE,
+)
+_HTML_SECTION_PATTERN = re.compile(
+    r"<(?:section|article)([^>]*)>(.*?)</(?:section|article)>",
+    re.IGNORECASE | re.DOTALL,
+)
+_HTML_TAG_PATTERN = re.compile(r"<[^>]+>")
+_WHITESPACE_PATTERN = re.compile(r"\s+")
+
+
+def _clean_text_lines(block: str) -> list[str]:
+    lines = [line.strip() for line in block.splitlines()]
+    return [line for line in lines if line]
+
+
+def _extract_pages(text: Iterable[str]) -> tuple[list[str], int | None, int | None]:
+    remaining: list[str] = []
+    page_from: int | None = None
+    page_to: int | None = None
+    for line in text:
+        match = _PAGE_PATTERN.search(line)
+        if match:
+            page_from = int(match.group(1))
+            page_to = int(match.group(2) or match.group(1))
+            continue
+        remaining.append(line)
+    return remaining, page_from, page_to
+
+
+def _parse_text_blocks(blocks: Iterable[str]) -> List[ClauseSegment]:
+    segments: List[ClauseSegment] = []
+    for raw_block in blocks:
+        lines = _clean_text_lines(raw_block)
+        if not lines:
+            continue
+        lines, page_from, page_to = _extract_pages(lines)
+        if not lines:
+            continue
+        first_line = lines[0]
+        heading: str | None = None
+        clause_ref: str | None = None
+        body_start_index = 1
+
+        header_match = _CLAUSE_HEADER_PATTERN.match(first_line)
+        if header_match:
+            clause_ref = header_match.group(1) or "unlabelled"
+            heading_candidate = header_match.group(2).strip()
+            if heading_candidate:
+                heading = heading_candidate
+        else:
+            parts = first_line.split(None, 1)
+            clause_ref = parts[0]
+            if len(parts) > 1:
+                heading = parts[1].strip() or None
+
+        if heading is None and len(lines) > 1:
+            heading = lines[1]
+            body_start_index = 2
+        else:
+            body_start_index = 1
+
+        text_span = " ".join(lines[body_start_index:]).strip()
+        segments.append(
+            ClauseSegment(
+                clause_ref=clause_ref or "unlabelled",
+                heading=heading,
+                text_span=text_span,
+                page_from=page_from,
+                page_to=page_to,
+            )
+        )
+    return segments
+
+
+def parse_pdf_clauses(payload: bytes) -> List[ClauseSegment]:
+    """Parse a PDF-derived text payload into clause segments."""
+
+    text = payload.decode("utf-8", errors="ignore")
+    blocks = re.split(r"\n\s*\n", text)
+    return _parse_text_blocks(blocks)
+
+
+def _strip_html(fragment: str) -> str:
+    text = _HTML_TAG_PATTERN.sub(" ", fragment)
+    return _WHITESPACE_PATTERN.sub(" ", text).strip()
+
+
+def parse_html_clauses(payload: bytes) -> List[ClauseSegment]:
+    """Parse an HTML payload into clause segments."""
+
+    html = payload.decode("utf-8", errors="ignore")
+    segments: List[ClauseSegment] = []
+    for match in _HTML_SECTION_PATTERN.finditer(html):
+        attributes = match.group(1) or ""
+        body = match.group(2) or ""
+
+        clause_ref_match = re.search(r'data-clause="([^"]+)"', attributes)
+        clause_ref = clause_ref_match.group(1) if clause_ref_match else None
+
+        pages_match = re.search(r'data-pages="([^"]+)"', attributes)
+        if pages_match:
+            numbers = re.findall(r"\d+", pages_match.group(1))
+            page_from = int(numbers[0]) if numbers else None
+            page_to = int(numbers[1]) if len(numbers) > 1 else page_from
+        else:
+            body_lines, page_from, page_to = _extract_pages(_clean_text_lines(body))
+            body = "\n".join(body_lines)
+
+        heading_match = re.search(r"<h[1-6][^>]*>(.*?)</h[1-6]>", body, re.IGNORECASE | re.DOTALL)
+        heading = _strip_html(heading_match.group(1)) if heading_match else None
+        paragraphs = [
+            _strip_html(fragment)
+            for fragment in re.findall(r"<p[^>]*>(.*?)</p>", body, re.IGNORECASE | re.DOTALL)
+        ]
+        text_span = " ".join(p for p in paragraphs if p).strip()
+        if not text_span:
+            text_span = _strip_html(body)
+
+        if clause_ref is None:
+            clause_ref = heading.split()[0] if heading else "unlabelled"
+
+        segments.append(
+            ClauseSegment(
+                clause_ref=clause_ref,
+                heading=heading,
+                text_span=text_span,
+                page_from=page_from,
+                page_to=page_to,
+            )
+        )
+
+    if not segments:
+        text = _strip_html(html)
+        blocks = re.split(r"\n\s*\n", text)
+        return _parse_text_blocks(blocks)
+
+    return segments
+
+
+def parse_document_clauses(payload: bytes, kind: str) -> List[ClauseSegment]:
+    """Parse *payload* according to *kind* and return clause segments."""
+
+    normalized_kind = (kind or "pdf").lower()
+    if normalized_kind in {"html", "sitemap"}:
+        return parse_html_clauses(payload)
+    return parse_pdf_clauses(payload)
+
+
+__all__ = [
+    "ClauseSegment",
+    "parse_document_clauses",
+    "parse_html_clauses",
+    "parse_pdf_clauses",
+]

--- a/backend/flows/__init__.py
+++ b/backend/flows/__init__.py
@@ -1,1 +1,16 @@
 """Prefect flows for backend orchestration."""
+
+from .ergonomics import DEFAULT_ERGONOMICS_METRICS, fetch_seeded_metrics, seed_ergonomics_metrics
+from .parse_segment import parse_reference_documents
+from .products import sync_vendor_products
+from .watch_fetch import FetchResult, watch_reference_sources
+
+__all__ = [
+    "DEFAULT_ERGONOMICS_METRICS",
+    "FetchResult",
+    "fetch_seeded_metrics",
+    "parse_reference_documents",
+    "seed_ergonomics_metrics",
+    "sync_vendor_products",
+    "watch_reference_sources",
+]

--- a/backend/flows/parse_segment.py
+++ b/backend/flows/parse_segment.py
@@ -1,0 +1,110 @@
+"""Prefect flow that parses stored reference documents into clauses."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from prefect import flow
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import selectinload
+
+from app.models.rkp import RefClause, RefDocument, RefSource
+from app.services.ref_documents import DocumentStorageService, get_document_storage_service
+from app.services.ref_parsers import ClauseSegment, parse_document_clauses
+
+
+def _classify_quality(segment: ClauseSegment) -> str:
+    if segment.heading and segment.text_span:
+        return "high"
+    if segment.text_span:
+        return "medium"
+    return "low"
+
+
+@flow(name="parse-reference-documents")
+async def parse_reference_documents(
+    session_factory: "async_sessionmaker[AsyncSession]",
+    *,
+    storage_service: Optional[DocumentStorageService] = None,
+    limit: Optional[int] = None,
+) -> List[Dict[str, int]]:
+    """Parse pending :class:`RefDocument` rows into :class:`RefClause` entries."""
+
+    storage = storage_service or get_document_storage_service()
+    summaries: List[Dict[str, int]] = []
+
+    async with session_factory() as session:
+        stmt = (
+            select(RefDocument)
+            .options(selectinload(RefDocument.source))
+            .where(RefDocument.suspected_update.is_(True))
+            .order_by(RefDocument.id)
+        )
+        if limit is not None:
+            stmt = stmt.limit(limit)
+
+        documents = (await session.execute(stmt)).scalars().unique().all()
+        for document in documents:
+            source = await _resolve_source(session, document)
+            if source is None:
+                continue
+
+            payload = await storage.read_document(document.storage_path)
+            segments = parse_document_clauses(payload, source.fetch_kind or "pdf")
+
+            await _clear_existing_clauses(session, document.id)
+            for segment in segments:
+                clause = RefClause(
+                    document_id=document.id,
+                    clause_ref=segment.clause_ref,
+                    section_heading=segment.heading,
+                    text_span=segment.text_span,
+                    page_from=segment.page_from,
+                    page_to=segment.page_to,
+                    extraction_quality=_classify_quality(segment),
+                )
+                session.add(clause)
+
+            document.suspected_update = False
+            await session.flush()
+            await session.commit()
+            summaries.append({"document_id": document.id, "clauses": len(segments)})
+
+    return summaries
+
+
+async def _resolve_source(session: AsyncSession, document: RefDocument):
+    source = getattr(document, "source", None)
+    if isinstance(source, list):
+        if source:
+            return source[0]
+        source = None
+    if source is not None:
+        return source
+    source_id = getattr(document, "source_id", None)
+    if source_id is None:
+        return None
+    return await session.get(RefSource, source_id)
+
+
+async def _clear_existing_clauses(session: AsyncSession, document_id: int) -> None:
+    database = getattr(session, "_database", None)
+    if database is not None and hasattr(database, "_data"):
+        rows = list(database._data.get(RefClause, []))  # type: ignore[attr-defined]
+        database._data[RefClause] = [  # type: ignore[attr-defined]
+            row for row in rows if getattr(row, "document_id", None) != document_id
+        ]
+        return
+
+    existing = (
+        await session.execute(select(RefClause).where(RefClause.document_id == document_id))
+    ).scalars().all()
+    delete_method = getattr(session, "delete", None)
+    if delete_method is None:
+        return
+    for clause in existing:
+        await delete_method(clause)
+
+
+__all__ = ["parse_reference_documents"]

--- a/backend/flows/watch_fetch.py
+++ b/backend/flows/watch_fetch.py
@@ -1,0 +1,228 @@
+"""Prefect flow that monitors reference sources for updated documents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Iterable, List, Mapping, Optional
+
+from prefect import flow
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models.rkp import RefDocument, RefSource
+from app.services.ref_documents import (
+    DocumentStorageService,
+    compute_document_checksum,
+    get_document_storage_service,
+)
+from app.services.ref_fetcher import DocumentFetcher, FetchResponse, get_document_fetcher
+
+
+@dataclass(slots=True)
+class FetchedPayload:
+    """Payload returned when a reference document is fetched."""
+
+    payload: bytes
+    etag: str | None
+    last_modified: str | None
+    content_type: str | None
+
+
+@dataclass(slots=True)
+class FetchResult:
+    """Summary describing a newly created :class:`RefDocument`."""
+
+    source_id: int
+    document_id: int
+    storage_path: str
+    checksum: str
+    suspected_update: bool
+    etag: str | None
+    last_modified: str | None
+
+
+_EXTENSION_BY_KIND = {"pdf": "pdf", "html": "html", "sitemap": "xml"}
+
+
+def _extension_for_kind(kind: str | None) -> str:
+    return _EXTENSION_BY_KIND.get((kind or "pdf").lower(), "bin")
+
+
+def _normalize_headers(headers: Mapping[str, str]) -> Dict[str, str]:
+    return {str(key).lower(): str(value) for key, value in headers.items()}
+
+
+def _header_lookup(headers: Iterable[Mapping[str, str]], key: str) -> str | None:
+    key_lower = key.lower()
+    for mapping in headers:
+        for header_key, value in mapping.items():
+            if str(header_key).lower() == key_lower:
+                return str(value)
+    return None
+
+
+async def _latest_document(session: AsyncSession, source_id: int) -> RefDocument | None:
+    stmt: Select[RefDocument] = (
+        select(RefDocument)
+        .where(RefDocument.source_id == source_id)
+        .order_by(RefDocument.retrieved_at.desc(), RefDocument.id.desc())
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    return result.scalars().first()
+
+
+async def _fetch_source_document(
+    source: RefSource,
+    fetcher: DocumentFetcher,
+    previous: RefDocument | None,
+) -> FetchedPayload | None:
+    conditional_headers: Dict[str, str] = {}
+    if previous and previous.http_etag:
+        conditional_headers["If-None-Match"] = previous.http_etag
+    if previous and previous.http_last_modified:
+        conditional_headers["If-Modified-Since"] = previous.http_last_modified
+
+    head_headers: Dict[str, str] = {}
+    if source.fetch_kind in {"pdf", "html", "sitemap"}:
+        try:
+            head_response: FetchResponse = await fetcher.head(
+                source.landing_url, headers=conditional_headers or None
+            )
+        except Exception:  # pragma: no cover - defensive; network errors are mocked in tests
+            head_response = None  # type: ignore[assignment]
+        if head_response is not None:
+            head_headers = _normalize_headers(head_response.headers)
+            if head_response.status_code == 304:
+                return None
+            if (
+                previous
+                and conditional_headers
+                and head_response.status_code == 200
+                and (
+                    (
+                        previous.http_etag
+                        and head_headers.get("etag") == previous.http_etag
+                    )
+                    or (
+                        not head_headers.get("etag")
+                        and previous.http_last_modified
+                        and head_headers.get("last-modified")
+                        == previous.http_last_modified
+                    )
+                )
+            ):
+                return None
+            if head_response.status_code >= 400 and head_response.status_code not in {405, 501}:
+                return None
+
+    try:
+        get_response = await fetcher.get(
+            source.landing_url, headers=conditional_headers or None
+        )
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+    if get_response.status_code in {304, 412}:
+        return None
+    if get_response.status_code >= 400:
+        return None
+
+    payload = get_response.content
+    if not payload:
+        return None
+
+    response_headers = _normalize_headers(get_response.headers)
+    etag = _header_lookup((response_headers, head_headers), "etag")
+    last_modified = _header_lookup((response_headers, head_headers), "last-modified")
+    content_type = _header_lookup((response_headers, head_headers), "content-type")
+    return FetchedPayload(
+        payload=payload,
+        etag=etag,
+        last_modified=last_modified,
+        content_type=content_type,
+    )
+
+
+def _derive_version_label(fetched: FetchedPayload) -> str:
+    if fetched.last_modified:
+        return fetched.last_modified
+    if fetched.etag:
+        return fetched.etag.strip('"')
+    return datetime.utcnow().isoformat()
+
+
+@flow(name="watch-reference-sources")
+async def watch_reference_sources(
+    session_factory: "async_sessionmaker[AsyncSession]",
+    *,
+    fetcher: Optional[DocumentFetcher] = None,
+    storage_service: Optional[DocumentStorageService] = None,
+    limit: Optional[int] = None,
+) -> List[FetchResult]:
+    """Iterate active :class:`RefSource` rows and record refreshed documents."""
+
+    created_fetcher = False
+    if fetcher is None:
+        fetcher = get_document_fetcher()
+        created_fetcher = True
+    storage = storage_service or get_document_storage_service()
+
+    results: List[FetchResult] = []
+    try:
+        async with session_factory() as session:
+            stmt = select(RefSource).where(RefSource.is_active.is_(True)).order_by(RefSource.id)
+            if limit is not None:
+                stmt = stmt.limit(limit)
+            sources = (await session.execute(stmt)).scalars().all()
+
+            for source in sources:
+                previous = await _latest_document(session, source.id)
+                fetched = await _fetch_source_document(source, fetcher, previous)
+                if fetched is None:
+                    continue
+
+                checksum = compute_document_checksum(fetched.payload)
+                if previous and previous.file_hash == checksum:
+                    continue
+
+                extension = _extension_for_kind(source.fetch_kind)
+                stored = await storage.write_document(
+                    source=source,
+                    payload=fetched.payload,
+                    extension=extension,
+                )
+
+                document = RefDocument(
+                    source_id=source.id,
+                    version_label=_derive_version_label(fetched),
+                    storage_path=stored.storage_path,
+                    file_hash=checksum,
+                    http_etag=fetched.etag,
+                    http_last_modified=fetched.last_modified,
+                    suspected_update=True,
+                )
+                session.add(document)
+                await session.flush()
+                await session.commit()
+
+                results.append(
+                    FetchResult(
+                        source_id=source.id,
+                        document_id=document.id,
+                        storage_path=document.storage_path,
+                        checksum=document.file_hash,
+                        suspected_update=document.suspected_update,
+                        etag=document.http_etag,
+                        last_modified=document.http_last_modified,
+                    )
+                )
+    finally:
+        if created_fetcher and hasattr(fetcher, "aclose"):
+            await fetcher.aclose()  # type: ignore[func-returns-value]
+
+    return results
+
+
+__all__ = ["FetchResult", "watch_reference_sources"]

--- a/backend/tests/test_flows/test_parse_segment_flow.py
+++ b/backend/tests/test_flows/test_parse_segment_flow.py
@@ -1,0 +1,116 @@
+"""Tests for the reference document parsing flow."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from sqlalchemy import select
+
+from app.models.rkp import RefClause, RefDocument, RefSource
+from app.services.ref_documents import compute_document_checksum
+from flows.parse_segment import parse_reference_documents
+
+
+@pytest.mark.asyncio
+async def test_parse_reference_documents(async_session_factory, ref_storage_service) -> None:
+    pdf_payload = (
+        "Clause 1.1: Means of Escape\n"
+        "Pages 1-2\n"
+        "Every building shall provide unobstructed exits.\n\n"
+        "Clause 2.0: Fire Resistance\n"
+        "Page 3\n"
+        "Structural elements must resist fire for two hours."
+    ).encode("utf-8")
+    html_payload = (
+        "<html><body>"
+        "<section data-clause=\"5.1\" data-pages=\"5-6\">"
+        "<h2>Escape Routes</h2>"
+        "<p>Routes to exits shall be clearly marked.</p>"
+        "</section>"
+        "</body></html>"
+    ).encode("utf-8")
+
+    async with async_session_factory() as session:
+        await session.execute(RefClause.__table__.delete())
+        await session.execute(RefDocument.__table__.delete())
+        await session.execute(RefSource.__table__.delete())
+        source_pdf = RefSource(
+            jurisdiction="SG",
+            authority="SCDF",
+            topic="fire",
+            doc_title="Fire Code",
+            landing_url="https://example.com/fire.pdf",
+            fetch_kind="pdf",
+            is_active=True,
+        )
+        source_html = RefSource(
+            jurisdiction="SG",
+            authority="BCA",
+            topic="accessibility",
+            doc_title="Accessibility Code",
+            landing_url="https://example.com/accessibility.html",
+            fetch_kind="html",
+            is_active=True,
+        )
+        session.add_all([source_pdf, source_html])
+        await session.flush()
+
+        stored_pdf = await ref_storage_service.write_document(
+            source=source_pdf, payload=pdf_payload, extension="pdf"
+        )
+        stored_html = await ref_storage_service.write_document(
+            source=source_html, payload=html_payload, extension="html"
+        )
+
+        document_pdf = RefDocument(
+            source_id=source_pdf.id,
+            storage_path=stored_pdf.storage_path,
+            file_hash=compute_document_checksum(pdf_payload),
+            http_etag='"pdf"',
+            suspected_update=True,
+        )
+        document_html = RefDocument(
+            source_id=source_html.id,
+            storage_path=stored_html.storage_path,
+            file_hash=compute_document_checksum(html_payload),
+            http_etag='"html"',
+            suspected_update=True,
+        )
+        session.add_all([document_pdf, document_html])
+        await session.commit()
+        pdf_id = document_pdf.id
+        html_id = document_html.id
+
+    summaries = await parse_reference_documents(
+        async_session_factory, storage_service=ref_storage_service
+    )
+
+    assert {summary["document_id"] for summary in summaries} == {pdf_id, html_id}
+
+    async with async_session_factory() as session:
+        pdf_doc = await session.get(RefDocument, pdf_id)
+        assert pdf_doc and pdf_doc.suspected_update is False
+        pdf_clauses = (
+            await session.execute(
+                select(RefClause)
+                .where(RefClause.document_id == pdf_id)
+                .order_by(RefClause.id)
+            )
+        ).scalars().all()
+        assert len(pdf_clauses) == 2
+        assert pdf_clauses[0].clause_ref == "1.1"
+        assert pdf_clauses[0].page_from == 1
+        assert "unobstructed exits" in pdf_clauses[0].text_span
+
+        html_doc = await session.get(RefDocument, html_id)
+        assert html_doc and html_doc.suspected_update is False
+        html_clauses = (
+            await session.execute(select(RefClause).where(RefClause.document_id == html_id))
+        ).scalars().all()
+        assert len(html_clauses) == 1
+        assert html_clauses[0].clause_ref == "5.1"
+        assert html_clauses[0].section_heading == "Escape Routes"
+        assert html_clauses[0].page_from == 5
+        assert "Routes to exits" in html_clauses[0].text_span

--- a/backend/tests/test_flows/test_watch_fetch_flow.py
+++ b/backend/tests/test_flows/test_watch_fetch_flow.py
@@ -1,0 +1,105 @@
+"""Tests for the reference document fetch flow."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from sqlalchemy import select
+
+from app.models.rkp import RefClause, RefDocument, RefSource
+from app.services.ref_documents import compute_document_checksum
+from app.services.ref_fetcher import FetchResponse
+from flows.watch_fetch import watch_reference_sources
+
+
+class StubFetcher:
+    """Simple fetcher stub returning predefined responses."""
+
+    def __init__(self, head_response: FetchResponse, get_response: FetchResponse) -> None:
+        self._head_response = head_response
+        self._get_response = get_response
+        self.head_calls: list[tuple[str, dict[str, str]]] = []
+        self.get_calls: list[tuple[str, dict[str, str]]] = []
+
+    async def head(self, url: str, headers=None) -> FetchResponse:
+        self.head_calls.append((url, dict(headers or {})))
+        return self._head_response
+
+    async def get(self, url: str, headers=None) -> FetchResponse:
+        self.get_calls.append((url, dict(headers or {})))
+        return self._get_response
+
+    async def aclose(self) -> None:  # pragma: no cover - simple stub
+        return None
+
+
+@pytest.mark.asyncio
+async def test_watch_reference_sources_creates_documents(
+    async_session_factory, ref_storage_service
+) -> None:
+    payload = (
+        b"Clause 1.1: Means of Escape\n"
+        b"Pages 1-2\n"
+        b"Every building shall provide unobstructed exits."
+    )
+
+    head_response = FetchResponse(
+        status_code=200,
+        headers={
+            "ETag": '"v1"',
+            "Last-Modified": "Mon, 01 Jan 2024 00:00:00 GMT",
+        },
+        content=b"",
+    )
+    get_response = FetchResponse(
+        status_code=200,
+        headers={"Content-Type": "application/pdf"},
+        content=payload,
+    )
+    fetcher = StubFetcher(head_response, get_response)
+
+    async with async_session_factory() as session:
+        await session.execute(RefClause.__table__.delete())
+        await session.execute(RefDocument.__table__.delete())
+        await session.execute(RefSource.__table__.delete())
+        source = RefSource(
+            jurisdiction="SG",
+            authority="SCDF",
+            topic="fire",
+            doc_title="Fire Code",
+            landing_url="https://example.com/fire.pdf",
+            fetch_kind="pdf",
+            is_active=True,
+        )
+        session.add(source)
+        await session.commit()
+        source_id = source.id
+
+    results = await watch_reference_sources(
+        async_session_factory,
+        fetcher=fetcher,
+        storage_service=ref_storage_service,
+        limit=1,
+    )
+
+    assert fetcher.head_calls
+    assert fetcher.get_calls
+    last_head_url, last_head_headers = fetcher.head_calls[-1]
+    assert last_head_url == "https://example.com/fire.pdf"
+    assert "If-None-Match" not in last_head_headers
+
+    assert results
+    summary = results[0]
+    assert summary.source_id == source_id
+    assert summary.checksum == compute_document_checksum(payload)
+
+    async with async_session_factory() as session:
+        documents = (await session.execute(select(RefDocument))).scalars().all()
+        assert len(documents) == 1
+        document = documents[0]
+        assert document.http_etag == '"v1"'
+        assert document.suspected_update is True
+        stored_bytes = await ref_storage_service.read_document(document.storage_path)
+        assert stored_bytes == payload


### PR DESCRIPTION
## Summary
- add storage, fetcher, and parser helpers for reference document ingestion
- create Prefect flows to watch active sources and parse stored documents into clauses
- extend test fixtures and add flow coverage for fetching and parsing scenarios

## Testing
- `pytest backend/tests/test_flows/test_parse_segment_flow.py backend/tests/test_flows/test_watch_fetch_flow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d1154b7b488320996439fe04e6bed8