### PR TITLE
Add finance metrics instrumentation and coverage

### DIFF
--- a/backend/app/api/v1/finance.py
+++ b/backend/app/api/v1/finance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import io
+from time import perf_counter
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from typing import Iterator, List, Optional
 
@@ -199,214 +200,223 @@ async def run_finance_feasibility(
     """Compute feasibility metrics, persist results and return a summary."""
 
     metrics.REQUEST_COUNTER.labels(endpoint="finance_feasibility").inc()
-    log_event(
-        logger,
-        "finance_feasibility_received",
-        project_id=payload.project_id,
-        scenario=payload.scenario.name,
-    )
-
-    fin_project: FinProject | None = None
-    if payload.fin_project_id is not None:
-        fin_project = await session.get(FinProject, payload.fin_project_id)
-        if fin_project is None:
-            raise HTTPException(status_code=404, detail="Finance project not found")
-    else:
-        stmt = (
-            select(FinProject)
-            .where(FinProject.project_id == payload.project_id)
-            .order_by(FinProject.id)
-            .limit(1)
-        )
-        result = await session.execute(stmt)
-        fin_project = result.scalar_one_or_none()
-
-    if fin_project is None:
-        fin_project = FinProject(
-            project_id=payload.project_id,
-            name=payload.project_name or payload.scenario.name,
-            currency=payload.scenario.currency,
-            discount_rate=payload.scenario.cash_flow.discount_rate,
-            metadata={},
-        )
-        session.add(fin_project)
-        await session.flush()
-    else:
-        fin_project.currency = payload.scenario.currency
-        fin_project.discount_rate = payload.scenario.cash_flow.discount_rate
-
-    scenario = FinScenario(
-        project_id=payload.project_id,
-        fin_project_id=fin_project.id,
-        name=payload.scenario.name,
-        description=payload.scenario.description,
-        assumptions=payload.scenario.model_dump(mode="json"),
-        is_primary=payload.scenario.is_primary,
-    )
-    session.add(scenario)
-    await session.flush()
-
-    cost_input = payload.scenario.cost_escalation
-    stmt = select(RefCostIndex).where(
-        RefCostIndex.series_name == cost_input.series_name,
-        RefCostIndex.jurisdiction == cost_input.jurisdiction,
-    )
-    if cost_input.provider:
-        stmt = stmt.where(RefCostIndex.provider == cost_input.provider)
-    indices_result = await session.execute(stmt)
-    indices: List[RefCostIndex] = list(indices_result.scalars().all())
-
-    escalated_cost = calculator.escalate_amount(
-        cost_input.amount,
-        base_period=cost_input.base_period,
-        indices=indices,
-        series_name=cost_input.series_name,
-        jurisdiction=cost_input.jurisdiction,
-        provider=cost_input.provider,
-    )
-
-    latest_index = RefCostIndex.latest(
-        indices,
-        jurisdiction=cost_input.jurisdiction,
-        provider=cost_input.provider,
-        series_name=cost_input.series_name,
-    )
-    base_index: RefCostIndex | None = None
-    for index in indices:
-        if str(index.period) != cost_input.base_period:
-            continue
-        if index.series_name != cost_input.series_name:
-            continue
-        if index.jurisdiction != cost_input.jurisdiction:
-            continue
-        if cost_input.provider and index.provider != cost_input.provider:
-            continue
-        base_index = index
-        break
-
-    base_snapshot = _build_cost_index_snapshot(base_index)
-    latest_snapshot = _build_cost_index_snapshot(latest_index)
-    cost_provenance = CostIndexProvenance(
-        series_name=cost_input.series_name,
-        jurisdiction=cost_input.jurisdiction,
-        provider=cost_input.provider,
-        base_period=cost_input.base_period,
-        latest_period=str(latest_snapshot.period) if latest_snapshot else None,
-        scalar=_compute_scalar(base_snapshot, latest_snapshot),
-        base_index=base_snapshot,
-        latest_index=latest_snapshot,
-    )
-
-    cash_inputs = payload.scenario.cash_flow
-    npv_value = calculator.npv(cash_inputs.discount_rate, cash_inputs.cash_flows)
-    npv_rounded = npv_value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
-
-    irr_value: Optional[Decimal] = None
-    irr_metadata = {
-        "cash_flows": [str(value) for value in cash_inputs.cash_flows],
-        "discount_rate": str(cash_inputs.discount_rate),
-    }
+    metrics.FINANCE_FEASIBILITY_TOTAL.inc()
+    start_time = perf_counter()
+    response: FinanceFeasibilityResponse | None = None
     try:
-        irr_raw = calculator.irr(cash_inputs.cash_flows)
-        irr_value = irr_raw.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
-    except ValueError:
-        irr_metadata["warning"] = "IRR could not be computed for the provided cash flows"
+        log_event(
+            logger,
+            "finance_feasibility_received",
+            project_id=payload.project_id,
+            scenario=payload.scenario.name,
+        )
 
-    dscr_entries: List[DscrEntrySchema] = []
-    dscr_metadata: dict[str, List[dict[str, object]]] = {}
-    if payload.scenario.dscr:
-        try:
-            timeline = calculator.dscr_timeline(
-                payload.scenario.dscr.net_operating_incomes,
-                payload.scenario.dscr.debt_services,
-                period_labels=payload.scenario.dscr.period_labels,
-                currency=payload.scenario.currency,
+        fin_project: FinProject | None = None
+        if payload.fin_project_id is not None:
+            fin_project = await session.get(FinProject, payload.fin_project_id)
+            if fin_project is None:
+                raise HTTPException(status_code=404, detail="Finance project not found")
+        else:
+            stmt = (
+                select(FinProject)
+                .where(FinProject.project_id == payload.project_id)
+                .order_by(FinProject.id)
+                .limit(1)
             )
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        dscr_entries = [_convert_dscr_entry(entry) for entry in timeline]
-        dscr_metadata = {
-            "entries": [entry.model_dump(mode="json") for entry in dscr_entries],
+            result = await session.execute(stmt)
+            fin_project = result.scalar_one_or_none()
+
+        if fin_project is None:
+            fin_project = FinProject(
+                project_id=payload.project_id,
+                name=payload.project_name or payload.scenario.name,
+                currency=payload.scenario.currency,
+                discount_rate=payload.scenario.cash_flow.discount_rate,
+                metadata={},
+            )
+            session.add(fin_project)
+            await session.flush()
+        else:
+            fin_project.currency = payload.scenario.currency
+            fin_project.discount_rate = payload.scenario.cash_flow.discount_rate
+
+        scenario = FinScenario(
+            project_id=payload.project_id,
+            fin_project_id=fin_project.id,
+            name=payload.scenario.name,
+            description=payload.scenario.description,
+            assumptions=payload.scenario.model_dump(mode="json"),
+            is_primary=payload.scenario.is_primary,
+        )
+        session.add(scenario)
+        await session.flush()
+
+        cost_input = payload.scenario.cost_escalation
+        stmt = select(RefCostIndex).where(
+            RefCostIndex.series_name == cost_input.series_name,
+            RefCostIndex.jurisdiction == cost_input.jurisdiction,
+        )
+        if cost_input.provider:
+            stmt = stmt.where(RefCostIndex.provider == cost_input.provider)
+        indices_result = await session.execute(stmt)
+        indices: List[RefCostIndex] = list(indices_result.scalars().all())
+
+        escalated_cost = calculator.escalate_amount(
+            cost_input.amount,
+            base_period=cost_input.base_period,
+            indices=indices,
+            series_name=cost_input.series_name,
+            jurisdiction=cost_input.jurisdiction,
+            provider=cost_input.provider,
+        )
+
+        latest_index = RefCostIndex.latest(
+            indices,
+            jurisdiction=cost_input.jurisdiction,
+            provider=cost_input.provider,
+            series_name=cost_input.series_name,
+        )
+        base_index: RefCostIndex | None = None
+        for index in indices:
+            if str(index.period) != cost_input.base_period:
+                continue
+            if index.series_name != cost_input.series_name:
+                continue
+            if index.jurisdiction != cost_input.jurisdiction:
+                continue
+            if cost_input.provider and index.provider != cost_input.provider:
+                continue
+            base_index = index
+            break
+
+        base_snapshot = _build_cost_index_snapshot(base_index)
+        latest_snapshot = _build_cost_index_snapshot(latest_index)
+        cost_provenance = CostIndexProvenance(
+            series_name=cost_input.series_name,
+            jurisdiction=cost_input.jurisdiction,
+            provider=cost_input.provider,
+            base_period=cost_input.base_period,
+            latest_period=str(latest_snapshot.period) if latest_snapshot else None,
+            scalar=_compute_scalar(base_snapshot, latest_snapshot),
+            base_index=base_snapshot,
+            latest_index=latest_snapshot,
+        )
+
+        cash_inputs = payload.scenario.cash_flow
+        npv_value = calculator.npv(cash_inputs.discount_rate, cash_inputs.cash_flows)
+        npv_rounded = npv_value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+        irr_value: Optional[Decimal] = None
+        irr_metadata = {
+            "cash_flows": [str(value) for value in cash_inputs.cash_flows],
+            "discount_rate": str(cash_inputs.discount_rate),
         }
+        try:
+            irr_raw = calculator.irr(cash_inputs.cash_flows)
+            irr_value = irr_raw.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
+        except ValueError:
+            irr_metadata["warning"] = "IRR could not be computed for the provided cash flows"
 
-    results: List[FinResult] = [
-        FinResult(
-            project_id=payload.project_id,
-            scenario_id=scenario.id,
-            name="escalated_cost",
-            value=escalated_cost,
-            unit=payload.scenario.currency,
-            metadata={
-                "base_amount": str(cost_input.amount),
-                "base_period": cost_input.base_period,
-                "cost_index": cost_provenance.model_dump(mode="json"),
-            },
-        ),
-        FinResult(
-            project_id=payload.project_id,
-            scenario_id=scenario.id,
-            name="npv",
-            value=npv_rounded,
-            unit=payload.scenario.currency,
-            metadata={
-                "discount_rate": str(cash_inputs.discount_rate),
-                "cash_flows": [str(value) for value in cash_inputs.cash_flows],
-            },
-        ),
-        FinResult(
-            project_id=payload.project_id,
-            scenario_id=scenario.id,
-            name="irr",
-            value=irr_value,
-            unit="ratio",
-            metadata=irr_metadata,
-        ),
-    ]
+        dscr_entries: List[DscrEntrySchema] = []
+        dscr_metadata: dict[str, List[dict[str, object]]] = {}
+        if payload.scenario.dscr:
+            try:
+                timeline = calculator.dscr_timeline(
+                    payload.scenario.dscr.net_operating_incomes,
+                    payload.scenario.dscr.debt_services,
+                    period_labels=payload.scenario.dscr.period_labels,
+                    currency=payload.scenario.currency,
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            dscr_entries = [_convert_dscr_entry(entry) for entry in timeline]
+            dscr_metadata = {
+                "entries": [entry.model_dump(mode="json") for entry in dscr_entries],
+            }
 
-    if dscr_entries:
-        results.append(
+        results: List[FinResult] = [
             FinResult(
                 project_id=payload.project_id,
                 scenario_id=scenario.id,
-                name="dscr_timeline",
-                value=None,
-                unit=None,
-                metadata=dscr_metadata,
+                name="escalated_cost",
+                value=escalated_cost,
+                unit=payload.scenario.currency,
+                metadata={
+                    "base_amount": str(cost_input.amount),
+                    "base_period": cost_input.base_period,
+                    "cost_index": cost_provenance.model_dump(mode="json"),
+                },
+            ),
+            FinResult(
+                project_id=payload.project_id,
+                scenario_id=scenario.id,
+                name="npv",
+                value=npv_rounded,
+                unit=payload.scenario.currency,
+                metadata={
+                    "discount_rate": str(cash_inputs.discount_rate),
+                    "cash_flows": [str(value) for value in cash_inputs.cash_flows],
+                },
+            ),
+            FinResult(
+                project_id=payload.project_id,
+                scenario_id=scenario.id,
+                name="irr",
+                value=irr_value,
+                unit="ratio",
+                metadata=irr_metadata,
+            ),
+        ]
+
+        if dscr_entries:
+            results.append(
+                FinResult(
+                    project_id=payload.project_id,
+                    scenario_id=scenario.id,
+                    name="dscr_timeline",
+                    value=None,
+                    unit=None,
+                    metadata=dscr_metadata,
+                )
             )
+
+        session.add_all(results)
+        scenario.results.extend(results)
+
+        await session.flush()
+        await session.commit()
+
+        log_event(
+            logger,
+            "finance_feasibility_completed",
+            scenario_id=scenario.id,
+            project_id=payload.project_id,
         )
 
-    session.add_all(results)
-    scenario.results.extend(results)
+        response = FinanceFeasibilityResponse(
+            scenario_id=scenario.id,
+            project_id=scenario.project_id,
+            fin_project_id=scenario.fin_project_id,
+            scenario_name=scenario.name,
+            currency=payload.scenario.currency,
+            escalated_cost=escalated_cost,
+            cost_index=cost_provenance,
+            results=[
+                FinanceResultSchema(
+                    name=result.name,
+                    value=result.value,
+                    unit=result.unit,
+                    metadata=dict(result.metadata or {}),
+                )
+                for result in results
+            ],
+            dscr_timeline=dscr_entries,
+        )
+    finally:
+        duration_ms = (perf_counter() - start_time) * 1000
+        metrics.FINANCE_FEASIBILITY_DURATION_MS.observe(duration_ms)
 
-    await session.flush()
-    await session.commit()
-
-    log_event(
-        logger,
-        "finance_feasibility_completed",
-        scenario_id=scenario.id,
-        project_id=payload.project_id,
-    )
-
-    response = FinanceFeasibilityResponse(
-        scenario_id=scenario.id,
-        project_id=scenario.project_id,
-        fin_project_id=scenario.fin_project_id,
-        scenario_name=scenario.name,
-        currency=payload.scenario.currency,
-        escalated_cost=escalated_cost,
-        cost_index=cost_provenance,
-        results=[
-            FinanceResultSchema(
-                name=result.name,
-                value=result.value,
-                unit=result.unit,
-                metadata=dict(result.metadata or {}),
-            )
-            for result in results
-        ],
-        dscr_timeline=dscr_entries,
-    )
+    assert response is not None
     return response
 
 
@@ -418,31 +428,40 @@ async def export_finance_scenario(
     """Stream a CSV export describing the requested finance scenario."""
 
     metrics.REQUEST_COUNTER.labels(endpoint="finance_export").inc()
-    if scenario_id < 1:
-        raise HTTPException(status_code=400, detail="scenario_id must be positive")
-    stmt = (
-        select(FinScenario)
-        .where(FinScenario.id == scenario_id)
-        .options(
-            selectinload(FinScenario.results),
-            selectinload(FinScenario.fin_project),
+    metrics.FINANCE_EXPORT_TOTAL.inc()
+    start_time = perf_counter()
+    response: StreamingResponse | None = None
+    try:
+        if scenario_id < 1:
+            raise HTTPException(status_code=400, detail="scenario_id must be positive")
+        stmt = (
+            select(FinScenario)
+            .where(FinScenario.id == scenario_id)
+            .options(
+                selectinload(FinScenario.results),
+                selectinload(FinScenario.fin_project),
+            )
+            .limit(1)
         )
-        .limit(1)
-    )
-    result = await session.execute(stmt)
-    scenario = result.scalar_one_or_none()
-    if scenario is None:
-        raise HTTPException(status_code=404, detail="Finance scenario not found")
+        result = await session.execute(stmt)
+        scenario = result.scalar_one_or_none()
+        if scenario is None:
+            raise HTTPException(status_code=404, detail="Finance scenario not found")
 
-    assumptions = scenario.assumptions or {}
-    currency = assumptions.get("currency") or getattr(scenario.fin_project, "currency", "USD")
+        assumptions = scenario.assumptions or {}
+        currency = assumptions.get("currency") or getattr(scenario.fin_project, "currency", "USD")
 
-    iterator = _iter_results_csv(scenario, currency=str(currency))
-    filename = f"finance_scenario_{scenario.id}.csv"
-    response = StreamingResponse(iterator, media_type="text/csv")
-    response.headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+        iterator = _iter_results_csv(scenario, currency=str(currency))
+        filename = f"finance_scenario_{scenario.id}.csv"
+        response = StreamingResponse(iterator, media_type="text/csv")
+        response.headers["Content-Disposition"] = f'attachment; filename="{filename}"'
 
-    log_event(logger, "finance_feasibility_export", scenario_id=scenario.id)
+        log_event(logger, "finance_feasibility_export", scenario_id=scenario.id)
+    finally:
+        duration_ms = (perf_counter() - start_time) * 1000
+        metrics.FINANCE_EXPORT_DURATION_MS.observe(duration_ms)
+
+    assert response is not None
     return response
 
 

--- a/backend/app/utils/metrics.py
+++ b/backend/app/utils/metrics.py
@@ -30,6 +30,10 @@ ALERT_COUNTER: Counter
 COST_ADJUSTMENT_GAUGE: Gauge
 PWP_BUILDABLE_TOTAL: Counter
 PWP_BUILDABLE_DURATION_MS: Histogram
+FINANCE_FEASIBILITY_TOTAL: Counter
+FINANCE_FEASIBILITY_DURATION_MS: Histogram
+FINANCE_EXPORT_TOTAL: Counter
+FINANCE_EXPORT_DURATION_MS: Histogram
 
 
 def _initialize_metrics() -> None:
@@ -43,6 +47,10 @@ def _initialize_metrics() -> None:
     global COST_ADJUSTMENT_GAUGE
     global PWP_BUILDABLE_TOTAL
     global PWP_BUILDABLE_DURATION_MS
+    global FINANCE_FEASIBILITY_TOTAL
+    global FINANCE_FEASIBILITY_DURATION_MS
+    global FINANCE_EXPORT_TOTAL
+    global FINANCE_EXPORT_DURATION_MS
 
     REGISTRY = CollectorRegistry(auto_describe=True)
 
@@ -91,6 +99,34 @@ def _initialize_metrics() -> None:
     PWP_BUILDABLE_DURATION_MS = Histogram(
         "pwp_buildable_duration_ms",
         "Duration of buildable screening computations in milliseconds.",
+        labelnames=(),
+        registry=REGISTRY,
+    )
+
+    FINANCE_FEASIBILITY_TOTAL = Counter(
+        "finance_feasibility_total",
+        "Number of finance feasibility calculations processed.",
+        labelnames=(),
+        registry=REGISTRY,
+    )
+
+    FINANCE_FEASIBILITY_DURATION_MS = Histogram(
+        "finance_feasibility_duration_ms",
+        "Duration of finance feasibility calculations in milliseconds.",
+        labelnames=(),
+        registry=REGISTRY,
+    )
+
+    FINANCE_EXPORT_TOTAL = Counter(
+        "finance_export_total",
+        "Number of finance scenario exports processed.",
+        labelnames=(),
+        registry=REGISTRY,
+    )
+
+    FINANCE_EXPORT_DURATION_MS = Histogram(
+        "finance_export_duration_ms",
+        "Duration of finance scenario exports in milliseconds.",
         labelnames=(),
         registry=REGISTRY,
     )

--- a/backend/tests/test_api/test_finance_metrics.py
+++ b/backend/tests/test_api/test_finance_metrics.py
@@ -1,0 +1,96 @@
+"""Tests for finance API metrics instrumentation."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlalchemy")
+
+from httpx import AsyncClient
+
+from app.models.rkp import RefCostIndex
+from app.utils import metrics
+
+
+@pytest.mark.asyncio
+async def test_finance_metrics_surface_in_health(client: AsyncClient, session) -> None:
+    session.add_all(
+        [
+            RefCostIndex(
+                jurisdiction="SG",
+                series_name="construction_cost",
+                category="cost",
+                subcategory="escalation",
+                period="2023-Q4",
+                value=Decimal("100"),
+                unit="index",
+                source="seed",
+                provider="official",
+            ),
+            RefCostIndex(
+                jurisdiction="SG",
+                series_name="construction_cost",
+                category="cost",
+                subcategory="escalation",
+                period="2024-Q1",
+                value=Decimal("110"),
+                unit="index",
+                source="seed",
+                provider="official",
+            ),
+        ]
+    )
+    await session.commit()
+
+    payload = {
+        "project_id": 4242,
+        "project_name": "Harbour Residences",
+        "scenario": {
+            "name": "Base Case",
+            "description": "Primary underwriting scenario",
+            "currency": "SGD",
+            "is_primary": True,
+            "cost_escalation": {
+                "amount": "1000000",
+                "base_period": "2023-Q4",
+                "series_name": "construction_cost",
+                "jurisdiction": "SG",
+                "provider": "official",
+            },
+            "cash_flow": {
+                "discount_rate": "0.05",
+                "cash_flows": ["-1000000", "350000", "400000", "450000"],
+            },
+        },
+    }
+
+    response = await client.post("/api/v1/finance/feasibility", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+
+    assert metrics.counter_value(metrics.FINANCE_FEASIBILITY_TOTAL, {}) == 1.0
+    metrics_output = metrics.render_latest_metrics().decode()
+    assert "finance_feasibility_duration_ms" in metrics_output
+
+    scenario_id = body["scenario_id"]
+
+    export_response = await client.get(
+        "/api/v1/finance/export",
+        params={"scenario_id": scenario_id},
+    )
+    assert export_response.status_code == 200
+    assert export_response.headers["content-type"].startswith("text/csv")
+    assert metrics.counter_value(metrics.FINANCE_EXPORT_TOTAL, {}) == 1.0
+
+    metrics_output = metrics.render_latest_metrics().decode()
+    assert "finance_export_duration_ms" in metrics_output
+
+    health_response = await client.get("/health/metrics")
+    assert health_response.status_code == 200
+    metrics_text = health_response.read().decode()
+    assert "finance_feasibility_total" in metrics_text
+    assert "finance_export_total" in metrics_text


### PR DESCRIPTION
## Summary
- add Prometheus counters and histograms for finance feasibility and export workflows
- instrument finance feasibility and export endpoints to record invocation counts and durations
- add regression coverage to confirm the new metrics surface via `/health/metrics`

## Testing
- PYTHONPATH=backend pytest backend/tests/test_api/test_finance_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68d1f5dbf05c8320bde2fbe302b490e9