### PR TITLE
Add CSV product sync flow with vendor-scoped deprecation

### DIFF
--- a/backend/flows/__init__.py
+++ b/backend/flows/__init__.py
@@ -3,6 +3,7 @@
 from .ergonomics import fetch_seeded_metrics, seed_ergonomics_metrics
 from .parse_segment import parse_reference_documents
 from .products import sync_vendor_products
+from .sync_products import sync_products_csv_once
 from .watch_fetch import watch_reference_sources
 
 __all__ = [
@@ -10,5 +11,6 @@ __all__ = [
     "parse_reference_documents",
     "seed_ergonomics_metrics",
     "sync_vendor_products",
+    "sync_products_csv_once",
     "watch_reference_sources",
 ]

--- a/backend/flows/adapters/__init__.py
+++ b/backend/flows/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Adapters for flow inputs."""
+
+from .products_csv_validator import ProductRow, ValidationReport, validate_csv
+
+__all__ = ["ProductRow", "ValidationReport", "validate_csv"]

--- a/backend/flows/adapters/products_csv_validator.py
+++ b/backend/flows/adapters/products_csv_validator.py
@@ -1,0 +1,154 @@
+"""Utilities for validating vendor product CSV exports."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Tuple
+
+__all__ = ["ProductRow", "ValidationReport", "validate_csv"]
+
+
+@dataclass(frozen=True)
+class ProductRow:
+    """Normalised representation of a single product row."""
+
+    sku: str
+    category: str
+    brand: str | None = None
+    model: str | None = None
+    name: str | None = None
+    product_code: str | None = None
+    width_mm: int | None = None
+    depth_mm: int | None = None
+    height_mm: int | None = None
+    weight_kg: float | None = None
+    power_w: float | None = None
+    bim_uri: str | None = None
+    spec_uri: str | None = None
+
+
+@dataclass
+class ValidationReport:
+    """Aggregate information about the CSV parsing process."""
+
+    total: int = 0
+    failed: int = 0
+    errors: List[str] = field(default_factory=list)
+
+    def model_dump(self) -> dict[str, object]:
+        """Return a serialisable representation."""
+
+        return {
+            "total": self.total,
+            "failed": self.failed,
+            "errors": list(self.errors),
+        }
+
+
+def _normalise_text(value: object | None) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _parse_int_field(raw: object | None) -> Tuple[int | None, str | None]:
+    text = _normalise_text(raw)
+    if text is None:
+        return None, None
+    try:
+        # Allow floats in the CSV by converting via ``float`` first.
+        return int(float(text)), None
+    except (TypeError, ValueError):
+        return None, text
+
+
+def _parse_float_field(raw: object | None) -> Tuple[float | None, str | None]:
+    text = _normalise_text(raw)
+    if text is None:
+        return None, None
+    try:
+        return float(text), None
+    except (TypeError, ValueError):
+        return None, text
+
+
+def _row_from_mapping(mapping: dict[str, object], *, line: int) -> Tuple[ProductRow | None, List[str]]:
+    errors: List[str] = []
+    sku = _normalise_text(mapping.get("sku"))
+    if not sku:
+        errors.append(f"Row {line}: missing SKU")
+        return None, errors
+
+    category = _normalise_text(mapping.get("category")) or "general"
+    brand = _normalise_text(mapping.get("brand"))
+    model = _normalise_text(mapping.get("model") or mapping.get("model_number"))
+    name = _normalise_text(mapping.get("name"))
+    product_code = _normalise_text(mapping.get("product_code") or sku)
+
+    width_mm, width_error = _parse_int_field(mapping.get("width_mm") or mapping.get("width"))
+    if width_error is not None:
+        errors.append(f"Row {line}: invalid width_mm value {width_error!r}")
+    depth_mm, depth_error = _parse_int_field(mapping.get("depth_mm") or mapping.get("depth"))
+    if depth_error is not None:
+        errors.append(f"Row {line}: invalid depth_mm value {depth_error!r}")
+    height_mm, height_error = _parse_int_field(mapping.get("height_mm") or mapping.get("height"))
+    if height_error is not None:
+        errors.append(f"Row {line}: invalid height_mm value {height_error!r}")
+
+    weight_kg, weight_error = _parse_float_field(mapping.get("weight_kg") or mapping.get("weight"))
+    if weight_error is not None:
+        errors.append(f"Row {line}: invalid weight_kg value {weight_error!r}")
+    power_w, power_error = _parse_float_field(mapping.get("power_w") or mapping.get("power"))
+    if power_error is not None:
+        errors.append(f"Row {line}: invalid power_w value {power_error!r}")
+
+    bim_uri = _normalise_text(mapping.get("bim_uri") or mapping.get("bim"))
+    spec_uri = _normalise_text(mapping.get("spec_uri") or mapping.get("spec"))
+
+    if errors:
+        return None, errors
+
+    row = ProductRow(
+        sku=sku,
+        category=category,
+        brand=brand,
+        model=model,
+        name=name,
+        product_code=product_code,
+        width_mm=width_mm,
+        depth_mm=depth_mm,
+        height_mm=height_mm,
+        weight_kg=weight_kg,
+        power_w=power_w,
+        bim_uri=bim_uri,
+        spec_uri=spec_uri,
+    )
+    return row, []
+
+
+def validate_csv(path: Path) -> Tuple[ValidationReport, List[ProductRow]]:
+    """Validate a vendor CSV file and return normalised rows."""
+
+    errors: List[str] = []
+    rows: List[ProductRow] = []
+    total = 0
+
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            report = ValidationReport(total=0, failed=1, errors=["missing header"])
+            return report, []
+        for line, mapping in enumerate(reader, start=2):  # account for header row
+            total += 1
+            row, row_errors = _row_from_mapping(dict(mapping), line=line)
+            if row_errors:
+                errors.extend(row_errors)
+                continue
+            if row is not None:
+                rows.append(row)
+
+    report = ValidationReport(total=total, failed=len(errors), errors=errors)
+    return report, rows

--- a/backend/flows/sync_products.py
+++ b/backend/flows/sync_products.py
@@ -1,0 +1,117 @@
+"""Flow utilities for synchronising vendor CSV product catalogues."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+from prefect import flow
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import AsyncSessionLocal
+from app.models.rkp import RefProduct
+
+from .adapters import ProductRow, validate_csv
+
+__all__ = [
+    "sync_products_csv_once",
+    "upsert_products",
+    "mark_deprecated",
+]
+
+
+def _row_to_payload(vendor: str, row: ProductRow) -> dict[str, object]:
+    name = row.name or " ".join(filter(None, (row.brand, row.model, row.sku))) or row.sku
+    product_code = row.product_code or row.sku
+    dimensions = {
+        key: value
+        for key, value in {
+            "width_mm": row.width_mm,
+            "depth_mm": row.depth_mm,
+            "height_mm": row.height_mm,
+        }.items()
+        if value is not None
+    }
+    specifications = {
+        key: value
+        for key, value in {
+            "weight_kg": row.weight_kg,
+            "power_w": row.power_w,
+        }.items()
+        if value is not None
+    }
+    return {
+        "vendor": vendor,
+        "category": row.category,
+        "product_code": product_code,
+        "name": name,
+        "brand": row.brand,
+        "model_number": row.model,
+        "sku": row.sku,
+        "dimensions": dimensions,
+        "specifications": specifications,
+        "bim_uri": row.bim_uri,
+        "spec_uri": row.spec_uri,
+        "is_active": True,
+    }
+
+
+async def upsert_products(session: AsyncSession, vendor: str, rows: Sequence[ProductRow]) -> int:
+    """Insert or update product rows for the given vendor."""
+
+    count = 0
+    for row in rows:
+        payload = _row_to_payload(vendor, row)
+        stmt = (
+            select(RefProduct)
+            .where(RefProduct.vendor == vendor)
+            .where(RefProduct.sku == row.sku)
+            .limit(1)
+        )
+        existing = (await session.execute(stmt)).scalar_one_or_none()
+        if existing:
+            for key, value in payload.items():
+                setattr(existing, key, value)
+        else:
+            session.add(RefProduct(**payload))
+        count += 1
+    return count
+
+
+async def mark_deprecated(session: AsyncSession, vendor: str, seen_skus: set[str]) -> int:
+    """Mark vendor products as inactive when missing from the latest feed."""
+
+    stmt = select(RefProduct).where(RefProduct.vendor == vendor)
+    result = await session.execute(stmt)
+    count = 0
+    for product in result.scalars():
+        if product.sku not in seen_skus and product.is_active:
+            product.is_active = False
+            count += 1
+        elif product.sku in seen_skus and not product.is_active:
+            product.is_active = True
+    return count
+
+
+@flow(name="sync_products_csv_once")
+async def sync_products_csv_once(csv_path: str, vendor: str = "ikea") -> dict[str, object]:
+    """Synchronise a vendor product CSV with the reference catalogue."""
+
+    path = Path(csv_path)
+    report, rows = validate_csv(path)
+    if report.failed > 0:
+        return {"ok": False, "report": report.model_dump()}
+
+    async with AsyncSessionLocal() as session:
+        inserted = await upsert_products(session, vendor, rows)
+        await session.commit()
+        deprecated = await mark_deprecated(session, vendor, {row.sku for row in rows})
+        await session.commit()
+
+    return {
+        "ok": True,
+        "inserted": inserted,
+        "deprecated": deprecated,
+        "report": report.model_dump(),
+    }


### PR DESCRIPTION
## Summary
- add a CSV validator for normalising vendor product rows
- implement a Prefect flow that upserts vendor products and deactivates missing SKUs
- export the new CSV sync flow from the flows package

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1c8c0fb2883208c26eb92d64fcd92