### PR TITLE
Ensure SQLAlchemy comes from environment

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -24,10 +24,10 @@ _MISSING_DEPS = [
 ]
 
 if "sqlalchemy" not in _MISSING_DEPS:
-    try:  # pragma: no cover - only exercised when the stub is present
+    try:  # pragma: no cover - ensures we use the real package
         import sqlalchemy as _sqlalchemy
     except ModuleNotFoundError:  # pragma: no cover - defensive
-        pass
+        _MISSING_DEPS.append("sqlalchemy")
     else:
         if getattr(_sqlalchemy, "root_missing_error", None) is not None:
             _MISSING_DEPS.append("sqlalchemy")

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,18 +1,22 @@
 # Continuous Integration
 
-## Dependency mirror maintenance
+## Dependency installation
 
-CI installs both Python and frontend dependencies from mirrors committed to the
-repository so that workflows do not reach public package registries. When any
-Python or Node dependency changes, refresh the mirrors before pushing:
+CI and local development environments install Python dependencies directly from
+the pinned requirement files instead of pre-downloaded wheels. Run the standard
+installation command whenever the backend requirements change:
 
 ```bash
-pip download --dest third_party/python -r backend/requirements-dev.txt
+pip install -r backend/requirements-dev.txt
+```
+
+Frontend dependencies continue to use the cached pnpm store that lives under
+`third_party/pnpm-store`. Refresh the cache when Node dependencies change:
+
+```bash
 pnpm fetch
 cp -r node_modules/.pnpm-store third_party/pnpm-store
 ```
 
-Commit the updated `third_party/python` wheels and the contents of
-`third_party/pnpm-store` together with the dependency lockfile updates. This
-keeps the GitHub Actions workflows functioning in offline mode and ensures that
-local developers can reproduce the CI environment.
+Commit the updated pnpm store together with the dependency lockfile updates so
+GitHub Actions workflows can continue to run without reaching public registries.

--- a/third_party/python/README.md
+++ b/third_party/python/README.md
@@ -1,12 +1,15 @@
-# Python Wheels Mirror
+# Python dependencies
 
-This directory is a placeholder for the pre-downloaded Python wheels that the CI
-workflow installs with `--no-index`. Refresh the contents whenever
-`backend/requirements-dev.txt` changes by running:
+Python dependencies are installed from the pinned requirement files using the
+standard `pip install` flow. SQLAlchemy is resolved from
+`backend/requirements.txt`, so there is no longer a vendored wheel committed in
+this directory.
+
+To install the backend dependencies for development or CI, run:
 
 ```bash
-pip download --dest third_party/python -r backend/requirements-dev.txt
+pip install -r backend/requirements-dev.txt
 ```
 
-Make sure the resulting wheels are committed to the repository so CI jobs can
-install dependencies without reaching external package indexes.
+The directory remains in the repository as a placeholder should we need to add
+future offline mirrors, but it is intentionally empty.


### PR DESCRIPTION
## Summary
- update the backend SQLAlchemy shim to import the real package when it is installed
- keep test fixtures aware of the shim so they skip when SQLAlchemy is unavailable
- refresh the CI and third_party documentation to reflect that SQLAlchemy now comes from pip-installed requirements

## Testing
- `pytest backend/tests/test_scripts/test_seed_nonreg.py` *(fails: file not found in repository)*
- `pytest backend/tests/test_api/test_nonreg_smoke.py` *(fails: file not found in repository)*


------
https://chatgpt.com/codex/tasks/task_e_68d268d371448320ace89cc2ea364d10