### PR TITLE
Add local dependency mirrors for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Install lint dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r backend/requirements-dev.txt
+          pip install --no-index --find-links third_party/python \
+            -r backend/requirements-dev.txt
 
       - name: Run pre-commit hooks
         run: pre-commit run --all-files --show-diff-on-failure
@@ -67,8 +67,8 @@ jobs:
 
       - name: Install backend dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r backend/requirements-dev.txt
+          pip install --no-index --find-links third_party/python \
+            -r backend/requirements-dev.txt
 
       - name: Start backing services
         run: |
@@ -192,8 +192,8 @@ jobs:
 
       - name: Install backend dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r backend/requirements-dev.txt
+          pip install --no-index --find-links third_party/python \
+            -r backend/requirements-dev.txt
 
       - name: Start backing services
         run: |
@@ -241,7 +241,7 @@ jobs:
           python -m scripts.seed_nonreg
 
       - name: Install frontend dependencies
-        run: pnpm -C frontend install --no-frozen-lockfile
+        run: pnpm -C frontend install --offline --store-dir ../third_party/pnpm-store
 
       - name: Cache Playwright browsers
         uses: actions/cache@v3

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,18 @@
+# Continuous Integration
+
+## Dependency mirror maintenance
+
+CI installs both Python and frontend dependencies from mirrors committed to the
+repository so that workflows do not reach public package registries. When any
+Python or Node dependency changes, refresh the mirrors before pushing:
+
+```bash
+pip download --dest third_party/python -r backend/requirements-dev.txt
+pnpm fetch
+cp -r node_modules/.pnpm-store third_party/pnpm-store
+```
+
+Commit the updated `third_party/python` wheels and the contents of
+`third_party/pnpm-store` together with the dependency lockfile updates. This
+keeps the GitHub Actions workflows functioning in offline mode and ensures that
+local developers can reproduce the CI environment.

--- a/third_party/pnpm-store/README.md
+++ b/third_party/pnpm-store/README.md
@@ -1,0 +1,12 @@
+# pnpm Fetch Store
+
+This directory should contain the pnpm fetch store used by CI for offline
+installs. When frontend dependencies change, refresh the mirror with:
+
+```bash
+pnpm fetch
+cp -r node_modules/.pnpm-store third_party/pnpm-store
+```
+
+Commit the updated store so the GitHub Actions workflow can run `pnpm install`
+with `--offline` and `--store-dir`.

--- a/third_party/python/README.md
+++ b/third_party/python/README.md
@@ -1,0 +1,12 @@
+# Python Wheels Mirror
+
+This directory is a placeholder for the pre-downloaded Python wheels that the CI
+workflow installs with `--no-index`. Refresh the contents whenever
+`backend/requirements-dev.txt` changes by running:
+
+```bash
+pip download --dest third_party/python -r backend/requirements-dev.txt
+```
+
+Make sure the resulting wheels are committed to the repository so CI jobs can
+install dependencies without reaching external package indexes.


### PR DESCRIPTION
## Summary
- configure CI workflows to install Python wheels and pnpm packages from committed mirrors
- add placeholder mirrors for Python wheels and the pnpm fetch store under third_party
- document how to refresh the cached dependencies when requirements change

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d240b32350832093be68353d7f223e