### PR TITLE
Handle optional advisory hints

### DIFF
--- a/frontend/src/api/buildable.ts
+++ b/frontend/src/api/buildable.ts
@@ -43,7 +43,7 @@ export type BuildableResponse = {
   input_kind: 'address' | 'geometry'
   zone_code: string | null
   overlays: string[]
-  advisory_hints: string[]
+  advisory_hints?: string[] | null
   metrics: {
     gfa_cap_m2: number
     floors_max: number
@@ -229,11 +229,15 @@ function mapRule(rule: RuleItem): BuildableRule {
 }
 
 function mapResponse(payload: BuildableResponse): BuildableSummary {
+  const advisoryHints = Array.isArray(payload.advisory_hints)
+    ? payload.advisory_hints.filter((hint): hint is string => typeof hint === 'string')
+    : []
+
   return {
     inputKind: payload.input_kind,
     zoneCode: payload.zone_code,
     overlays: [...payload.overlays],
-    advisoryHints: [...payload.advisory_hints],
+    advisoryHints: [...advisoryHints],
     metrics: {
       gfaCapM2: payload.metrics.gfa_cap_m2,
       floorsMax: payload.metrics.floors_max,

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -162,6 +162,9 @@
         "floorsMax": "Maximum floors",
         "footprint": "Max footprint",
         "nsa": "Net saleable area"
+      },
+      "advisory": {
+        "title": "Authority advisory hints"
       }
     },
     "citations": {

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -162,6 +162,9 @@
         "floorsMax": "最大階数",
         "footprint": "許容建築面積",
         "nsa": "販売可能床面積"
+      },
+      "advisory": {
+        "title": "当局からの助言"
       }
     },
     "citations": {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -885,6 +885,33 @@ h1, h2, h3 {
   font-weight: 600;
 }
 
+.feasibility-advisory {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background-color: rgba(15, 23, 42, 0.45);
+  padding: 1.25rem 1.5rem;
+  border-radius: 0.85rem;
+}
+
+.feasibility-advisory h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.feasibility-advisory ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.feasibility-advisory li {
+  line-height: 1.45;
+}
+
 .feasibility-citations {
   display: flex;
   flex-direction: column;

--- a/frontend/src/modules/feasibility/FeasibilityWizard.tsx
+++ b/frontend/src/modules/feasibility/FeasibilityWizard.tsx
@@ -389,6 +389,23 @@ export function FeasibilityWizard() {
     )
   }, [numberFormatter, result, t])
 
+  const advisoryView = useMemo(() => {
+    const hints = result?.advisoryHints ?? []
+    if (hints.length === 0) {
+      return null
+    }
+    return (
+      <section className="feasibility-advisory" data-testid="advisory-hints">
+        <h3>{t('wizard.results.advisory.title')}</h3>
+        <ul>
+          {hints.map((hint, index) => (
+            <li key={`${hint}-${index}`}>{hint}</li>
+          ))}
+        </ul>
+      </section>
+    )
+  }, [result, t])
+
   return (
     <div className="feasibility-wizard" data-testid="feasibility-wizard">
       <header className="feasibility-wizard__header">
@@ -555,6 +572,8 @@ export function FeasibilityWizard() {
               </header>
 
               {metricsView}
+
+              {advisoryView}
 
               {status === 'empty' && (
                 <p className="feasibility-results__empty">{t('wizard.states.empty')}</p>

--- a/frontend/tests/e2e/feasibility-wizard.spec.ts
+++ b/frontend/tests/e2e/feasibility-wizard.spec.ts
@@ -45,6 +45,16 @@ test.describe('Feasibility wizard', () => {
         numberFormatter.format(body.metrics.nsa_est_m2),
       )
 
+      const advisoryHints = Array.isArray(body.advisory_hints) ? body.advisory_hints : []
+      const advisoryLocator = page.getByTestId('advisory-hints')
+      if (advisoryHints.length > 0) {
+        await expect(advisoryLocator).toBeVisible()
+        const hints = await advisoryLocator.locator('li').allTextContents()
+        expect(new Set(hints)).toEqual(new Set(advisoryHints))
+      } else {
+        await expect(advisoryLocator).toHaveCount(0)
+      }
+
       if (body.rules.length > 0) {
         const firstRule = body.rules[0]
         await expect(page.getByText(firstRule.authority)).toBeVisible()


### PR DESCRIPTION
## Summary
- surface backend advisory hints in the feasibility wizard beneath the key metrics
- add localized copy and styling for the advisory list to match the results panel
- expand the feasibility Playwright spec to assert advisory hints are rendered when provided
- guard the API mapping and wizard rendering so missing advisory hints don't break the UI or tests

## Testing
- not run (pnpm install blocked by registry 403)


------
https://chatgpt.com/codex/tasks/task_e_68d1deea51a88320a83354b0e7d64673