### PR TITLE
Add buildable latency smoke test and histogram percentile helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install format lint test test-cov clean build deploy init-db seed-data logs down reset dev-start dev-stop import-sample run-overlay export-approved test-aec seed-nonreg sync-products
+.PHONY: help install format lint test test-cov smoke-buildable clean build deploy init-db seed-data logs down reset dev-start dev-stop import-sample run-overlay export-approved test-aec seed-nonreg sync-products
 
 DEV_RUNTIME_DIR ?= .devstack
 DEV_RUNTIME_DIR_ABS := $(abspath $(DEV_RUNTIME_DIR))
@@ -40,6 +40,9 @@ lint: ## Run linting
 test: ## Run tests
 	cd backend && pytest
 	cd frontend && npm test
+
+smoke-buildable: ## Run the buildable latency smoke test and report the observed P90
+	cd backend && pytest -s tests/pwp/test_buildable_latency.py
 
 import-sample: ## Upload the bundled sample payload and seed overlay geometry
 	@mkdir -p $(DEV_RUNTIME_DIR_ABS)

--- a/backend/app/utils/_prometheus_stub.py
+++ b/backend/app/utils/_prometheus_stub.py
@@ -10,7 +10,8 @@ stub will remain unused.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable, Iterator, Tuple
+from math import isinf
+from typing import Dict, Iterable, Iterator, List, Sequence, Tuple
 
 
 @dataclass
@@ -54,6 +55,7 @@ class _MetricBase:
         documentation: str,
         labelnames: Iterable[str],
         registry: CollectorRegistry | None,
+        **_: object,
     ) -> None:
         self._name = name
         self._documentation = documentation
@@ -96,19 +98,32 @@ class _Sample:
 
 
 class _HistogramSample(_Sample):
-    def __init__(self) -> None:
+    def __init__(self, bounds: Sequence[float]) -> None:
         super().__init__()
         self._count = _ValueHolder()
+        self._bounds = tuple(bounds)
+        self._bucket_counts: List[float] = [0.0 for _ in self._bounds]
+        self._observations: List[float] = []
 
     def observe(self, amount: float) -> None:
         self._count.value += 1.0
         self._value.value += amount
+        self._observations.append(amount)
+        for index, bound in enumerate(self._bounds):
+            if amount <= bound:
+                self._bucket_counts[index] += 1.0
 
     def count(self) -> float:
         return self._count.get()
 
     def sum(self) -> float:
         return self._value.get()
+
+    def bucket_counts(self) -> List[Tuple[float, float]]:
+        return list(zip(self._bounds, self._bucket_counts))
+
+    def observations(self) -> List[float]:
+        return list(self._observations)
 
 
 class Counter(_MetricBase):
@@ -130,14 +145,46 @@ class Gauge(_MetricBase):
 
 
 class Histogram(_MetricBase):
-    """Histogram metric stub supporting sum and count."""
+    """Histogram metric stub supporting sum, count, and buckets."""
 
     _type = "histogram"
+    DEFAULT_BUCKETS: Tuple[float, ...] = (
+        0.005,
+        0.01,
+        0.025,
+        0.05,
+        0.075,
+        0.1,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        2.5,
+        5.0,
+        7.5,
+        10.0,
+        float("inf"),
+    )
+
+    def __init__(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: Iterable[str],
+        registry: CollectorRegistry | None,
+        *,
+        buckets: Sequence[float] | None = None,
+        **kwargs: object,
+    ) -> None:
+        self._upper_bounds: Tuple[float, ...] = tuple(
+            buckets if buckets is not None else self.DEFAULT_BUCKETS
+        )
+        super().__init__(name, documentation, labelnames, registry, **kwargs)
 
     def labels(self, **labels: str) -> _HistogramSample:  # type: ignore[override]
         key = tuple(labels.get(label, "") for label in self._labelnames)
         if key not in self._metrics:
-            self._metrics[key] = _HistogramSample()
+            self._metrics[key] = _HistogramSample(self._upper_bounds)
         sample = self._metrics[key]
         assert isinstance(sample, _HistogramSample)
         return sample
@@ -155,6 +202,21 @@ def generate_latest(registry: CollectorRegistry) -> bytes:
         lines.append(f"# TYPE {metric._name} {metric._type}")
         for label_map, sample in metric._iter_samples():
             if metric._type == "histogram" and isinstance(sample, _HistogramSample):
