### PR TITLE
Ensure Playwright browsers installed before e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,9 @@ jobs:
           rsync -a --delete .playwright-browsers/ "$HOME/.cache/ms-playwright/"
           echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/ms-playwright" >> "$GITHUB_ENV"
 
+      - name: Install Playwright browsers
+        run: pnpm -C frontend exec playwright install --with-deps
+
       - name: Run frontend end-to-end tests
         run: pnpm -C frontend test:e2e
 

--- a/frontend/scripts/run-e2e.js
+++ b/frontend/scripts/run-e2e.js
@@ -4,6 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const repoRoot = path.resolve(__dirname, '..', '..');
+const frontendRoot = path.resolve(__dirname, '..');
 const defaultCache = path.join(repoRoot, '.playwright-browsers');
 const env = { ...process.env };
 
@@ -11,32 +12,60 @@ if (!env.PLAYWRIGHT_BROWSERS_PATH || env.PLAYWRIGHT_BROWSERS_PATH.trim() === '')
   env.PLAYWRIGHT_BROWSERS_PATH = defaultCache;
 }
 
+ensurePlaywrightBrowsers();
+
 const cachePath = env.PLAYWRIGHT_BROWSERS_PATH;
 
 if (!fs.existsSync(cachePath)) {
   console.error(`Playwright browser cache not found at ${cachePath}.`);
-  console.error('Populate the directory by running the install command on a machine with internet access:');
+  console.error('Ensure the install command completed successfully:');
   console.error('  pnpm -C frontend exec playwright install --with-deps');
-  console.error('Then copy the contents of ~/.cache/ms-playwright into .playwright-browsers/.');
   process.exit(1);
 }
 
 const metadataFile = path.join(cachePath, 'browsers.json');
 if (!fs.existsSync(metadataFile)) {
   console.error(`Playwright metadata missing at ${metadataFile}.`);
-  console.error('Ensure the cache directory contains the downloaded browser builds expected by Playwright.');
+  console.error('Ensure the install command completed successfully:');
+  console.error('  pnpm -C frontend exec playwright install --with-deps');
   process.exit(1);
 }
 
-const result = spawnSync('playwright', ['test'], {
-  stdio: 'inherit',
-  cwd: path.resolve(__dirname, '..'),
-  env,
-});
+const result = runPnpm(['exec', 'playwright', 'test']);
 
 if (result.error) {
   console.error(result.error);
 }
 
 process.exit(result.status ?? 1);
+
+function ensurePlaywrightBrowsers() {
+  console.log('Ensuring Playwright browser binaries are installed...');
+  const installArgs = ['exec', 'playwright', 'install', '--with-deps'];
+  const installResult = runPnpm(installArgs);
+
+  if (installResult.error) {
+    console.error(installResult.error);
+  }
+
+  if ((installResult.status ?? 1) !== 0) {
+    console.error('Failed to install Playwright browser binaries.');
+    process.exit(installResult.status ?? 1);
+  }
+}
+
+function runPnpm(args) {
+  const options = {
+    stdio: 'inherit',
+    cwd: frontendRoot,
+    env,
+  };
+
+  if (process.env.npm_execpath && process.execPath) {
+    return spawnSync(process.execPath, [process.env.npm_execpath, ...args], options);
+  }
+
+  const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+  return spawnSync(pnpmCommand, args, options);
+}
 


### PR DESCRIPTION
## Summary
- ensure the E2E runner invokes `pnpm exec playwright install --with-deps` so local runs always have browsers ready
- teach the CI workflow to install Playwright browsers before running the frontend E2E suite

## Testing
- pnpm -C frontend test:e2e *(fails: Playwright CLI not available in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d251db4c4883209c267602009fda26