### PR TITLE
Add CSV product sync flow with vendor filtering

### DIFF
--- a/backend/flows/__init__.py
+++ b/backend/flows/__init__.py
@@ -3,6 +3,7 @@
 from .ergonomics import fetch_seeded_metrics, seed_ergonomics_metrics
 from .parse_segment import parse_reference_documents
 from .products import sync_vendor_products
+from .sync_products import sync_products_csv_once
 from .watch_fetch import watch_reference_sources
 
 __all__ = [
@@ -10,5 +11,6 @@ __all__ = [
     "parse_reference_documents",
     "seed_ergonomics_metrics",
     "sync_vendor_products",
+    "sync_products_csv_once",
     "watch_reference_sources",
 ]

--- a/backend/flows/sync_products.py
+++ b/backend/flows/sync_products.py
@@ -1,0 +1,213 @@
+"""Prefect flow for syncing vendor product CSV files."""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from prefect import flow, task
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.database import AsyncSessionLocal
+from app.models.rkp import RefProduct
+from flows.adapters.products_csv_validator import ProductRow, validate_csv
+
+
+def _table_column_names() -> set[str]:
+    """Return the set of column names available on :class:`RefProduct`."""
+
+    mapped = getattr(RefProduct, "__mapped_columns__", None)
+    if mapped:
+        return set(mapped.keys())
+    table = getattr(RefProduct, "__table__", None)
+    if table is None:  # pragma: no cover - defensive; RefProduct is declarative in practice
+        return set()
+    if hasattr(table, "columns"):
+        return {column.name for column in table.columns}
+    if hasattr(table, "c"):
+        return set(getattr(table, "c").keys())
+    return set()
+
+
+def _normalise_optional_url(value: str | None) -> str | None:
+    """Convert optional URL values to plain strings."""
+
+    if value is None:
+        return None
+    return str(value)
+
+
+def _build_product_values(row: ProductRow, vendor: str, now: dt.datetime) -> dict[str, object]:
+    """Construct a mapping of column values for a ``RefProduct`` upsert."""
+
+    columns = _table_column_names()
+    values: dict[str, object] = {}
+
+    def maybe_set(column: str, value: object) -> None:
+        if column in columns:
+            values[column] = value
+
+    maybe_set("vendor", vendor)
+    maybe_set("brand", row.brand)
+    if "model" in columns:
+        maybe_set("model", row.model)
+    else:
+        maybe_set("model_number", row.model)
+    maybe_set("sku", row.sku)
+    if "product_code" in columns and "sku" not in columns:
+        maybe_set("product_code", row.sku)
+    maybe_set("category", row.category)
+
+    dimensions = {
+        "width_mm": int(row.width_mm),
+        "depth_mm": int(row.depth_mm),
+        "height_mm": int(row.height_mm),
+    }
+    if "dimensions" in columns:
+        maybe_set("dimensions", dimensions)
+    else:
+        for key, value in dimensions.items():
+            maybe_set(key, value)
+
+    if "weight_kg" in columns:
+        maybe_set("weight_kg", float(row.weight_kg) if row.weight_kg is not None else None)
+    if "power_w" in columns:
+        maybe_set("power_w", float(row.power_w) if row.power_w is not None else None)
+    maybe_set("bim_uri", _normalise_optional_url(row.bim_uri))
+    maybe_set("spec_uri", _normalise_optional_url(row.spec_uri))
+    maybe_set("data_source", "csv")
+    if "last_synced_at" in columns:
+        maybe_set("last_synced_at", now)
+    if "deprecated_at" in columns:
+        maybe_set("deprecated_at", None)
+    if "is_active" in columns:
+        maybe_set("is_active", True)
+
+    return values
+
+
+def _sku_filters(vendor: str) -> tuple[list, dict[str, object]]:
+    """Return filters and additional insert defaults for vendor-aware lookups."""
+
+    columns = _table_column_names()
+    filters = []
+    defaults: dict[str, object] = {}
+
+    if "vendor" in columns:
+        filters.append(getattr(RefProduct, "vendor") == vendor)
+        defaults["vendor"] = vendor
+    if "data_source" in columns:
+        filters.append(getattr(RefProduct, "data_source") == "csv")
+        defaults["data_source"] = "csv"
+
+    return filters, defaults
+
+
+def _resolve_sku(row: RefProduct) -> str | None:
+    """Extract the SKU identifier from a ``RefProduct`` instance."""
+
+    if hasattr(row, "sku") and row.sku is not None:
+        return str(row.sku)
+    if hasattr(row, "product_code") and row.product_code is not None:
+        return str(row.product_code)
+    return None
+
+
+@task
+async def upsert_products(
+    session: AsyncSession, vendor: str, rows: Sequence[ProductRow]
+) -> int:
+    """Insert or update rows in the ``ref_products`` table."""
+
+    now = dt.datetime.now(dt.timezone.utc)
+    count = 0
+
+    sku_column_name = "sku" if "sku" in _table_column_names() else "product_code"
+    sku_column = getattr(RefProduct, sku_column_name)
+
+    filters, defaults = _sku_filters(vendor)
+
+    for row in rows:
+        stmt = select(RefProduct).where(sku_column == row.sku, *filters)
+        existing = (await session.execute(stmt)).scalar_one_or_none()
+        values = _build_product_values(row, vendor, now)
+        if existing:
+            for key, value in values.items():
+                setattr(existing, key, value)
+        else:
+            payload = {**defaults, **values}
+            instance = RefProduct(**payload)
+            session.add(instance)
+        count += 1
+    return count
+
+
+@task
+async def mark_deprecated(
+    session: AsyncSession, vendor: str, seen_skus: Iterable[str]
+) -> int:
+    """Mark products as deprecated when they disappear from the feed."""
+
+    seen = {str(sku) for sku in seen_skus}
+    filters, _ = _sku_filters(vendor)
+    stmt = select(RefProduct).where(*filters)
+    result = await session.execute(stmt)
+    rows = result.scalars().all()
+
+    now = dt.datetime.now(dt.timezone.utc)
+    count = 0
+    has_deprecated_at = "deprecated_at" in _table_column_names()
+    has_is_active = "is_active" in _table_column_names()
+
+    for row in rows:
+        sku = _resolve_sku(row)
+        if sku in seen:
+            continue
+        if has_deprecated_at and getattr(row, "deprecated_at", None) is not None:
+            continue
+        if has_is_active and getattr(row, "is_active", True) is False:
+            continue
+
+        if has_deprecated_at:
+            row.deprecated_at = now
+        if has_is_active:
+            row.is_active = False
+        session.add(row)
+        count += 1
+    return count
+
+
+@flow(name="sync_products_csv_once")
+async def sync_products_csv_once(
+    csv_path: str,
+    vendor: str = "ikea",
+    session_factory: async_sessionmaker[AsyncSession] | None = None,
+) -> dict[str, object]:
+    """Validate a CSV file and upsert its contents into ``ref_products``."""
+
+    path = Path(csv_path)
+    report, rows = validate_csv(path)
+    if report.failed > 0:
+        return {"ok": False, "report": report.model_dump()}
+
+    factory = session_factory or AsyncSessionLocal
+    rows_list = list(rows)
+    async with factory() as session:
+        upsert_callable = getattr(upsert_products, "fn", upsert_products)
+        mark_callable = getattr(mark_deprecated, "fn", mark_deprecated)
+        inserted = await upsert_callable(session, vendor, rows_list)
+        await session.commit()
+        deprecated = await mark_callable(session, vendor, {row.sku for row in rows_list})
+        await session.commit()
+    return {
+        "ok": True,
+        "inserted": inserted,
+        "deprecated": deprecated,
+        "report": report.model_dump(),
+    }
+
+
+__all__ = ["sync_products_csv_once", "upsert_products", "mark_deprecated"]
+

--- a/backend/prefect/__init__.py
+++ b/backend/prefect/__init__.py
@@ -7,13 +7,26 @@ from typing import Any, Callable, TypeVar
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-def flow(name: str | None = None) -> Callable[[F], F]:
+def flow(_func: F | None = None, *, name: str | None = None) -> Callable[[F], F] | F:
     """Return a no-op decorator mimicking `prefect.flow`."""
 
     def decorator(func: F) -> F:
         return func
 
+    if _func is not None and callable(_func):
+        return decorator(_func)
     return decorator
 
 
-__all__ = ["flow"]
+def task(_func: F | None = None, *, name: str | None = None) -> Callable[[F], F] | F:
+    """Return a no-op decorator mimicking `prefect.task`."""
+
+    def decorator(func: F) -> F:
+        return func
+
+    if _func is not None and callable(_func):
+        return decorator(_func)
+    return decorator
+
+
+__all__ = ["flow", "task"]

--- a/backend/tests/test_flows/test_sync_products_csv_flow.py
+++ b/backend/tests/test_flows/test_sync_products_csv_flow.py
@@ -1,0 +1,105 @@
+"""Tests for the CSV-based product sync flow."""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import Column, DateTime, Integer, String, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase
+
+from flows import sync_products as sync_products_flow
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Product(Base):
+    """Simplified reference product model for testing."""
+
+    __tablename__ = "ref_products"
+
+    id = Column(Integer, primary_key=True)
+    vendor = Column(String(100), nullable=False, index=True)
+    sku = Column(String(100), nullable=False, index=True)
+    data_source = Column(String(20), nullable=True)
+    deprecated_at = Column(DateTime, nullable=True)
+    last_synced_at = Column(DateTime, nullable=True)
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> async_sessionmaker[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+def _write_sample_csv(path: Path) -> None:
+    path.write_text(
+        """brand,model,sku,category,width_mm,depth_mm,height_mm,weight_kg,power_w,bim_uri,spec_uri
+IkeaBrand,ModernSeat,SKU-1,chair,600,500,400,12.5,20.1,https://example.com/bim1,https://example.com/spec1
+IkeaBrand,NewSeat,SKU-4,chair,650,520,410,11.2,18.5,https://example.com/bim4,https://example.com/spec4
+""",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_products_marks_missing_skus(
+    tmp_path: Path, session_factory: async_sessionmaker[AsyncSession], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Products absent from a vendor feed should be deprecated without touching others."""
+
+    monkeypatch.setattr(sync_products_flow, "RefProduct", Product, raising=False)
+
+    async with session_factory() as session:
+        session.add_all(
+            [
+                Product(vendor="ikea", sku="SKU-1", data_source="csv"),
+                Product(vendor="ikea", sku="SKU-2", data_source="csv"),
+                Product(vendor="ikea", sku="SKU-5", data_source="manual"),
+                Product(vendor="acme", sku="SKU-3", data_source="csv"),
+            ]
+        )
+        await session.commit()
+
+    csv_path = tmp_path / "products.csv"
+    _write_sample_csv(csv_path)
+
+    result = await sync_products_flow.sync_products_csv_once(
+        str(csv_path), vendor="ikea", session_factory=session_factory
+    )
+
+    assert result == {
+        "ok": True,
+        "inserted": 2,
+        "deprecated": 1,
+        "report": result["report"],
+    }
+    assert result["report"]["failed"] == 0
+
+    async with session_factory() as session:
+        rows = (
+            await session.execute(select(Product).order_by(Product.sku))
+        ).scalars().all()
+
+    by_sku = {row.sku: row for row in rows}
+
+    assert by_sku["SKU-1"].deprecated_at is None
+    assert by_sku["SKU-1"].data_source == "csv"
+    assert by_sku["SKU-2"].deprecated_at is not None
+    assert isinstance(by_sku["SKU-2"].deprecated_at, dt.datetime)
+    assert by_sku["SKU-3"].deprecated_at is None  # different vendor untouched
+    assert by_sku["SKU-5"].deprecated_at is None  # non-csv source untouched
+    assert by_sku["SKU-4"].vendor == "ikea"
+    assert by_sku["SKU-4"].data_source == "csv"
+


### PR DESCRIPTION
## Summary
- add a Prefect flow for syncing vendor CSV product feeds with vendor/data-source aware upserts and deprecations
- extend testing stubs for Prefect and Pydantic to support task decorators and constrained URL/number fields
- add a flow test covering vendor-specific deprecation behaviour and export the new flow

## Testing
- pytest backend/tests/test_flows/test_sync_products_csv_flow.py
- pytest backend/tests/test_flows

------
https://chatgpt.com/codex/tasks/task_e_68d1cfbaea348320859cdfb6eee4a5d0