### PR TITLE
Use offline Playwright cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,8 +328,11 @@ PY
           restore-keys: |
             playwright-${{ runner.os }}-
 
-      - name: Install Playwright browsers
-        run: pnpm -C frontend exec playwright install --with-deps
+      - name: Sync Playwright browsers
+        run: |
+          mkdir -p "$HOME/.cache/ms-playwright"
+          rsync -a --delete .playwright-browsers/ "$HOME/.cache/ms-playwright/"
+          echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/ms-playwright" >> "$GITHUB_ENV"
 
       - name: Run frontend end-to-end tests
         run: pnpm -C frontend test:e2e

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,0 +1,22 @@
+# Frontend operations
+
+## Refreshing the Playwright browser cache
+
+Our CI pipeline keeps a checked-in `.playwright-browsers/` directory so Playwright never needs to download browsers during the `test:e2e` run. When bumping Playwright, regenerate the cache and accompanying tarball so the workflow keeps using the prebuilt binaries:
+
+1. Remove the existing cache and create a clean workspace:
+   ```bash
+   rm -rf .playwright-browsers
+   mkdir -p .playwright-browsers
+   ```
+2. Install the browsers into the local cache:
+   ```bash
+   PLAYWRIGHT_BROWSERS_PATH=$(pwd)/.playwright-browsers pnpm -C frontend exec playwright install --with-deps
+   ```
+3. Package the cache into a tarball that can be uploaded to the artifact store or committed alongside the directory:
+   ```bash
+   tar -C .playwright-browsers -czf .playwright-browsers.tar.gz .
+   ```
+4. Commit the refreshed `.playwright-browsers/` directory and updated tarball, then push the changes.
+
+This ensures the synced browsers match the version expected by the GitHub Actions workflow and keeps the offline cache reproducible.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview --host 127.0.0.1 --port 4173",
     "lint": "eslint --ext .ts,.tsx src",
     "test": "node --test tests",
-    "test:e2e": "playwright test"
+    "test:e2e": "node -e \"const { execSync } = require('node:child_process'); if (!process.env.PLAYWRIGHT_BROWSERS_PATH) { const command = process.platform === 'linux' ? 'playwright install --with-deps' : 'playwright install'; execSync(command, { stdio: 'inherit' }); }\" && playwright test"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- sync the checked-in Playwright browser bundle in CI rather than reinstalling it on every run
- make the `test:e2e` script respect `PLAYWRIGHT_BROWSERS_PATH` so cached browsers are reused
- document how to refresh the offline browser cache and archive when Playwright is upgraded

## Testing
- `pnpm -C frontend lint`


------
https://chatgpt.com/codex/tasks/task_e_68d22ce1fa2083209c04f1f935e9fbbf