### PR TITLE
Add typed buildable client and advisories e2e

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,6 +12,10 @@ import './index.css'
 const router = createBrowserRouter([
   {
     path: '/',
+    element: <FeasibilityWizard />,
+  },
+  {
+    path: '/home',
     element: <HomeOverview />,
   },
   {

--- a/frontend/src/modules/feasibility/FeasibilityWizard.tsx
+++ b/frontend/src/modules/feasibility/FeasibilityWizard.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent, FormEvent } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { fetchBuildable, type BuildableResponse } from '../../api/buildable'
+import { fetchBuildable, type BuildableSummary } from '../../api/buildable'
 import { useTranslation } from '../../i18n'
 
 const DEFAULT_ASSUMPTIONS = {
@@ -53,7 +53,7 @@ export function FeasibilityWizard() {
   const [assumptionErrors, setAssumptionErrors] = useState<AssumptionErrors>({})
   const [appliedAssumptions, setAppliedAssumptions] = useState({ ...DEFAULT_ASSUMPTIONS })
   const [payload, setPayload] = useState<PendingPayload | null>(null)
-  const [result, setResult] = useState<BuildableResponse | null>(null)
+  const [result, setResult] = useState<BuildableSummary | null>(null)
   const [status, setStatus] = useState<WizardStatus>('idle')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [liveAnnouncement, setLiveAnnouncement] = useState('')
@@ -319,7 +319,7 @@ export function FeasibilityWizard() {
     return <p className="feasibility-assumptions__error">{t(messageKey)}</p>
   }
 
-  const renderProvenanceBadge = (provenance: BuildableResponse['rules'][number]['provenance']) => {
+  const renderProvenanceBadge = (provenance: BuildableSummary['rules'][number]['provenance']) => {
     if (provenance.documentId && provenance.pages && provenance.pages.length > 0) {
       return (
         <span className="feasibility-citation__badge">
@@ -356,25 +356,25 @@ export function FeasibilityWizard() {
         key: 'gfaCapM2',
         label: t('wizard.results.metrics.gfaCap'),
         value: numberFormatter.format(result.metrics.gfaCapM2),
-        testId: 'metric-gfa',
+        testId: 'gfa-cap',
       },
       {
         key: 'floorsMax',
         label: t('wizard.results.metrics.floorsMax'),
         value: numberFormatter.format(result.metrics.floorsMax),
-        testId: 'metric-floors',
+        testId: 'floors-max',
       },
       {
         key: 'footprintM2',
         label: t('wizard.results.metrics.footprint'),
         value: numberFormatter.format(result.metrics.footprintM2),
-        testId: 'metric-footprint',
+        testId: 'footprint',
       },
       {
         key: 'nsaEstM2',
         label: t('wizard.results.metrics.nsa'),
         value: numberFormatter.format(result.metrics.nsaEstM2),
-        testId: 'metric-nsa',
+        testId: 'nsa-est',
       },
     ]
     return (
@@ -432,11 +432,16 @@ export function FeasibilityWizard() {
                 value={addressInput}
                 onChange={handleAddressChange}
                 placeholder={t('wizard.form.addressPlaceholder')}
+                data-testid="address-input"
               />
               {addressError && <p className="feasibility-form__error">{addressError}</p>}
             </div>
             <div className="feasibility-form__actions">
-              <button type="submit" className="feasibility-form__submit">
+              <button
+                type="submit"
+                className="feasibility-form__submit"
+                data-testid="compute-button"
+              >
                 {status === 'loading'
                   ? t('wizard.form.submitLoading')
                   : t('wizard.form.submitLabel')}
@@ -461,6 +466,7 @@ export function FeasibilityWizard() {
                   min={0}
                   value={assumptionInputs.typFloorToFloorM}
                   onChange={handleAssumptionChange('typFloorToFloorM')}
+                  data-testid="assumption-floor"
                 />
                 <p className="feasibility-assumptions__hint">
                   {t('wizard.assumptions.fields.typFloorToFloor.hint', {
@@ -559,7 +565,7 @@ export function FeasibilityWizard() {
               )}
 
               {result.rules.length > 0 && (
-                <section className="feasibility-citations">
+                <section className="feasibility-citations" data-testid="citations">
                   <h3>{t('wizard.citations.title')}</h3>
                   <ul>
                     {result.rules.map((rule) => (

--- a/frontend/tests/e2e/feasibility-wizard.spec.ts
+++ b/frontend/tests/e2e/feasibility-wizard.spec.ts
@@ -32,16 +32,16 @@ test.describe('Feasibility wizard', () => {
       expect(new Set(overlayTexts)).toEqual(new Set(expectedOverlays))
 
       const numberFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 })
-      await expect(page.getByTestId('metric-gfa')).toHaveText(
+      await expect(page.getByTestId('gfa-cap')).toHaveText(
         numberFormatter.format(body.metrics.gfa_cap_m2),
       )
-      await expect(page.getByTestId('metric-floors')).toHaveText(
+      await expect(page.getByTestId('floors-max')).toHaveText(
         numberFormatter.format(body.metrics.floors_max),
       )
-      await expect(page.getByTestId('metric-footprint')).toHaveText(
+      await expect(page.getByTestId('footprint')).toHaveText(
         numberFormatter.format(body.metrics.footprint_m2),
       )
-      await expect(page.getByTestId('metric-nsa')).toHaveText(
+      await expect(page.getByTestId('nsa-est')).toHaveText(
         numberFormatter.format(body.metrics.nsa_est_m2),
       )
 
@@ -85,7 +85,7 @@ test.describe('Feasibility wizard', () => {
     await page.goto('/feasibility')
     await page.getByLabel('Site address').fill(address)
     await page.getByRole('button', { name: 'Compute feasibility' }).click()
-    await expect(page.getByTestId('metric-nsa')).toHaveText(
+    await expect(page.getByTestId('nsa-est')).toHaveText(
       new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(
         initialBody.metrics.nsa_est_m2,
       ),
@@ -103,7 +103,7 @@ test.describe('Feasibility wizard', () => {
     expect(lastEvent.status).toBe('success')
     expect(lastEvent.durationMs).toBeLessThan(500)
 
-    await expect(page.getByTestId('metric-nsa')).toHaveText(
+    await expect(page.getByTestId('nsa-est')).toHaveText(
       new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(
         updatedBody.metrics.nsa_est_m2,
       ),

--- a/frontend/tests/e2e/feasibility_advisories.spec.ts
+++ b/frontend/tests/e2e/feasibility_advisories.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@playwright/test'
+
+test('feasibility advisories render with citations', async ({ page }) => {
+  await page.goto('/')
+  await page.getByTestId('address-input').fill('123 Example Ave')
+  await page.getByTestId('compute-button').click()
+  await expect(page.getByTestId('zone-code')).toHaveText(/R|C|B/)
+  await expect(page.getByTestId('gfa-cap')).toContainText(/\d/)
+  await expect(page.getByTestId('citations')).toContainText(/clause|SCDF|URA|BCA|PUB/)
+  await page.getByTestId('assumption-floor').fill('3.5')
+  await expect(page.getByTestId('floors-max')).toContainText(/\d/)
+})


### PR DESCRIPTION
## Summary
- expose typed buildable API response/request shapes and a `postBuildable` helper that `fetchBuildable` reuses
- update the feasibility wizard to use the new types, surface test ids for key metrics and citations, and make it the default route
- add a Playwright end-to-end test that checks advisory citations render with seeded data

## Testing
- `npm install` *(fails: 403 fetching @playwright/test from the npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c8fa5c2c8320bbd16bd053811dd3