### PR TITLE
Add Alembic module entrypoint and docker-aware make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install format lint test test-cov smoke-buildable clean build deploy init-db seed-data logs down reset dev-start dev-stop import-sample run-overlay export-approved test-aec seed-nonreg sync-products
+.PHONY: help install format lint test test-cov smoke-buildable clean build deploy init-db db.upgrade seed-data logs down reset dev-start dev-stop import-sample run-overlay export-approved test-aec seed-nonreg sync-products
 
 DEV_RUNTIME_DIR ?= .devstack
 DEV_RUNTIME_DIR_ABS := $(abspath $(DEV_RUNTIME_DIR))
@@ -12,6 +12,19 @@ BACKEND_CMD ?= uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 FRONTEND_CMD ?= npm run dev
 ADMIN_CMD ?= npm run dev
 INCLUDE_ADMIN ?= 1
+
+DOCKER_COMPOSE ?= $(shell \
+if command -v docker >/dev/null 2>&1; then \
+if docker compose version >/dev/null 2>&1; then \
+printf '%s' 'docker compose'; \
+exit 0; \
+fi; \
+fi; \
+if command -v docker-compose >/dev/null 2>&1; then \
+printf '%s' 'docker-compose'; \
+exit 0; \
+fi; \
+)
 
 AEC_SAMPLE ?= tests/samples/sample_floorplan.json
 AEC_PROJECT_ID ?= 101
@@ -72,30 +85,63 @@ clean: ## Clean build artifacts
 	cd frontend && rm -rf dist node_modules/.cache
 
 build: ## Build production images
-	docker-compose build
+        @if [ -n "$(DOCKER_COMPOSE)" ]; then \
+                $(DOCKER_COMPOSE) build; \
+        else \
+                echo "Docker Compose is required to build container images."; \
+                exit 1; \
+        fi
 
 init-db: ## Apply Alembic migrations
-	docker-compose exec backend alembic upgrade head
+        @if [ -n "$(DOCKER_COMPOSE)" ]; then \
+                $(DOCKER_COMPOSE) exec backend python -m backend.migrations upgrade head; \
+        else \
+                $(MAKE) db.upgrade; \
+        fi
+
+db.upgrade: ## Apply Alembic migrations in the current Python environment
+        python -m backend.migrations upgrade head
 
 seed-data: ## Seed screening data and finance demo scenarios
-	docker-compose exec backend python -m scripts.seed_screening
-	docker-compose exec backend python -m scripts.seed_finance_demo
+        @if [ -n "$(DOCKER_COMPOSE)" ]; then \
+                $(DOCKER_COMPOSE) exec backend python -m backend.scripts.seed_screening; \
+                $(DOCKER_COMPOSE) exec backend python -m backend.scripts.seed_finance_demo; \
+        else \
+                python -m backend.scripts.seed_screening; \
+                python -m backend.scripts.seed_finance_demo; \
+        fi
 
 logs: ## Show application logs
-	docker-compose logs -f backend frontend
+        @if [ -n "$(DOCKER_COMPOSE)" ]; then \
+                $(DOCKER_COMPOSE) logs -f backend frontend; \
+        else \
+                echo "Docker Compose is not available; skipping container logs."; \
+        fi
 
 down: ## Stop all services
-	docker-compose down
+        @if [ -n "$(DOCKER_COMPOSE)" ]; then \
+                $(DOCKER_COMPOSE) down; \
+        else \
+                echo "Docker Compose is not available; nothing to stop."; \
+        fi
 
 reset: ## Reset development environment
-	docker-compose down -v
-	docker-compose up -d
-	make init-db
-	make seed-data
+        @if [ -n "$(DOCKER_COMPOSE)" ]; then \
+                $(DOCKER_COMPOSE) down -v; \
+                $(DOCKER_COMPOSE) up -d; \
+        else \
+                echo "Docker Compose is not available; skipping container reset."; \
+        fi
+        $(MAKE) init-db
+        $(MAKE) seed-data
 
 dev-start: ## Start supporting services, the backend API, and frontends
-	@mkdir -p $(DEV_RUNTIME_DIR_ABS)
-	@docker-compose up -d
+        @mkdir -p $(DEV_RUNTIME_DIR_ABS)
+        @if [ -n "$(DOCKER_COMPOSE)" ]; then \
+                $(DOCKER_COMPOSE) up -d; \
+        else \
+                echo "Docker Compose is not available; skipping container startup."; \
+        fi
 	@if [ -f $(DEV_BACKEND_PID) ] && kill -0 $$(cat $(DEV_BACKEND_PID)) 2>/dev/null; then \
 		echo "Backend API already running (PID $$(cat $(DEV_BACKEND_PID)))."; \
 	else \

--- a/backend/migrations/__main__.py
+++ b/backend/migrations/__main__.py
@@ -1,0 +1,46 @@
+"""Entry point for running Alembic via ``python -m backend.migrations``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from alembic.config import CommandLine, Config
+
+
+def _build_config(script_location: Path) -> Config:
+    """Construct an Alembic ``Config`` anchored to ``script_location``."""
+
+    config = Config()
+    location = str(script_location)
+
+    config.set_main_option("script_location", location)
+    config.set_section_option(config.config_ini_section, "script_location", location)
+    config.set_section_option(
+        config.config_ini_section,
+        "prepend_sys_path",
+        str(script_location.parent),
+    )
+
+    return config
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Invoke Alembic with arguments forwarded from the command line."""
+
+    options = argv if argv is not None else sys.argv[1:]
+    command = CommandLine(prog="python -m backend.migrations")
+    parsed = command.parser.parse_args(list(options))
+
+    if not getattr(parsed, "cmd", None):
+        command.parser.print_help()
+        return 0
+
+    config = _build_config(Path(__file__).resolve().parent)
+    command.run_cmd(config, parsed)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a Python entry point so `python -m backend.migrations` can invoke Alembic with the repository's script location
- teach the Makefile to detect the available Docker Compose binary, add a `db.upgrade` target, and fall back to in-process seeders when Docker is absent
- document Docker and Python prerequisites plus the new targets in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2619bb77c8320a8cba9167118f8fa