### PR TITLE
Add CLI sanity test and reference API coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ dev-stop: ## Stop services started with dev-start (excluding docker-compose)
 	fi
 
 seed-nonreg:
-	python scripts/seed_nonreg.py
+	python -m backend.scripts.seed_nonreg
 
 sync-products:
 	python -m backend.flows.sync_products --csv-path vendor.csv

--- a/README.md
+++ b/README.md
@@ -175,6 +175,13 @@ curl -L -o finance_scenario.csv \
 
 Replace `<SCENARIO_ID>` with the identifier returned by the feasibility call.
 
+## Non-regulatory reference seeding
+
+Run `make seed-nonreg` to populate ergonomics, material standards, and cost
+index reference tables. The Makefile target executes `python -m
+backend.scripts.seed_nonreg`, which you can also invoke directly from the
+repository root when seeding outside Docker.
+
 ## Entitlements roadmap seeding
 
 Run `python scripts/seed_entitlements_sg.py --project-id 90301 --reset` to seed the

--- a/backend/tests/reference/test_reference_endpoints.py
+++ b/backend/tests/reference/test_reference_endpoints.py
@@ -1,0 +1,69 @@
+"""Integration tests for seeded reference data endpoints."""
+
+import json
+from typing import Any, Dict, Iterable
+
+import pytest
+
+from backend.scripts import seed_nonreg
+
+
+async def _seed_reference_data(async_session_factory) -> None:
+    async with async_session_factory() as session:
+        await seed_nonreg.seed_nonregulated_reference_data(session, commit=True)
+
+
+async def test_ergonomics_endpoint_returns_seeded_metrics(async_session_factory, client) -> None:
+    await _seed_reference_data(async_session_factory)
+
+    response = await client.get("/api/v1/ergonomics")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert isinstance(payload, list)
+
+    expected = json.loads(seed_nonreg.ERGONOMICS_SEED.read_text(encoding="utf-8"))
+    expected_pairs = {(item["metric_key"], item["population"]) for item in expected}
+    observed_pairs = {(item["metric_key"], item["population"]) for item in payload}
+    assert observed_pairs == expected_pairs
+
+
+async def test_products_endpoint_handles_seeded_database(async_session_factory, client) -> None:
+    await _seed_reference_data(async_session_factory)
+
+    response = await client.get("/api/v1/products")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert isinstance(payload, list)
+
+
+async def test_standards_endpoint_includes_metadata(async_session_factory, client) -> None:
+    await _seed_reference_data(async_session_factory)
+
+    response = await client.get("/api/v1/standards")
+    assert response.status_code == 200
+
+    records: Iterable[Dict[str, Any]] = response.json()
+    expected = json.loads(seed_nonreg.STANDARDS_SEED.read_text(encoding="utf-8"))
+    assert len(records) == len(expected)
+
+    for record in records:
+        assert record.get("provenance") is not None
+        assert record.get("license_ref")
+        assert record.get("edition")
+
+
+async def test_cost_indices_latest_endpoint_returns_seeded_index(async_session_factory, client) -> None:
+    await _seed_reference_data(async_session_factory)
+
+    params = {"series_name": "construction_all_in", "jurisdiction": "SG"}
+    response = await client.get("/api/v1/costs/indices/latest", params=params)
+    assert response.status_code == 200
+
+    record = response.json()
+    expected = json.loads(seed_nonreg.COST_INDEX_SEED.read_text(encoding="utf-8"))[0]
+    assert record["series_name"] == expected["series_name"]
+    assert record["jurisdiction"] == expected.get("jurisdiction", "SG")
+    assert record["value"] == pytest.approx(expected["value"], rel=1e-6)
+    assert record["unit"] == expected["unit"]

--- a/tests/reference/test_seed_nonreg_cli.py
+++ b/tests/reference/test_seed_nonreg_cli.py
@@ -1,0 +1,47 @@
+"""Sanity checks for the seed_nonreg CLI entry point."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Dict
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.models.base import BaseModel
+from backend.scripts import seed_nonreg
+
+
+def _load_fixture_count(path: Path) -> int:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    assert isinstance(payload, list)
+    return len(payload)
+
+
+def test_seed_nonreg_cli_summary(monkeypatch) -> None:
+    """The CLI should report counts matching the JSON seed fixtures."""
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def _initialise_schema() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(BaseModel.metadata.create_all)
+
+    asyncio.run(_initialise_schema())
+
+    monkeypatch.setattr(seed_nonreg, "AsyncSessionLocal", session_factory, raising=False)
+    monkeypatch.setattr(seed_nonreg, "engine", engine, raising=False)
+
+    summary = seed_nonreg.main([])
+
+    expected: Dict[str, int] = {
+        "ergonomics": _load_fixture_count(seed_nonreg.ERGONOMICS_SEED),
+        "standards": _load_fixture_count(seed_nonreg.STANDARDS_SEED),
+        "cost_indices": _load_fixture_count(seed_nonreg.COST_INDEX_SEED),
+    }
+    assert summary.as_dict() == expected
+
+    asyncio.run(engine.dispose())


### PR DESCRIPTION
## Summary
- update the seed-nonreg make target to invoke the module entry point and document the workflow in the README
- add a CLI regression test that ensures `backend.scripts.seed_nonreg.main()` reports fixture-aligned counts
- add reference API integration tests that exercise ergonomics, products, standards, and cost indices seeded data

## Testing
- pytest tests/reference/test_seed_nonreg_cli.py backend/tests/reference


------
https://chatgpt.com/codex/tasks/task_e_68d22cc81a6c8320a1eae344b49017eb