### PR TITLE
Ensure Playwright browsers install before e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,9 @@ jobs:
           rsync -a --delete .playwright-browsers/ "$HOME/.cache/ms-playwright/"
           echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/ms-playwright" >> "$GITHUB_ENV"
 
+      - name: Install Playwright browsers
+        run: pnpm -C frontend exec playwright install --with-deps
+
       - name: Run frontend end-to-end tests
         run: pnpm -C frontend test:e2e
 


### PR DESCRIPTION
## Summary
- run the Playwright browser install command from the e2e runner before starting tests
- add the same install step to the CI workflow so browsers are provisioned ahead of pnpm -C frontend test:e2e

## Testing
- pnpm -C frontend test:e2e *(fails: Playwright install requires network access that is blocked in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d255011efc8320aa45a153a39e0a78