### PR TITLE
Document finance API endpoints and enrich metadata

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -34,6 +34,8 @@ api_router.include_router(export.router)
 api_router.include_router(roi.router)
 api_router.include_router(imports.router)
 api_router.include_router(audit.router)
+# Finance flows rely on both feasibility and export endpoints being present in the
+# main application so that the interactive documentation exposes them.
 api_router.include_router(feasibility.router)
 api_router.include_router(finance.router)
 

--- a/backend/app/api/v1/finance.py
+++ b/backend/app/api/v1/finance.py
@@ -197,7 +197,14 @@ async def run_finance_feasibility(
     payload: FinanceFeasibilityRequest,
     session: AsyncSession = Depends(get_session),
 ) -> FinanceFeasibilityResponse:
-    """Compute feasibility metrics, persist results and return a summary."""
+    """Execute the full finance pipeline for the submitted scenario.
+
+    The endpoint escalates base construction costs, calculates NPV and IRR
+    figures, optionally derives a DSCR timeline, persists the scenario to the
+    database, and returns a structured summary that the frontend can render.
+    A ``404`` error is returned if the referenced finance project cannot be
+    located.
+    """
 
     metrics.REQUEST_COUNTER.labels(endpoint="finance_feasibility").inc()
     metrics.FINANCE_FEASIBILITY_TOTAL.inc()
@@ -425,7 +432,15 @@ async def export_finance_scenario(
     scenario_id: int = Query(...),
     session: AsyncSession = Depends(get_session),
 ) -> StreamingResponse:
-    """Stream a CSV export describing the requested finance scenario."""
+    """Stream a CSV export describing the requested finance scenario.
+
+    The export is optimised for spreadsheet workflows and mirrors the data that
+    is persisted after running the feasibility analysis. Consumers receive the
+    same escalated cost provenance, headline ratios, and the optional DSCR
+    timeline that appear in the UI. A ``400`` error is raised for non-positive
+    scenario identifiers while a ``404`` is returned when the scenario cannot be
+    found.
+    """
 
     metrics.REQUEST_COUNTER.labels(endpoint="finance_export").inc()
     metrics.FINANCE_EXPORT_TOTAL.inc()

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,8 @@ codebase so that policy, engineering, and review practices remain in lockstep.
   reviewers prior to promoting new references to production.
 * [`export_api.md`](export_api.md) — CAD/BIM export endpoint reference for
   frontend integrations.
+* [`finance_api.md`](finance_api.md) — finance feasibility endpoints and CSV
+  export contract for reporting teams.
 * [`feasibility_workflows.md`](feasibility_workflows.md) — feasibility wizard
   endpoints, payloads, and regression coverage.
 * [`sample_fixtures.md`](sample_fixtures.md) — provenance and guidance for the

--- a/docs/finance_api.md
+++ b/docs/finance_api.md
@@ -1,0 +1,151 @@
+# Finance Feasibility API
+
+The finance service exposes endpoints used by the feasibility workflow to
+persist model runs and to provide downloadable summaries for finance teams.
+Requests are authenticated with the same mechanisms as the rest of the
+`/api/v1` namespace.
+
+## Run a finance scenario
+
+`POST /api/v1/finance/feasibility`
+
+Submit a project scenario to calculate escalated construction costs, net present
+value (NPV), internal rate of return (IRR), and optionally a debt-service
+coverage ratio (DSCR) timeline. When the request succeeds the scenario is
+persisted and a summary of the results is returned.
+
+### Request body
+
+```jsonc
+{
+  "project_id": 101,
+  "project_name": "Emerald Logistics Hub",
+  "fin_project_id": null,
+  "scenario": {
+    "name": "Base Case",
+    "description": "Primary development case for investor deck",
+    "currency": "SGD",
+    "is_primary": true,
+    "cost_escalation": {
+      "amount": "12500000",
+      "base_period": "2023-Q4",
+      "series_name": "construction_cost_index",
+      "jurisdiction": "SG",
+      "provider": "BCA"
+    },
+    "cash_flow": {
+      "discount_rate": "0.085",
+      "cash_flows": ["-12500000", "3200000", "4300000", "5100000"]
+    },
+    "dscr": {
+      "net_operating_incomes": ["2200000", "2400000", "2600000"],
+      "debt_services": ["1800000", "1800000", "1800000"],
+      "period_labels": ["2025", "2026", "2027"]
+    }
+  }
+}
+```
+
+### Response body
+
+```jsonc
+{
+  "scenario_id": 42,
+  "project_id": 101,
+  "fin_project_id": 12,
+  "scenario_name": "Base Case",
+  "currency": "SGD",
+  "escalated_cost": "13450000.00",
+  "cost_index": {
+    "series_name": "construction_cost_index",
+    "jurisdiction": "SG",
+    "provider": "BCA",
+    "base_period": "2023-Q4",
+    "latest_period": "2024-Q2",
+    "scalar": "1.0760",
+    "base_index": {
+      "period": "2023-Q4",
+      "value": "115.1",
+      "unit": "index",
+      "source": "Construction Economics Digest"
+    },
+    "latest_index": {
+      "period": "2024-Q2",
+      "value": "123.8",
+      "unit": "index",
+      "provider": "BCA"
+    }
+  },
+  "results": [
+    {
+      "name": "escalated_cost",
+      "value": "13450000.00",
+      "unit": "SGD",
+      "metadata": {
+        "base_amount": "12500000",
+        "base_period": "2023-Q4",
+        "cost_index": {"scalar": "1.0760"}
+      }
+    },
+    {
+      "name": "npv",
+      "value": "2419234.17",
+      "unit": "SGD",
+      "metadata": {
+        "discount_rate": "0.085",
+        "cash_flows": ["-12500000", "3200000", "4300000", "5100000"]
+      }
+    },
+    {
+      "name": "irr",
+      "value": "0.1125",
+      "unit": "ratio",
+      "metadata": {
+        "cash_flows": ["-12500000", "3200000", "4300000", "5100000"]
+      }
+    },
+    {
+      "name": "dscr_timeline",
+      "metadata": {
+        "entries": [
+          {
+            "period": "2025",
+            "noi": "2200000",
+            "debt_service": "1800000",
+            "dscr": "1.2222",
+            "currency": "SGD"
+          }
+        ]
+      }
+    }
+  ],
+  "dscr_timeline": [
+    {
+      "period": "2025",
+      "noi": "2200000",
+      "debt_service": "1800000",
+      "dscr": "1.2222",
+      "currency": "SGD"
+    }
+  ]
+}
+```
+
+## Export a finance scenario
+
+`GET /api/v1/finance/export?scenario_id={id}`
+
+Streams a CSV attachment that mirrors the persisted scenario. The CSV includes
+all headline metrics and, when available, the DSCR timeline with one row per
+period.
+
+### Response headers
+
+- `Content-Disposition` – contains the suggested filename for the download.
+- `Content-Type` – set to `text/csv`.
+
+### CSV structure
+
+The export begins with metric name/value/unit rows and, when present, DSCR and
+cost index provenance sections. Consumers can ingest the file directly in Excel
+or Google Sheets for reporting workflows.


### PR DESCRIPTION
## Summary
- document that the finance feasibility and export routers must stay registered so the app documentation exposes them
- expand the finance feasibility and export handlers with detailed docstrings covering behaviour and error responses
- add a finance API reference page and link it from the docs index so reporting teams can find the payload contract

## Testing
- pytest backend/tests/test_api/test_finance_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68d20cc63a688320a679b96c5d51c914