### PR TITLE
Improve vendored structlog fallback and finance smoke support

### DIFF
--- a/backend/scripts/run_smokes.py
+++ b/backend/scripts/run_smokes.py
@@ -41,10 +41,11 @@ def _write_json(path: Path, payload: Any) -> None:
 def _augment_pythonpath(env: MutableMapping[str, str], backend_dir: Path) -> None:
     current = env.get("PYTHONPATH")
     parts = [part for part in (current.split(os.pathsep) if current else []) if part]
-    backend_str = str(backend_dir)
-    if backend_str not in parts:
-        parts.append(backend_str)
-    env["PYTHONPATH"] = os.pathsep.join(parts) if parts else backend_str
+    for candidate in (backend_dir, backend_dir.parent):
+        candidate_str = str(candidate)
+        if candidate_str not in parts:
+            parts.append(candidate_str)
+    env["PYTHONPATH"] = os.pathsep.join(parts) if parts else str(backend_dir)
 
 
 def run_alembic_upgrades(backend_dir: Path) -> None:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -12,6 +12,11 @@ from typing import Any
 
 import pytest
 
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+if importlib.util.find_spec("structlog") is None and str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
 _MISSING_DEPS = [
     name
     for name in ("fastapi", "pydantic", "sqlalchemy")
@@ -28,9 +33,6 @@ if "sqlalchemy" not in _MISSING_DEPS:
             _MISSING_DEPS.append("sqlalchemy")
 
 if _MISSING_DEPS:  # pragma: no cover - offline test fallback
-    _PROJECT_ROOT = Path(__file__).resolve().parents[2]
-    if str(_PROJECT_ROOT) not in sys.path:
-        sys.path.insert(0, str(_PROJECT_ROOT))
     pytestmark = pytest.mark.skip(
         reason=f"Required dependencies missing: {', '.join(sorted(_MISSING_DEPS))}"
     )

--- a/structlog/__init__.py
+++ b/structlog/__init__.py
@@ -16,6 +16,7 @@ from ._internal import (
 )
 
 __all__ = [
+    "BoundLogger",
     "configure",
     "get_logger",
     "make_filtering_bound_logger",

--- a/structlog/_internal.py
+++ b/structlog/_internal.py
@@ -71,22 +71,70 @@ class BoundLogger:
         new_context.update(kwargs)
         return BoundLogger(self.name, new_context, self._logger)
 
+    def new(self, **kwargs: Any) -> "BoundLogger":
+        """Return a new logger using *kwargs* as the complete context."""
+
+        return BoundLogger(self.name, dict(kwargs), self._logger)
+
+    def unbind(self, *keys: str) -> "BoundLogger":
+        """Return a new logger without the specified context keys."""
+
+        new_context = {key: value for key, value in self._context.items() if key not in keys}
+        return BoundLogger(self.name, new_context, self._logger)
+
     def _apply_processors(self, method_name: str, event_dict: MutableMapping[str, Any]) -> Any:
         result: Any = event_dict
         for processor in iter_processors():
             result = processor(self._logger, method_name, result)
         return result
 
-    def info(self, event: str, **kwargs: Any) -> None:
-        """Emit a processed log record for ``event``."""
-
+    def _prepare_event(
+        self, method_name: str, event: str, kwargs: MutableMapping[str, Any]
+    ) -> tuple[str, Any]:
         event_dict: MutableMapping[str, Any] = {"event": event, **self._context, **kwargs}
-        result = self._apply_processors("info", event_dict)
-        if isinstance(result, dict):
-            message = json.dumps(result)
+        processed = self._apply_processors(method_name, event_dict)
+        exc_info: Any | None = None
+        if isinstance(processed, dict):
+            payload = dict(processed)
+            exc_info = payload.pop("exc_info", None)
+            message = json.dumps(payload)
         else:
-            message = str(result)
-        self._logger.info(message)
+            message = str(processed)
+        return message, exc_info
+
+    def _log(self, method_name: str, event: str, **kwargs: Any) -> None:
+        message, exc_info = self._prepare_event(method_name, event, kwargs)
+        log_method = getattr(self._logger, method_name, None)
+        log_kwargs: dict[str, Any] = {}
+        if method_name == "exception" and exc_info is None:
+            exc_info = True
+        if exc_info is not None:
+            log_kwargs["exc_info"] = exc_info
+
+        if callable(log_method):
+            log_method(message, **log_kwargs)
+        else:
+            level_name = "ERROR" if method_name == "exception" else method_name.upper()
+            level = getattr(logging, level_name, logging.INFO)
+            self._logger.log(level, message, **log_kwargs)
+
+    def debug(self, event: str, **kwargs: Any) -> None:
+        self._log("debug", event, **kwargs)
+
+    def info(self, event: str, **kwargs: Any) -> None:
+        self._log("info", event, **kwargs)
+
+    def warning(self, event: str, **kwargs: Any) -> None:
+        self._log("warning", event, **kwargs)
+
+    def error(self, event: str, **kwargs: Any) -> None:
+        self._log("error", event, **kwargs)
+
+    def exception(self, event: str, **kwargs: Any) -> None:
+        self._log("exception", event, **kwargs)
+
+    def critical(self, event: str, **kwargs: Any) -> None:
+        self._log("critical", event, **kwargs)
 
 
 __all__ = [

--- a/tests/finance/test_structlog_fallback.py
+++ b/tests/finance/test_structlog_fallback.py
@@ -41,6 +41,12 @@ def test_seed_finance_demo_uses_structlog_fallback(
     logger = logging_module.get_logger("structlog-fallback")
     logger.info("structlog_stub_event", detail="ok")
 
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        logger.warning("structlog_stub_warning", detail="warn")
+
+    assert any("structlog_stub_warning" in record.getMessage() for record in caplog.records)
+
     project_root = Path(__file__).resolve().parents[2]
     script_path = project_root / "scripts" / "seed_finance_demo.py"
     spec = importlib.util.spec_from_file_location("tests.structlog_cli", script_path)


### PR DESCRIPTION
## Summary
- extend the vendored structlog stub with additional logging helpers so warn/error paths work without the PyPI package
- ensure backend tooling and tests can import the vendored structlog module by adding the project root to PYTHONPATH when needed
- harden the structlog fallback regression test to cover warning level logging

## Testing
- `pytest tests/finance/test_structlog_fallback.py`
- `pytest backend/tests/test_utils/test_logging.py`
- `pytest tests/finance/test_finance_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68d261afc2788320b46cc4c14097fefa