### PR TITLE
Tighten finance defaults and JSON persistence

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,6 +3,6 @@
 from .base import Base  # noqa: F401
 
 # Import model modules so their metadata is registered with SQLAlchemy.
-from . import audit, imports, overlay, rkp, rulesets  # noqa: F401  pylint: disable=unused-import
+from . import audit, finance, imports, overlay, rkp, rulesets  # noqa: F401  pylint: disable=unused-import
 
 __all__ = ["Base"]

--- a/backend/app/models/finance.py
+++ b/backend/app/models/finance.py
@@ -1,0 +1,228 @@
+"""Financial modelling tables for pro forma scenarios."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import List
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from app.models.base import BaseModel
+from app.models.types import FlexibleJSONB
+
+
+JSONType = FlexibleJSONB
+
+
+class FinProject(BaseModel):
+    """Finance workspace seeded for a project."""
+
+    __tablename__ = "fin_projects"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    project_id: Mapped[int] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    currency: Mapped[str] = mapped_column(
+        String(3), nullable=False, default="USD", server_default="USD"
+    )
+    discount_rate: Mapped[Decimal | None] = mapped_column(Numeric(5, 4))
+    total_development_cost: Mapped[Decimal | None] = mapped_column(Numeric(16, 2))
+    total_gross_profit: Mapped[Decimal | None] = mapped_column(Numeric(16, 2))
+    metadata: Mapped[dict] = mapped_column(JSONType, default=dict, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    scenarios: Mapped[List["FinScenario"]] = relationship(
+        "FinScenario", back_populates="fin_project", cascade="all, delete-orphan"
+    )
+
+    __table_args__ = (
+        Index("idx_fin_projects_project_name", "project_id", "name"),
+    )
+
+
+class FinScenario(BaseModel):
+    """Scenario-specific underwriting assumptions."""
+
+    __tablename__ = "fin_scenarios"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    project_id: Mapped[int] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    fin_project_id: Mapped[int] = mapped_column(
+        ForeignKey("fin_projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text)
+    assumptions: Mapped[dict] = mapped_column(JSONType, default=dict, nullable=False)
+    is_primary: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    fin_project: Mapped[FinProject] = relationship(
+        "FinProject", back_populates="scenarios"
+    )
+    cost_items: Mapped[List["FinCostItem"]] = relationship(
+        "FinCostItem", back_populates="scenario", cascade="all, delete-orphan"
+    )
+    schedules: Mapped[List["FinSchedule"]] = relationship(
+        "FinSchedule", back_populates="scenario", cascade="all, delete-orphan"
+    )
+    capital_stack: Mapped[List["FinCapitalStack"]] = relationship(
+        "FinCapitalStack", back_populates="scenario", cascade="all, delete-orphan"
+    )
+    results: Mapped[List["FinResult"]] = relationship(
+        "FinResult", back_populates="scenario", cascade="all, delete-orphan"
+    )
+
+    __table_args__ = (
+        Index("idx_fin_scenarios_project_name", "project_id", "name"),
+    )
+
+
+class FinCostItem(BaseModel):
+    """Line item level detail for cost modelling."""
+
+    __tablename__ = "fin_cost_items"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    project_id: Mapped[int] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    scenario_id: Mapped[int] = mapped_column(
+        ForeignKey("fin_scenarios.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    category: Mapped[str | None] = mapped_column(String(50))
+    cost_group: Mapped[str | None] = mapped_column(String(50))
+    quantity: Mapped[Decimal | None] = mapped_column(Numeric(14, 2))
+    unit_cost: Mapped[Decimal | None] = mapped_column(Numeric(14, 2))
+    total_cost: Mapped[Decimal | None] = mapped_column(Numeric(16, 2))
+    metadata: Mapped[dict] = mapped_column(JSONType, default=dict, nullable=False)
+
+    scenario: Mapped[FinScenario] = relationship("FinScenario", back_populates="cost_items")
+
+    __table_args__ = (
+        Index("idx_fin_cost_items_project_name", "project_id", "name"),
+    )
+
+
+class FinSchedule(BaseModel):
+    """Monthly cash flow view for a scenario."""
+
+    __tablename__ = "fin_schedules"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    project_id: Mapped[int] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    scenario_id: Mapped[int] = mapped_column(
+        ForeignKey("fin_scenarios.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    month_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    hard_cost: Mapped[Decimal | None] = mapped_column(Numeric(16, 2))
+    soft_cost: Mapped[Decimal | None] = mapped_column(Numeric(16, 2))
+    revenue: Mapped[Decimal | None] = mapped_column(Numeric(16, 2))
+    cash_flow: Mapped[Decimal | None] = mapped_column(Numeric(16, 2))
+    cumulative_cash_flow: Mapped[Decimal | None] = mapped_column(Numeric(16, 2))
+    metadata: Mapped[dict] = mapped_column(JSONType, default=dict, nullable=False)
+
+    scenario: Mapped[FinScenario] = relationship("FinScenario", back_populates="schedules")
+
+    __table_args__ = (
+        Index("idx_fin_schedules_project_month", "project_id", "month_index"),
+    )
+
+
+class FinCapitalStack(BaseModel):
+    """Capital stack composition for financing mix."""
+
+    __tablename__ = "fin_capital_stacks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    project_id: Mapped[int] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    scenario_id: Mapped[int] = mapped_column(
+        ForeignKey("fin_scenarios.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    source_type: Mapped[str | None] = mapped_column(String(50))
+    tranche_order: Mapped[int | None] = mapped_column(Integer)
+    amount: Mapped[Decimal | None] = mapped_column(Numeric(16, 2))
+    rate: Mapped[Decimal | None] = mapped_column(Numeric(8, 4))
+    equity_share: Mapped[Decimal | None] = mapped_column(Numeric(6, 4))
+    metadata: Mapped[dict] = mapped_column(JSONType, default=dict, nullable=False)
+
+    scenario: Mapped[FinScenario] = relationship(
+        "FinScenario", back_populates="capital_stack"
+    )
+
+    __table_args__ = (
+        Index("idx_fin_capital_stacks_project_name", "project_id", "name"),
+    )
+
+
+class FinResult(BaseModel):
+    """Key results emitted from financing calculations."""
+
+    __tablename__ = "fin_results"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    project_id: Mapped[int] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    scenario_id: Mapped[int] = mapped_column(
+        ForeignKey("fin_scenarios.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    value: Mapped[Decimal | None] = mapped_column(Numeric(16, 4))
+    unit: Mapped[str | None] = mapped_column(String(20))
+    metadata: Mapped[dict] = mapped_column(JSONType, default=dict, nullable=False)
+
+    scenario: Mapped[FinScenario] = relationship("FinScenario", back_populates="results")
+
+    __table_args__ = (
+        Index("idx_fin_results_project_name", "project_id", "name"),
+    )
+
+
+__all__ = [
+    "FinProject",
+    "FinScenario",
+    "FinCostItem",
+    "FinSchedule",
+    "FinCapitalStack",
+    "FinResult",
+]

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,10 +1,10 @@
+import asyncio
 from logging.config import fileConfig
+
+from alembic import context
 from sqlalchemy import pool
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import create_async_engine
-import asyncio
-
-from alembic import context
 
 # Import your models
 from app.models import Base

--- a/backend/migrations/versions/20240801_000003_add_finance_tables.py
+++ b/backend/migrations/versions/20240801_000003_add_finance_tables.py
@@ -1,0 +1,276 @@
+"""Create finance modelling tables."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "20240801_000003"
+down_revision = "20240626_000002"
+branch_labels = None
+depends_on = None
+
+
+JSONB_TYPE = postgresql.JSONB(astext_type=sa.Text())
+
+
+def upgrade() -> None:
+    """Apply the migration."""
+
+    op.create_table(
+        "fin_projects",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.Integer(),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column(
+            "currency",
+            sa.String(length=3),
+            nullable=False,
+            server_default=sa.text("'USD'"),
+        ),
+        sa.Column("discount_rate", sa.Numeric(5, 4), nullable=True),
+        sa.Column("total_development_cost", sa.Numeric(16, 2), nullable=True),
+        sa.Column("total_gross_profit", sa.Numeric(16, 2), nullable=True),
+        sa.Column("metadata", JSONB_TYPE, nullable=False, server_default=sa.text("'{}'")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_fin_projects_project_id", "fin_projects", ["project_id"])
+    op.create_index("ix_fin_projects_created_at", "fin_projects", ["created_at"])
+    op.create_index(
+        "idx_fin_projects_project_name",
+        "fin_projects",
+        ["project_id", "name"],
+    )
+
+    op.create_table(
+        "fin_scenarios",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.Integer(),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "fin_project_id",
+            sa.Integer(),
+            sa.ForeignKey("fin_projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "assumptions", JSONB_TYPE, nullable=False, server_default=sa.text("'{}'")
+        ),
+        sa.Column(
+            "is_primary",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_fin_scenarios_project_id", "fin_scenarios", ["project_id"])
+    op.create_index("ix_fin_scenarios_fin_project_id", "fin_scenarios", ["fin_project_id"])
+    op.create_index("ix_fin_scenarios_is_primary", "fin_scenarios", ["is_primary"])
+    op.create_index("ix_fin_scenarios_created_at", "fin_scenarios", ["created_at"])
+    op.create_index(
+        "idx_fin_scenarios_project_name",
+        "fin_scenarios",
+        ["project_id", "name"],
+    )
+
+    op.create_table(
+        "fin_cost_items",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.Integer(),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "scenario_id",
+            sa.Integer(),
+            sa.ForeignKey("fin_scenarios.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("category", sa.String(length=50), nullable=True),
+        sa.Column("cost_group", sa.String(length=50), nullable=True),
+        sa.Column("quantity", sa.Numeric(14, 2), nullable=True),
+        sa.Column("unit_cost", sa.Numeric(14, 2), nullable=True),
+        sa.Column("total_cost", sa.Numeric(16, 2), nullable=True),
+        sa.Column("metadata", JSONB_TYPE, nullable=False, server_default=sa.text("'{}'")),
+    )
+    op.create_index("ix_fin_cost_items_project_id", "fin_cost_items", ["project_id"])
+    op.create_index("ix_fin_cost_items_scenario_id", "fin_cost_items", ["scenario_id"])
+    op.create_index(
+        "idx_fin_cost_items_project_name",
+        "fin_cost_items",
+        ["project_id", "name"],
+    )
+
+    op.create_table(
+        "fin_schedules",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.Integer(),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "scenario_id",
+            sa.Integer(),
+            sa.ForeignKey("fin_scenarios.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("month_index", sa.Integer(), nullable=False),
+        sa.Column("hard_cost", sa.Numeric(16, 2), nullable=True),
+        sa.Column("soft_cost", sa.Numeric(16, 2), nullable=True),
+        sa.Column("revenue", sa.Numeric(16, 2), nullable=True),
+        sa.Column("cash_flow", sa.Numeric(16, 2), nullable=True),
+        sa.Column("cumulative_cash_flow", sa.Numeric(16, 2), nullable=True),
+        sa.Column("metadata", JSONB_TYPE, nullable=False, server_default=sa.text("'{}'")),
+    )
+    op.create_index("ix_fin_schedules_project_id", "fin_schedules", ["project_id"])
+    op.create_index("ix_fin_schedules_scenario_id", "fin_schedules", ["scenario_id"])
+    op.create_index(
+        "idx_fin_schedules_project_month",
+        "fin_schedules",
+        ["project_id", "month_index"],
+    )
+
+    op.create_table(
+        "fin_capital_stacks",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.Integer(),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "scenario_id",
+            sa.Integer(),
+            sa.ForeignKey("fin_scenarios.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("source_type", sa.String(length=50), nullable=True),
+        sa.Column("tranche_order", sa.Integer(), nullable=True),
+        sa.Column("amount", sa.Numeric(16, 2), nullable=True),
+        sa.Column("rate", sa.Numeric(8, 4), nullable=True),
+        sa.Column("equity_share", sa.Numeric(6, 4), nullable=True),
+        sa.Column("metadata", JSONB_TYPE, nullable=False, server_default=sa.text("'{}'")),
+    )
+    op.create_index(
+        "ix_fin_capital_stacks_project_id",
+        "fin_capital_stacks",
+        ["project_id"],
+    )
+    op.create_index(
+        "ix_fin_capital_stacks_scenario_id",
+        "fin_capital_stacks",
+        ["scenario_id"],
+    )
+    op.create_index(
+        "idx_fin_capital_stacks_project_name",
+        "fin_capital_stacks",
+        ["project_id", "name"],
+    )
+
+    op.create_table(
+        "fin_results",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.Integer(),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "scenario_id",
+            sa.Integer(),
+            sa.ForeignKey("fin_scenarios.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("value", sa.Numeric(16, 4), nullable=True),
+        sa.Column("unit", sa.String(length=20), nullable=True),
+        sa.Column("metadata", JSONB_TYPE, nullable=False, server_default=sa.text("'{}'")),
+    )
+    op.create_index("ix_fin_results_project_id", "fin_results", ["project_id"])
+    op.create_index("ix_fin_results_scenario_id", "fin_results", ["scenario_id"])
+    op.create_index(
+        "idx_fin_results_project_name",
+        "fin_results",
+        ["project_id", "name"],
+    )
+
+
+def downgrade() -> None:
+    """Revert the migration."""
+
+    op.drop_index("idx_fin_results_project_name", table_name="fin_results")
+    op.drop_index("ix_fin_results_scenario_id", table_name="fin_results")
+    op.drop_index("ix_fin_results_project_id", table_name="fin_results")
+    op.drop_table("fin_results")
+
+    op.drop_index("idx_fin_capital_stacks_project_name", table_name="fin_capital_stacks")
+    op.drop_index("ix_fin_capital_stacks_scenario_id", table_name="fin_capital_stacks")
+    op.drop_index("ix_fin_capital_stacks_project_id", table_name="fin_capital_stacks")
+    op.drop_table("fin_capital_stacks")
+
+    op.drop_index("idx_fin_schedules_project_month", table_name="fin_schedules")
+    op.drop_index("ix_fin_schedules_scenario_id", table_name="fin_schedules")
+    op.drop_index("ix_fin_schedules_project_id", table_name="fin_schedules")
+    op.drop_table("fin_schedules")
+
+    op.drop_index("idx_fin_cost_items_project_name", table_name="fin_cost_items")
+    op.drop_index("ix_fin_cost_items_scenario_id", table_name="fin_cost_items")
+    op.drop_index("ix_fin_cost_items_project_id", table_name="fin_cost_items")
+    op.drop_table("fin_cost_items")
+
+    op.drop_index("idx_fin_scenarios_project_name", table_name="fin_scenarios")
+    op.drop_index("ix_fin_scenarios_created_at", table_name="fin_scenarios")
+    op.drop_index("ix_fin_scenarios_is_primary", table_name="fin_scenarios")
+    op.drop_index("ix_fin_scenarios_fin_project_id", table_name="fin_scenarios")
+    op.drop_index("ix_fin_scenarios_project_id", table_name="fin_scenarios")
+    op.drop_table("fin_scenarios")
+
+    op.drop_index("idx_fin_projects_project_name", table_name="fin_projects")
+    op.drop_index("ix_fin_projects_created_at", table_name="fin_projects")
+    op.drop_index("ix_fin_projects_project_id", table_name="fin_projects")
+    op.drop_table("fin_projects")


### PR DESCRIPTION
## Summary
- require empty-object defaults for finance JSON columns and enforce non-null constraints in the ORM models
- align the Alembic revision with the stricter defaults so finance tables seed deterministic values

## Testing
- `pytest backend/tests/test_flows/test_watch_fetch_flow.py::test_watch_fetch_records_new_document -q`
- `PYTHONPATH=backend SQLALCHEMY_DATABASE_URI=sqlite+aiosqlite:///./test.db python -m alembic upgrade head` *(fails: alembic module is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ed6c3464832091f81a90e26e03c5