### PR TITLE
Improve init-db bootstrap script configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ Apply the Alembic migrations before booting the API or background workers. The
 while local environments can execute `cd backend && alembic upgrade head` to
 create and update the schema.
 
+The Postgres service defined in `docker-compose.yml` mounts
+[`scripts/init-db.sql`](scripts/init-db.sql) into
+`/docker-entrypoint-initdb.d/`. The script reads the `POSTGRES_DB` and
+`POSTGRES_USER` values from the container environment (falling back to the
+repository defaults) before provisioning the database and enabling the UUID
+helper extensions the application expects. When migrations introduce new
+extensions or other global prerequisites, update the SQL bootstrap script and
+run `alembic upgrade head` so the declarative schema and the on-disk database
+stay aligned. Because the script only executes when the Postgres data directory
+is empty, run `docker compose down -v` (or remove the `postgres_data` volume)
+to rebuild the database after changing the bootstrap logic.
+
 ## CI Smokes
 
 Before pushing changes, run `python -m backend.scripts.run_smokes --artifacts artifacts/`

--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -1,0 +1,30 @@
+\echo 'Running initial database bootstrap'
+\set ON_ERROR_STOP on
+
+-- Read the desired database name and owner from the environment so the script
+-- tracks docker-compose overrides. Fall back to the defaults that ship with the
+-- repository when the variables are unset.
+\getenv dbname POSTGRES_DB
+\if :dbname = ''
+  \set dbname building_compliance
+\endif
+
+\getenv dbowner POSTGRES_USER
+\if :dbowner = ''
+  \set dbowner postgres
+\endif
+
+\echo 'Ensuring database' :'dbname' 'exists with owner' :'dbowner'
+
+-- Connect to the maintenance database so we can create the application database when needed.
+\connect postgres
+
+SELECT format('CREATE DATABASE %I OWNER %I', :'dbname', :'dbowner')
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = :'dbname')
+\gexec
+
+-- Switch to the application database for extension setup.
+\connect :dbname
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";


### PR DESCRIPTION
## Summary
- add a docker-entrypoint bootstrap SQL script that creates the application database, enables UUID extensions, and now respects the `POSTGRES_DB`/`POSTGRES_USER` overrides supplied by docker-compose
- document how the init script fits alongside `alembic upgrade head` in the README and note how to rebuild the volume after changing the bootstrap SQL

## Testing
- docker compose up postgres *(fails: `docker` CLI is unavailable in this execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d24645dd6c8320afb1fadc7adfff48