### PR TITLE
Enable HTML reference source fetching

### DIFF
--- a/backend/app/services/reference_sources.py
+++ b/backend/app/services/reference_sources.py
@@ -72,14 +72,21 @@ class ReferenceSourceFetcher:
     ) -> Optional[FetchedDocument]:
         """Fetch ``source`` if it has been updated since ``existing``."""
 
+        fetch_kind = (getattr(source, "fetch_kind", None) or "pdf").lower()
         conditional_headers = self._conditional_headers(existing)
         head_response: Optional[HTTPResponse] = None
-        if source.fetch_kind == "pdf":
-            head_response = await self._safe_head(source.landing_url, headers=conditional_headers)
+        if fetch_kind in {"pdf", "html", "sitemap"}:
+            head_response = await self._safe_head(
+                source.landing_url,
+                headers=conditional_headers or None,
+            )
             if head_response and self._is_not_modified(head_response, existing):
                 return None
-        else:
-            head_response = await self._safe_head(source.landing_url, headers=conditional_headers)
+        elif conditional_headers:
+            head_response = await self._safe_head(
+                source.landing_url,
+                headers=conditional_headers or None,
+            )
             if head_response and head_response.status_code == 304:
                 return None
 


### PR DESCRIPTION
## Summary
- allow the watch flow to fetch any active reference source whose fetch kind is pdf, html, or sitemap instead of excluding update hints
- normalise fetch kind handling inside ReferenceSourceFetcher so HTML sources get conditional HEAD logic before fetching
- add a regression test that seeds the sample URA/BCA sources and ensures the flow writes RefDocument rows for them

## Testing
- pytest backend/tests/test_flows/test_watch_fetch_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68d1decdc3208320a50fb76085d3d140