### PR TITLE
Add OpenAPI schema generation and tests

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -193,6 +193,20 @@ async def database_status(session: AsyncSession = Depends(get_session)) -> Dict[
 
 
 if __name__ == "__main__":  # pragma: no cover
-    import uvicorn
+    import argparse
+    import json
 
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    parser = argparse.ArgumentParser(description="Application smoke test entry point.")
+    parser.add_argument(
+        "--dump-openapi",
+        action="store_true",
+        help="Output the generated OpenAPI schema and exit.",
+    )
+    args = parser.parse_args()
+
+    if args.dump_openapi:
+        print(json.dumps(app.openapi(), indent=2, sort_keys=True))
+    else:
+        import uvicorn
+
+        uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/tests/test_api/test_openapi_generation.py
+++ b/backend/tests/test_api/test_openapi_generation.py
@@ -1,0 +1,47 @@
+"""Tests for the lightweight OpenAPI generation helper."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlalchemy")
+
+from app.api.v1 import TAGS_METADATA  # noqa: E402  (import after dependency checks)
+from app.core.config import settings  # noqa: E402
+from app.main import app  # noqa: E402
+
+
+def test_openapi_includes_expected_paths() -> None:
+    """Ensure the generated OpenAPI schema documents key endpoints."""
+
+    schema = app.openapi()
+    assert app.openapi() is schema  # cached result
+
+    assert schema["info"]["title"] == settings.PROJECT_NAME
+    assert schema.get("tags") == TAGS_METADATA
+
+    paths = schema["paths"]
+    assert "/api/v1/screen/buildable" in paths
+    assert "/api/v1/finance/feasibility" in paths
+
+    buildable_post = paths["/api/v1/screen/buildable"]["post"]
+    request_example = buildable_post["requestBody"]["content"]["application/json"]["example"]
+    assert request_example["address"] == "string"
+    assert request_example["defaults"]["plot_ratio"] == 3.5
+    assert request_example["geometry"] == {"string": None}
+
+    response_example = buildable_post["responses"]["200"]["content"]["application/json"]["example"]
+    assert response_example["input_kind"] == "address"
+    assert response_example["zone_source"]["kind"] == "parcel"
+    assert response_example["rules"][0]["provenance"]["rule_id"] == 0
+
+    finance_post = paths["/api/v1/finance/feasibility"]["post"]
+    finance_request = finance_post["requestBody"]["content"]["application/json"]["example"]
+    assert finance_request["scenario"]["cost_escalation"]["jurisdiction"] == "SG"
+    assert finance_request["scenario"]["cash_flow"]["cash_flows"] == ["0"]
+
+    finance_response = finance_post["responses"]["200"]["content"]["application/json"]["example"]
+    assert finance_response["cost_index"]["base_index"]["value"] == "0"
+    assert finance_response["results"][0]["metadata"] == {}


### PR DESCRIPTION
## Summary
- add an OpenAPI generator to the FastAPI stub that inspects routes, builds JSON-friendly examples and caches the schema
- extend the CLI smoke test so the schema can be dumped without running the server
- cover the new functionality with a unit test that checks the documented buildable and finance endpoints

## Testing
- `pytest backend/tests/test_api/test_openapi_generation.py`


------
https://chatgpt.com/codex/tasks/task_e_68d22cd40dd883208158f266d7515882