### PR TITLE
Add buildable metrics integration test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
             tests/test_api/test_rules.py \
             tests/test_flows/test_watch_fetch_flow.py \
             tests/test_flows/test_parse_segment_flow.py \
+            ../tests/pwp/test_buildable_metrics.py \
             ../tests/finance/test_finance_smoke.py
 
       - name: Collect coverage artifact

--- a/docs/feasibility.md
+++ b/docs/feasibility.md
@@ -53,4 +53,7 @@ and performance:
 Both metrics are included in the `/health/metrics` endpoint and in the output of
 `app.utils.metrics.render_latest_metrics()`, enabling dashboards and alerts to
 verify that requests are flowing and that latency stays within expected
-thresholds.
+thresholds. After triggering `POST /api/v1/screen/buildable`, fetching
+`/health/metrics` again will show `pwp_buildable_total` incrementing by one and
+`pwp_buildable_duration_ms_count` increasing to reflect the observed latency for
+that request.

--- a/tests/pwp/test_buildable_metrics.py
+++ b/tests/pwp/test_buildable_metrics.py
@@ -1,0 +1,70 @@
+"""Integration tests for buildable screening Prometheus metrics."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("pytest_asyncio")
+
+from backend.tests.pwp.test_buildable_golden import (  # noqa: E402
+    DEFAULT_REQUEST_DEFAULTS,
+    DEFAULT_REQUEST_OVERRIDES,
+    buildable_client,
+)
+
+
+def _metric_value(metrics_text: str, metric_name: str) -> float:
+    """Extract the numeric value for a metric from Prometheus text output."""
+
+    for line in metrics_text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        if not line.startswith(metric_name):
+            continue
+        try:
+            return float(line.rsplit(" ", 1)[-1])
+        except ValueError:
+            continue
+    return 0.0
+
+
+@pytest.mark.asyncio
+async def test_buildable_metrics_increment_after_request(buildable_client) -> None:
+    """Calling buildable screening should increment the exported metrics."""
+
+    client, _ = buildable_client
+
+    initial_metrics = (await client.get("/health/metrics")).text
+    initial_total = _metric_value(initial_metrics, "pwp_buildable_total")
+    initial_duration_count = _metric_value(
+        initial_metrics, "pwp_buildable_duration_ms_count"
+    )
+    initial_duration_sum = _metric_value(
+        initial_metrics, "pwp_buildable_duration_ms_sum"
+    )
+
+    payload = {
+        "address": "123 Example Ave",
+        "defaults": dict(DEFAULT_REQUEST_DEFAULTS),
+        **DEFAULT_REQUEST_OVERRIDES,
+    }
+
+    response = await client.post("/api/v1/screen/buildable", json=payload)
+    assert response.status_code == 200
+
+    metrics_text = (await client.get("/health/metrics")).text
+    final_total = _metric_value(metrics_text, "pwp_buildable_total")
+    final_duration_count = _metric_value(
+        metrics_text, "pwp_buildable_duration_ms_count"
+    )
+    final_duration_sum = _metric_value(metrics_text, "pwp_buildable_duration_ms_sum")
+
+    assert "pwp_buildable_total" in metrics_text
+    assert "pwp_buildable_duration_ms" in metrics_text
+
+    assert final_total >= initial_total + 1.0
+    assert final_duration_count >= initial_duration_count + 1.0
+    assert final_duration_sum > initial_duration_sum


### PR DESCRIPTION
## Summary
- add an integration test that exercises the buildable screening endpoint and asserts Prometheus metrics increment
- run the new test in the backend CI job after the seeding smoke suite completes
- expand the feasibility README snippet to describe how to observe the metrics via `/health/metrics`

## Testing
- `pytest tests/pwp/test_buildable_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68d261c0f214832088bb968f817e7cc5