### PR TITLE
Add Python-backed migration target and Docker compose detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Optimal Build
 
+## Prerequisites
+
+* Docker with the Compose plugin (or the legacy `docker-compose` binary) for targets that manage services such as `make dev-start`, `make init-db`, `make reset`, `make build`, and `make logs`. The Makefile auto-detects whichever CLI is available and surfaces a descriptive error when neither is present.
+* A local Python interpreter with the backend dependencies installed (e.g., `pip install -r backend/requirements-dev.txt`) so that Python fallbacks like `make seed-data` and `make db.upgrade` can talk to the database when Docker is unavailable.
+
 ## Frontend environment configuration
 
 The frontend reads API locations from the `VITE_API_BASE_URL` variable that is loaded by Vite at build time. The value is resolved with `new URL(path, base)` so that links behave correctly whether the backend is exposed on the same origin, via a sub-path proxy, or through a separate host. For local development we provide a default of `/` in `frontend/.env` (copy `frontend/.env.example`) so the app talks to whichever host serves the frontend.
@@ -31,10 +36,11 @@ These values are consumed by `backend/app/core/config.py`. When only `REDIS_URL`
 
 ### Database migrations
 
-Apply the Alembic migrations before booting the API or background workers. The
-`init-db` make target runs `alembic upgrade head` inside the backend container,
-while local environments can execute `cd backend && alembic upgrade head` to
-create and update the schema.
+Apply the Alembic migrations before booting the API or background workers. Use
+`make db.upgrade` to run `python -m backend.migrations alembic upgrade head`
+directly against your local environment. Docker-driven setups can call
+`make init-db`, which executes the same module inside the backend container
+once the Compose CLI is available.
 
 The Postgres service defined in `docker-compose.yml` mounts
 [`scripts/init-db.sql`](scripts/init-db.sql) into
@@ -49,8 +55,8 @@ introduce new extensions or other global prerequisites, update the SQL
 bootstrap script and run `alembic upgrade head` so the declarative schema and
 the on-disk database stay aligned. Because the script only executes when the
 Postgres data directory is empty, run `docker compose down -v` (or remove the
-`postgres_data` volume) to rebuild the database after changing the bootstrap
-logic. Document any new assumptions in this README so local and CI environments
+`postgres_data` volume) — or the equivalent `docker-compose down -v` command —
+to rebuild the database after changing the bootstrap logic. Document any new assumptions in this README so local and CI environments
 stay in sync.
 
 ## CI Smokes
@@ -135,16 +141,19 @@ underlying heuristics and instrumentation assumptions are documented in
 ## Finance feasibility demo
 
 Run `make seed-data` after applying migrations to populate both the screening
-fixtures and a finance feasibility workspace. The make target now executes the
-finance demo seeder (`python -m scripts.seed_finance_demo`) inside the backend
-container, which creates:
+fixtures and a finance feasibility workspace. When Docker Compose is available
+the target executes `python -m backend.scripts.seed_screening` and
+`python -m backend.scripts.seed_finance_demo` inside the backend container. If
+Compose is missing, the Makefile falls back to running the same modules
+locally, so ensure your Python environment can reach the configured database.
+The seeding process creates:
 
 * a finance project linked to `project_id=401` named “Finance Demo Development”,
 * three scenarios (A/B/C) with escalated cost assumptions and cash-flow inputs,
 * cost line items and monthly cash-flow schedules for each scenario, and
 * persisted results mirroring the `/api/v1/finance/feasibility` response payload.
 
-To run the seeder outside Docker, execute `python scripts/seed_finance_demo.py`
+To run the seeder outside Docker, execute `python -m backend.scripts.seed_finance_demo`
 from the repository root. The CLI accepts `--project-id`, `--project-name`, and
 `--currency` options plus `--keep-existing` to retain previous demo rows.
 

--- a/backend/migrations/__main__.py
+++ b/backend/migrations/__main__.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from tempfile import NamedTemporaryFile, gettempdir
+from textwrap import dedent
+
+from alembic.config import main as alembic_main
+
+_CONFIG_TEMPLATE = """\
+[alembic]
+script_location = {script_location}
+prepend_sys_path = {prepend_sys_path}
+sqlalchemy.url = sqlite:///placeholder
+
+timezone = UTC
+
+autogenerate = true
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+"""
+
+
+def _normalize_args(args: list[str]) -> list[str]:
+    # Allow commands to include an "alembic" prefix to mirror the upstream CLI.
+    if args and args[0] == "alembic":
+        return args[1:]
+    return args
+
+
+def _write_config(tmp_dir: Path) -> Path:
+    migrations_dir = Path(__file__).resolve().parent
+    config_body = _CONFIG_TEMPLATE.format(
+        script_location=migrations_dir.as_posix(),
+        prepend_sys_path=migrations_dir.parent.as_posix(),
+    )
+
+    with NamedTemporaryFile("w", suffix=".ini", dir=tmp_dir, delete=False) as handle:
+        handle.write(dedent(config_body))
+        return Path(handle.name)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    normalized = _normalize_args(args)
+
+    tmp_dir = Path(os.getenv("TMPDIR", gettempdir()))
+    config_path = _write_config(tmp_dir)
+    try:
+        alembic_main(["-c", str(config_path), *normalized])
+    finally:
+        try:
+            config_path.unlink()
+        except FileNotFoundError:
+            pass
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- detect the available Docker Compose CLI, guard compose-driven targets, and add a db.upgrade rule that runs migrations via `python -m backend.migrations`
- fall back to local Python seeders when Compose is unavailable while keeping container exec paths aligned
- document the new prerequisites and workflow updates in the README
- add a minimal `backend.migrations` entrypoint that materialises an Alembic config on the fly before delegating to Alembic

## Testing
- make -n build
- make -n seed-data
- make -n dev-start


------
https://chatgpt.com/codex/tasks/task_e_68d26452aa1083208d5fedd72634b0e7