### PR TITLE
Validate finance project ownership

### DIFF
--- a/backend/app/api/v1/finance.py
+++ b/backend/app/api/v1/finance.py
@@ -225,6 +225,11 @@ async def run_finance_feasibility(
             fin_project = await session.get(FinProject, payload.fin_project_id)
             if fin_project is None:
                 raise HTTPException(status_code=404, detail="Finance project not found")
+            if fin_project.project_id != payload.project_id:
+                raise HTTPException(
+                    status_code=403,
+                    detail="Finance project does not belong to the requested project",
+                )
         else:
             stmt = (
                 select(FinProject)

--- a/backend/tests/test_api/test_finance_project_scope.py
+++ b/backend/tests/test_api/test_finance_project_scope.py
@@ -1,0 +1,71 @@
+"""Tests ensuring finance projects cannot be reassigned across projects."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlalchemy")
+
+from httpx import AsyncClient
+
+from app.models.finance import FinProject
+
+
+@pytest.mark.asyncio
+async def test_finance_feasibility_rejects_foreign_fin_project(
+    client: AsyncClient, async_session_factory
+) -> None:
+    async with async_session_factory() as setup_session:
+        local_project = FinProject(
+            project_id=101,
+            name="Local Project",
+            currency="USD",
+            discount_rate=Decimal("0.05"),
+            metadata={},
+        )
+        foreign_project = FinProject(
+            project_id=202,
+            name="Foreign Project",
+            currency="EUR",
+            discount_rate=Decimal("0.07"),
+            metadata={},
+        )
+        setup_session.add_all([local_project, foreign_project])
+        await setup_session.flush()
+        foreign_project_id = foreign_project.id
+        await setup_session.commit()
+
+    payload = {
+        "project_id": 101,
+        "project_name": "Local Project",
+        "fin_project_id": foreign_project_id,
+        "scenario": {
+            "name": "Mismatch Scenario",
+            "description": "Attempt to reuse a foreign finance workspace",
+            "currency": "SGD",
+            "is_primary": False,
+            "cost_escalation": {
+                "amount": "1000000",
+                "base_period": "2024-Q1",
+                "series_name": "construction_cost",
+                "jurisdiction": "SG",
+            },
+            "cash_flow": {
+                "discount_rate": "0.08",
+                "cash_flows": ["-1000000", "350000", "400000", "450000"],
+            },
+        },
+    }
+
+    response = await client.post("/api/v1/finance/feasibility", json=payload)
+    assert response.status_code in (403, 404)
+
+    async with async_session_factory() as verify_session:
+        persisted = await verify_session.get(FinProject, foreign_project_id)
+        assert persisted is not None
+        assert persisted.currency == "EUR"
+        assert persisted.discount_rate == Decimal("0.07")


### PR DESCRIPTION
## Summary
- ensure the finance feasibility endpoint rejects finance projects that belong to a different project
- add a regression test confirming mismatched finance project IDs are denied and leave the foreign project untouched

## Testing
- pytest backend/tests/test_api/test_finance_project_scope.py

------
https://chatgpt.com/codex/tasks/task_e_68d28d2288548320bffc3875577a5b88