### PR TITLE
Improve db.upgrade dependency handling and CI smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,61 @@ jobs:
       - name: Run pre-commit hooks
         run: pre-commit run --all-files --show-diff-on-failure
 
+  db_upgrade_smoke:
+    name: DB Upgrade Smoke
+    runs-on: ubuntu-latest
+    needs: lint
+    env:
+      POSTGRES_SERVER: 127.0.0.1
+      POSTGRES_DB: building_compliance
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_PORT: '5432'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install backend runtime dependencies
+        run: |
+          pip install -r backend/requirements.txt
+
+      - name: Start Postgres service
+        run: |
+          docker compose -f docker-compose.yml up -d postgres
+
+      - name: Wait for Postgres
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 30); do
+            if docker compose -f docker-compose.yml exec -T postgres pg_isready -U "$POSTGRES_USER"; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Postgres did not become ready in time" >&2
+          exit 1
+
+      - name: Run Alembic migrations
+        run: make db.upgrade
+
+      - name: Stop Postgres service
+        if: always()
+        run: |
+          docker compose -f docker-compose.yml down --volumes
+
   backend:
     name: Backend Smokes & Tests
     runs-on: ubuntu-latest
-    needs: lint
+    needs:
+      - lint
+      - db_upgrade_smoke
     env:
       POSTGRES_SERVER: 127.0.0.1
       POSTGRES_DB: building_compliance

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ init-db: ## Apply Alembic migrations inside Docker
 	$(DOCKER_COMPOSE) exec backend python -m backend.migrations alembic upgrade head
 
 db.upgrade: ## Apply Alembic migrations locally
+	python scripts/ensure_alembic.py
 	python -m backend.migrations alembic upgrade head
 
 seed-data: ## Seed screening data and finance demo scenarios

--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@
 * Docker with the Compose plugin (or the legacy `docker-compose` binary) for targets that manage services such as `make dev-start`, `make init-db`, `make reset`, `make build`, and `make logs`. The Makefile auto-detects whichever CLI is available and surfaces a descriptive error when neither is present.
 * A local Python interpreter with the backend dependencies installed (e.g., `pip install -r backend/requirements-dev.txt`) so that Python fallbacks like `make seed-data` and `make db.upgrade` can talk to the database when Docker is unavailable.
 
+## Bootstrap
+
+Before running any `make` targets, install the backend runtime dependencies so Alembic and other CLI entry points are available locally:
+
+```bash
+pip install -r backend/requirements.txt
+```
+
+If you plan to run linting or tests directly, follow up with the development extras:
+
+```bash
+pip install -r backend/requirements-dev.txt
+```
+
 ## Frontend environment configuration
 
 The frontend reads API locations from the `VITE_API_BASE_URL` variable that is loaded by Vite at build time. The value is resolved with `new URL(path, base)` so that links behave correctly whether the backend is exposed on the same origin, via a sub-path proxy, or through a separate host. For local development we provide a default of `/` in `frontend/.env` (copy `frontend/.env.example`) so the app talks to whichever host serves the frontend.

--- a/scripts/ensure_alembic.py
+++ b/scripts/ensure_alembic.py
@@ -1,0 +1,116 @@
+"""Ensure Alembic is available before running migrations."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_REQUIREMENTS = _REPO_ROOT / "backend" / "requirements.txt"
+
+
+def _print_error(lines: Iterable[str]) -> None:
+    for line in lines:
+        print(line, file=sys.stderr, flush=True)
+
+
+def _in_virtualenv() -> bool:
+    if sys.prefix != getattr(sys, "base_prefix", sys.prefix):
+        return True
+
+    real_prefix = getattr(sys, "real_prefix", None)
+    if real_prefix and real_prefix != sys.prefix:
+        return True
+
+    if os.environ.get("VIRTUAL_ENV") or os.environ.get("CONDA_PREFIX"):
+        return True
+
+    return False
+
+
+def _safe_to_install() -> bool:
+    """Return ``True`` when it's safe to install requirements automatically."""
+
+    if os.environ.get("PIP_REQUIRE_VIRTUALENV"):
+        return False
+
+    if _in_virtualenv():
+        return True
+
+    if os.environ.get("CI"):
+        return True
+
+    return False
+
+
+def _install_requirements(requirements: Path) -> None:
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", str(requirements)])
+
+
+def ensure_alembic(requirements: Path | None = None) -> None:
+    """Install or prompt for Alembic when it's missing."""
+
+    if importlib.util.find_spec("alembic") is not None:
+        return
+
+    requirements_path = Path(requirements) if requirements else _DEFAULT_REQUIREMENTS
+
+    if not requirements_path.exists():
+        _print_error(
+            [
+                f"Error: requirements file not found at '{requirements_path}'.",
+                "Install backend dependencies manually before rerunning 'make db.upgrade'.",
+            ]
+        )
+        raise SystemExit(1)
+
+    try:
+        requirement_display = requirements_path.relative_to(_REPO_ROOT)
+    except ValueError:
+        requirement_display = requirements_path
+
+    if _safe_to_install():
+        print(
+            f"Alembic not found; installing backend dependencies ({requirement_display}).",
+            flush=True,
+        )
+        try:
+            _install_requirements(requirements_path)
+        except subprocess.CalledProcessError as exc:
+            _print_error(
+                [
+                    "Failed to install backend requirements automatically.",
+                    f"Run 'pip install -r {requirement_display}' and rerun 'make db.upgrade'.",
+                ]
+            )
+            raise SystemExit(exc.returncode)
+
+        if importlib.util.find_spec("alembic") is None:
+            _print_error(
+                [
+                    "Alembic is still unavailable after installing backend requirements.",
+                    f"Verify that '{requirement_display}' pins Alembic and reinstall manually.",
+                ]
+            )
+            raise SystemExit(1)
+        return
+
+    _print_error(
+        [
+            "Error: Alembic is not installed.",
+            f"Install backend dependencies with 'pip install -r {requirement_display}' before rerunning.",
+            "If you prefer an isolated environment:",
+            "  python -m venv .venv",
+            "  source .venv/bin/activate  # (use .venv\\Scripts\\activate on Windows)",
+            f"  pip install -r {requirement_display}",
+        ]
+    )
+    raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    ensure_alembic()


### PR DESCRIPTION
## Summary
- add an Alembic guard script and hook it into `make db.upgrade` so missing dependencies trigger an install (when safe) or an actionable message, including stricter environment detection and post-install verification
- document the backend bootstrap step that installs `backend/requirements.txt`
- run `make db.upgrade` as a dedicated CI smoke job before the backend suite

## Testing
- python -m compileall scripts/ensure_alembic.py

------
https://chatgpt.com/codex/tasks/task_e_68d27aad3a7c832082e90469fa4c7877