### PR TITLE
Add IKEA products CSV JSON schema

### DIFF
--- a/docs/vendors/ikea_products.schema.json
+++ b/docs/vendors/ikea_products.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "IKEA Product CSV Schema",
+  "type": "object",
+  "properties": {
+    "brand": { "type": "string" },
+    "model": { "type": "string" },
+    "sku": { "type": "string" },
+    "category": { "type": "string" },
+    "width_mm": { "type": "integer", "minimum": 0 },
+    "depth_mm": { "type": "integer", "minimum": 0 },
+    "height_mm": { "type": "integer", "minimum": 0 },
+    "weight_kg": { "type": "number", "minimum": 0 },
+    "power_w": { "type": "number", "minimum": 0 },
+    "bim_uri": { "type": "string" },
+    "spec_uri": { "type": "string" }
+  },
+  "required": ["brand", "model", "sku", "category", "width_mm", "depth_mm", "height_mm"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add JSON schema for IKEA vendor product CSVs, including required dimensions and optional metadata fields

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1c863408483209908f42cd004f15a