+                for bound, value in sample.bucket_counts():
+                    bound_label = "+Inf" if isinf(bound) else f"{bound:g}"
+                    bucket_labels = dict(label_map)
+                    bucket_labels["le"] = bound_label
+                    if bucket_labels:
+                        labels = ",".join(
+                            f"{k}=\"{v}\"" for k, v in bucket_labels.items()
+                        )
+                        lines.append(
+                            f"{metric._name}_bucket{{{labels}}} {value}"
+                        )
+                    else:
+                        lines.append(
+                            f"{metric._name}_bucket{{le=\"{bound_label}\"}} {value}"
+                        )
                 if label_map:
                     labels = ",".join(f"{k}=\"{v}\"" for k, v in label_map.items())
                     lines.append(f"{metric._name}_sum{{{labels}}} {sample.sum()}")

--- a/backend/app/utils/metrics.py
+++ b/backend/app/utils/metrics.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Dict
+from dataclasses import dataclass
+import math
+from typing import Dict, Iterable, List, Sequence, Tuple
 
 try:  # pragma: no cover - exercised when dependency is available
     from prometheus_client import (
@@ -202,6 +204,160 @@ def counter_value(counter: Counter, labels: Dict[str, str]) -> float:
             return float(value)
 
     raise RuntimeError("Unable to read counter value from Prometheus metric")
+
+
+@dataclass(frozen=True)
+class HistogramPercentile:
+    """Summary of a histogram percentile calculation."""
+
+    percentile: float
+    value: float
+    buckets: Tuple[Tuple[float, float], ...]
+
+
+def histogram_percentile(
+    histogram: Histogram,
+    percentile: float,
+    labels: Dict[str, str] | None = None,
+) -> HistogramPercentile:
+    """Compute a percentile for a Prometheus histogram."""
+
+    if not 0.0 <= percentile <= 1.0:
+        raise ValueError("Percentile must be expressed as a value between 0 and 1")
+
+    labels = labels or {}
+    normalized_labels = _normalize_histogram_labels(histogram, labels)
+    buckets, observations = _collect_histogram_data(histogram, normalized_labels)
+    if not buckets:
+        raise RuntimeError("No observations recorded for histogram")
+
+    value: float
+    if observations:
+        value = _percentile_from_observations(observations, percentile)
+    else:
+        value = _percentile_from_buckets(buckets, percentile)
+
+    return HistogramPercentile(
+        percentile=percentile, value=value, buckets=tuple(buckets)
+    )
+
+
+def _normalize_histogram_labels(
+    histogram: Histogram, labels: Dict[str, str]
+) -> Dict[str, str]:
+    names: Iterable[str] = getattr(histogram, "_labelnames", ())
+    return {name: str(labels.get(name, "")) for name in names}
+
+
+def _collect_histogram_data(
+    histogram: Histogram, labels: Dict[str, str]
+) -> Tuple[List[Tuple[float, float]], List[float]]:
+    buckets: List[Tuple[float, float]] = []
+    observations: List[float] = []
+
+    metrics_map = getattr(histogram, "_metrics", None)
+    label_names: Sequence[str] = tuple(getattr(histogram, "_labelnames", ()))
+    if isinstance(metrics_map, dict):
+        key = tuple(labels.get(name, "") for name in label_names)
+        sample = metrics_map.get(key)
+        if sample is not None:
+            bucket_method = getattr(sample, "bucket_counts", None)
+            if callable(bucket_method):
+                buckets = [
+                    (float(bound), float(count))
+                    for bound, count in bucket_method()
+                ]
+            observation_method = getattr(sample, "observations", None)
+            if callable(observation_method):
+                observations = [float(value) for value in observation_method()]
+            if buckets:
+                return buckets, observations
+
+    metric_name = getattr(histogram, "_name", "")
+    for metric in REGISTRY.collect():
+        candidate_name = getattr(metric, "name", getattr(metric, "_name", ""))
+        if candidate_name != metric_name:
+            continue
+        samples = getattr(metric, "samples", None)
+        if samples is None:
+            continue
+        bucket_results: List[Tuple[float, float]] = []
+        for sample in samples:
+            sample_name = getattr(sample, "name", "")
+            sample_labels = getattr(sample, "labels", {})
+            if not _labels_match(sample_labels, labels):
+                continue
+            if sample_name == f"{metric_name}_bucket":
+                bound_label = sample_labels.get("le")
+                if bound_label is None:
+                    continue
+                if bound_label == "+Inf":
+                    bound = float("inf")
+                else:
+                    try:
+                        bound = float(bound_label)
+                    except (TypeError, ValueError):
+                        continue
+                bucket_results.append((bound, float(sample.value)))
+        bucket_results.sort(key=lambda item: item[0])
+        if bucket_results:
+            buckets = bucket_results
+        break
+
+    return buckets, observations
+
+
+def _labels_match(sample_labels: Dict[str, str], expected: Dict[str, str]) -> bool:
+    for key, value in expected.items():
+        if sample_labels.get(key, "") != value:
+            return False
+    return True
+
+
+def _percentile_from_observations(values: List[float], percentile: float) -> float:
+    if not values:
+        raise ValueError("Histogram percentile requested with no observations")
+    if len(values) == 1:
+        return float(values[0])
+
+    sorted_values = sorted(values)
+    rank = percentile * (len(sorted_values) - 1)
+    lower_index = math.floor(rank)
+    upper_index = math.ceil(rank)
+    lower_value = sorted_values[lower_index]
+    upper_value = sorted_values[upper_index]
+    if lower_index == upper_index:
+        return float(lower_value)
+    fraction = rank - lower_index
+    return float(lower_value + (upper_value - lower_value) * fraction)
+
+
+def _percentile_from_buckets(
+    buckets: Sequence[Tuple[float, float]], percentile: float
+) -> float:
+    if not buckets:
+        raise ValueError("Histogram percentile requested without bucket data")
+
+    total = buckets[-1][1]
+    if total <= 0:
+        raise ValueError("Histogram percentile requested before any observations")
+
+    target = percentile * total
+    previous_upper = 0.0
+    previous_count = 0.0
+
+    for upper, cumulative in buckets:
+        if cumulative >= target:
+            if math.isinf(upper):
+                return previous_upper
+            if cumulative == previous_count:
+                return float(upper)
+            proportion = (target - previous_count) / (cumulative - previous_count)
+            return float(previous_upper + (upper - previous_upper) * proportion)
+        previous_upper = upper
+        previous_count = cumulative
+
+    return float(buckets[-1][0])
 
 
 def render_latest_metrics() -> bytes:

--- a/backend/tests/pwp/test_buildable_latency.py
+++ b/backend/tests/pwp/test_buildable_latency.py
@@ -1,0 +1,82 @@
+"""Latency regression tests for buildable screening metrics."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("pytest_asyncio")
+
+import pytest_asyncio
+from httpx import AsyncClient
+
+from app.core.config import settings
+from app.core.database import get_session
+from app.main import app
+from app.utils import metrics
+from scripts.seed_screening import seed_screening_sample_data
+
+
+DEFAULT_REQUEST_DEFAULTS = {
+    "plot_ratio": 3.5,
+    "site_area_m2": 1000.0,
+    "site_coverage": 0.45,
+    "floor_height_m": 4.0,
+    "efficiency_factor": 0.82,
+}
+DEFAULT_REQUEST_OVERRIDES = {
+    "typ_floor_to_floor_m": 4.0,
+    "efficiency_ratio": 0.82,
+}
+
+
+async def _seed_screening_data(async_session_factory) -> None:
+    async with async_session_factory() as session:
+        await seed_screening_sample_data(session, commit=False)
+        await session.commit()
+
+
+@pytest_asyncio.fixture
+async def buildable_client(async_session_factory, monkeypatch):
+    await _seed_screening_data(async_session_factory)
+
+    monkeypatch.setattr(settings, "BUILDABLE_TYP_FLOOR_TO_FLOOR_M", 4.0)
+    monkeypatch.setattr(settings, "BUILDABLE_EFFICIENCY_RATIO", 0.82)
+
+    async def _override_get_session():
+        async with async_session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = _override_get_session
+    async with AsyncClient(app=app, base_url="http://testserver") as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_buildable_latency_p90(buildable_client):
+    client = buildable_client
+
+    payload = {
+        "address": "123 Example Ave",
+        "defaults": dict(DEFAULT_REQUEST_DEFAULTS),
+        **DEFAULT_REQUEST_OVERRIDES,
+    }
+
+    for _ in range(5):
+        response = await client.post("/api/v1/screen/buildable", json=payload)
+        assert response.status_code == 200
+
+    snapshot = metrics.histogram_percentile(
+        metrics.PWP_BUILDABLE_DURATION_MS, 0.90
+    )
+
+    assert snapshot.buckets, "Expected histogram buckets to be recorded"
+    assert snapshot.buckets[-1][1] == pytest.approx(5.0)
+
+    print(f"Observed buildable P90 latency: {snapshot.value:.2f} ms")
+    print(f"Bucket counts: {snapshot.buckets}")
+
+    assert snapshot.value <= 2000.0


### PR DESCRIPTION
## Summary
- add a metrics helper that reads histogram buckets and computes percentiles
- extend the offline Prometheus stub to keep bucket counters and raw observations
- add a buildable latency smoke test plus a make target for running it quickly

## Testing
- cd backend && pytest -s tests/pwp/test_buildable_latency.py
- make smoke-buildable

------
https://chatgpt.com/codex/tasks/task_e_68d22c8fdc8483208f3f5fd2fe17537b