### PR TITLE
Add flow to normalize reference rules

### DIFF
--- a/backend/flows/__init__.py
+++ b/backend/flows/__init__.py
@@ -1,6 +1,7 @@
 """Prefect flows for backend orchestration."""
 
 from .ergonomics import fetch_seeded_metrics, seed_ergonomics_metrics
+from .normalize_rules import normalize_reference_rules
 from .parse_segment import parse_reference_documents
 from .products import sync_vendor_products
 from .sync_products import sync_products_csv_once
@@ -8,6 +9,7 @@ from .watch_fetch import watch_reference_sources
 
 __all__ = [
     "fetch_seeded_metrics",
+    "normalize_reference_rules",
     "parse_reference_documents",
     "seed_ergonomics_metrics",
     "sync_vendor_products",

--- a/backend/flows/normalize_rules.py
+++ b/backend/flows/normalize_rules.py
@@ -1,0 +1,173 @@
+"""Flow for normalising reference clauses into structured rules."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from prefect import flow
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models.rkp import RefClause, RefDocument, RefRule, RefSource
+from app.services.normalize import NormalizedRule, RuleNormalizer
+
+
+@flow(name="normalize-reference-rules")
+async def normalize_reference_rules(
+    session_factory: "async_sessionmaker[AsyncSession]",
+    *,
+    clause_ids: Optional[Sequence[int]] = None,
+    normalizer: Optional[RuleNormalizer] = None,
+) -> List[Dict[str, Any]]:
+    """Generate structured rules from stored ``RefClause`` entries.
+
+    Parameters
+    ----------
+    session_factory:
+        Async SQLAlchemy session factory used for database interaction.
+    clause_ids:
+        Optional collection of clause identifiers to restrict processing to a
+        subset of records. When omitted, all clauses are considered.
+    normalizer:
+        Optional :class:`RuleNormalizer` instance. A default instance is created
+        when not provided so that callers can inject custom behaviour during
+        tests.
+
+    Returns
+    -------
+    list of dict
+        A summary of the rules detected for each processed clause. Each entry
+        contains the ``clause_id`` and the extracted ``parameter_key``.
+    """
+
+    normalizer = normalizer or RuleNormalizer()
+    clause_filter = list(clause_ids) if clause_ids is not None else []
+    results: List[Dict[str, Any]] = []
+
+    async with session_factory() as session:
+        stmt = _build_clause_query(clause_filter)
+        clauses = (await session.execute(stmt)).scalars().all()
+
+        for clause in clauses:
+            if not clause.text_span:
+                continue
+
+            document = await session.get(RefDocument, clause.document_id)
+            if document is None:
+                continue
+
+            source = await session.get(RefSource, document.source_id)
+            if source is None:
+                continue
+
+            matches = normalizer.normalize(clause.text_span)
+            if not matches:
+                continue
+
+            for match in matches:
+                rule = await _upsert_rule(session, clause, document, source, match)
+                results.append({
+                    "clause_id": clause.id,
+                    "parameter_key": rule.parameter_key,
+                })
+
+        await session.commit()
+
+    return results
+
+
+def _build_clause_query(clause_filter: Iterable[int]) -> Select[tuple[RefClause]]:
+    stmt = select(RefClause).order_by(RefClause.id)
+    ids = list(clause_filter)
+    if ids:
+        stmt = stmt.where(RefClause.id.in_(ids))
+    return stmt
+
+
+def _format_rule_value(value: Any) -> str:
+    if isinstance(value, float):
+        if value.is_integer():
+            return str(int(value))
+        return format(value, "g")
+    return str(value)
+
+
+def _collect_pages(clause: RefClause) -> List[int]:
+    pages: List[int] = []
+    for page in (clause.page_from, clause.page_to):
+        if page is None:
+            continue
+        page_int = int(page)
+        if page_int not in pages:
+            pages.append(page_int)
+    return pages
+
+
+def _build_provenance(clause: RefClause, document: RefDocument) -> Dict[str, Any]:
+    provenance: Dict[str, Any] = {
+        "document_id": document.id,
+        "clause_id": clause.id,
+        "document_hash": getattr(document, "file_hash", None),
+    }
+    pages = _collect_pages(clause)
+    if pages:
+        provenance["pages"] = pages
+    if clause.clause_ref:
+        provenance["clause_ref"] = clause.clause_ref
+    if getattr(document, "version_label", None):
+        provenance["document_version"] = document.version_label
+    return {key: value for key, value in provenance.items() if value not in (None, [], "")}
+
+
+async def _upsert_rule(
+    session: AsyncSession,
+    clause: RefClause,
+    document: RefDocument,
+    source: RefSource,
+    match: NormalizedRule,
+) -> RefRule:
+    stmt = (
+        select(RefRule)
+        .where(RefRule.document_id == document.id)
+        .where(RefRule.clause_ref == clause.clause_ref)
+        .where(RefRule.parameter_key == match.parameter_key)
+        .limit(1)
+    )
+    existing = (await session.execute(stmt)).scalar_one_or_none()
+    value = _format_rule_value(match.value)
+    provenance = _build_provenance(clause, document)
+
+    if existing:
+        existing.source_id = source.id
+        existing.document_id = document.id
+        existing.jurisdiction = source.jurisdiction
+        existing.authority = source.authority
+        existing.topic = source.topic
+        existing.clause_ref = clause.clause_ref
+        existing.operator = match.operator
+        existing.value = value
+        existing.unit = match.unit
+        existing.applicability = match.context or {}
+        existing.source_provenance = provenance
+        return existing
+
+    rule = RefRule(
+        source_id=source.id,
+        document_id=document.id,
+        jurisdiction=source.jurisdiction,
+        authority=source.authority,
+        topic=source.topic,
+        clause_ref=clause.clause_ref,
+        parameter_key=match.parameter_key,
+        operator=match.operator,
+        value=value,
+        unit=match.unit,
+        applicability=match.context or {},
+        source_provenance=provenance,
+        review_status="needs_review",
+    )
+    session.add(rule)
+    return rule
+
+
+__all__ = ["normalize_reference_rules"]

--- a/backend/tests/test_flows/test_normalize_rules_flow.py
+++ b/backend/tests/test_flows/test_normalize_rules_flow.py
@@ -1,0 +1,105 @@
+"""Tests for the reference rule normalisation flow."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from sqlalchemy import select
+
+from app.models.rkp import RefClause, RefDocument, RefRule, RefSource
+from flows.normalize_rules import normalize_reference_rules
+
+
+@pytest.mark.asyncio
+async def test_normalize_reference_rules_extracts_zoning_metrics(async_session_factory) -> None:
+    async with async_session_factory() as session:
+        source = RefSource(
+            jurisdiction="SG",
+            authority="URA",
+            topic="zoning",
+            doc_title="URA Zoning Handbook",
+            landing_url="https://example.com/zoning.pdf",
+        )
+        session.add(source)
+        await session.flush()
+
+        document = RefDocument(
+            source_id=source.id,
+            version_label="2024",
+            storage_path="s3://bucket/ura-2024.pdf",
+            file_hash="hash-2024",
+        )
+        session.add(document)
+        await session.flush()
+
+        clause = RefClause(
+            document_id=document.id,
+            clause_ref="5.1",
+            section_heading="Zoning Controls",
+            text_span=(
+                "The URA Master Plan specifies a maximum gross plot ratio of 3.5. "
+                "Building height shall not exceed 120 metres within the precinct. "
+                "Site coverage must not exceed 65 percent for new developments. "
+                "A minimum front setback of 7.5 m is required along arterial roads."
+            ),
+            page_from=12,
+            page_to=14,
+        )
+        session.add(clause)
+        await session.commit()
+        clause_id = clause.id
+        document_id = document.id
+        source_id = source.id
+
+    results = await normalize_reference_rules(async_session_factory)
+    assert any(item["parameter_key"] == "zoning.max_far" for item in results)
+
+    async with async_session_factory() as session:
+        rules = (
+            await session.execute(select(RefRule).order_by(RefRule.parameter_key))
+        ).scalars().all()
+
+    assert {rule.parameter_key for rule in rules} == {
+        "zoning.max_building_height_m",
+        "zoning.max_far",
+        "zoning.setback.front_min_m",
+        "zoning.site_coverage.max_percent",
+    }
+
+    for rule in rules:
+        assert rule.source_id == source_id
+        assert rule.document_id == document_id
+        assert rule.clause_ref == "5.1"
+        assert rule.review_status == "needs_review"
+        if rule.parameter_key == "zoning.max_far":
+            assert rule.value == "3.5"
+            assert rule.operator == "<="
+            assert rule.unit == "ratio"
+        elif rule.parameter_key == "zoning.max_building_height_m":
+            assert rule.value == "120"
+            assert rule.unit == "m"
+        elif rule.parameter_key == "zoning.site_coverage.max_percent":
+            assert rule.value == "65"
+            assert rule.unit == "percent"
+        elif rule.parameter_key == "zoning.setback.front_min_m":
+            assert rule.value == "7.5"
+            assert rule.unit == "m"
+
+        provenance = rule.source_provenance or {}
+        assert provenance["document_id"] == document_id
+        assert provenance["clause_id"] == clause_id
+        assert provenance["document_hash"] == "hash-2024"
+        assert provenance["pages"] == [12, 14]
+
+    # Re-running the flow should update existing rules rather than duplicating them.
+    repeat_results = await normalize_reference_rules(async_session_factory)
+    assert len(repeat_results) == len(results)
+
+    async with async_session_factory() as session:
+        total_rules = (
+            await session.execute(select(RefRule).where(RefRule.document_id == document_id))
+        ).scalars().all()
+    assert len(total_rules) == 4
+


### PR DESCRIPTION
## Summary
- add a Prefect flow that normalizes stored clauses into reference rules and upserts them with provenance
- expose the new flow in the flows package exports
- add flow tests covering zoning FAR, height, site coverage, and setback normalization

## Testing
- pytest backend/tests/test_flows/test_normalize_rules_flow.py


------
https://chatgpt.com/codex/tasks/task_e_68d1ded27a3c8320b05079b1ac7b4c3d