### PR TITLE
test: clean fixtures and update imports

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,251 +3,179 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from collections.abc import AsyncGenerator, Callable, Iterator
 from contextlib import asynccontextmanager
-from pathlib import Path
-import importlib.util
-import sys
-from typing import Any
+from importlib import import_module
 
 import pytest
-
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
-
-_MISSING_DEPS = [
-    name
-    for name in ("fastapi", "pydantic", "sqlalchemy")
-    if importlib.util.find_spec(name) is None
-]
-
-if "sqlalchemy" not in _MISSING_DEPS:
-    try:  # pragma: no cover - ensures we use the real package
-        import sqlalchemy as _sqlalchemy
-    except ModuleNotFoundError:  # pragma: no cover - defensive
-        _MISSING_DEPS.append("sqlalchemy")
-    else:
-        if getattr(_sqlalchemy, "root_missing_error", None) is not None:
-            _MISSING_DEPS.append("sqlalchemy")
-
-if _MISSING_DEPS:  # pragma: no cover - offline test fallback
-    pytestmark = pytest.mark.skip(
-        reason=f"Required dependencies missing: {', '.join(sorted(_MISSING_DEPS))}"
-    )
-
-try:  # pragma: no cover - exercised indirectly via tests
-    import pytest_asyncio
-except ModuleNotFoundError:  # pragma: no cover - fallback stub for offline testing
-    from types import ModuleType
-
-    _pytest_asyncio_stub = ModuleType("pytest_asyncio")
-    _pytest_asyncio_stub.fixture = pytest.fixture  # type: ignore[attr-defined]
-    sys.modules.setdefault("pytest_asyncio", _pytest_asyncio_stub)
-    pytest_asyncio = _pytest_asyncio_stub  # type: ignore[assignment]
-
-try:  # pragma: no cover - optional dependency for API tests
-    from httpx import AsyncClient
-except ModuleNotFoundError:  # pragma: no cover - fallback stub for offline testing
-    class AsyncClient:  # type: ignore[no-redef]
-        """Fallback stub used when httpx is not installed."""
-
-        def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401 - simple stub
-            self._error = ModuleNotFoundError(
-                "The optional dependency 'httpx' is required for AsyncClient fixtures. "
-                "Install httpx to run API client tests."
-            )
-
-        async def __aenter__(self) -> "AsyncClient":  # pragma: no cover - invoked in tests
-            raise self._error
-
-        async def __aexit__(self, exc_type, exc, tb) -> bool:  # pragma: no cover - invoked in tests
-            return False
-
-try:  # pragma: no cover - optional dependency for database fixtures
-    from sqlalchemy._memory import GLOBAL_DATABASE as _GLOBAL_DATABASE
-except ModuleNotFoundError:  # pragma: no cover - running against real SQLAlchemy
-    _GLOBAL_DATABASE = None
-
-try:  # pragma: no cover - optional dependency for database fixtures
-    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-except ModuleNotFoundError as exc:  # pragma: no cover - fallback stub for offline testing
-    class AsyncSession:  # type: ignore[no-redef]
-        """Stub used when SQLAlchemy is unavailable."""
-
-    def async_sessionmaker(*args: Any, **kwargs: Any):  # type: ignore[no-redef]
-        raise ModuleNotFoundError(
-            "SQLAlchemy is required for database fixtures. Install 'sqlalchemy' to run database tests."
-        )
-
-    def create_async_engine(*args: Any, **kwargs: Any):  # type: ignore[no-redef]
-        raise ModuleNotFoundError(
-            "SQLAlchemy is required for database fixtures. Install 'sqlalchemy' to run database tests."
-        )
-
-    structlog_module.processors = processors_module  # type: ignore[attr-defined]
-    structlog_module.stdlib = stdlib_module  # type: ignore[attr-defined]
-    structlog_module.BoundLogger = _StubBoundLogger  # type: ignore[attr-defined]
-
-    sys.modules.setdefault("structlog", structlog_module)
-    sys.modules.setdefault("structlog.processors", processors_module)
-    sys.modules.setdefault("structlog.stdlib", stdlib_module)
-
-_APP_IMPORT_ERROR: ModuleNotFoundError | None = None
-
-try:  # pragma: no cover - optional dependency for database fixtures
-    from app.core.database import get_session
-except ModuleNotFoundError as exc:  # pragma: no cover - fallback stub for offline testing
-    _APP_IMPORT_ERROR = exc
-
-    async def get_session(*args: Any, **kwargs: Any):  # type: ignore[no-redef]
-        raise exc
-
-try:  # pragma: no cover - optional dependency for API fixtures
-    from app.main import app
-except ModuleNotFoundError as exc:  # pragma: no cover - fallback stub for offline testing
-    if _APP_IMPORT_ERROR is None:
-        _APP_IMPORT_ERROR = exc
-    app = None  # type: ignore[assignment]
-
-try:  # pragma: no cover - optional dependency for database fixtures
-    from app.models.base import BaseModel
-except ModuleNotFoundError as exc:  # pragma: no cover - fallback stub for offline testing
-    if _APP_IMPORT_ERROR is None:
-        _APP_IMPORT_ERROR = exc
-
-    class _BaseModelMetadataStub:
-        sorted_tables: list = []
-
-        def create_all(self, *args: Any, **kwargs: Any) -> None:
-            raise exc
-
-    class BaseModel:  # type: ignore[no-redef]
-        metadata = _BaseModelMetadataStub()
-
-try:  # pragma: no cover - optional dependency for storage fixtures
-    from app.services.storage import get_storage_service, reset_storage_service
-except ModuleNotFoundError:  # pragma: no cover - fallback stubs for offline testing
-    def get_storage_service():  # type: ignore[no-redef]
-        raise ModuleNotFoundError(
-            "Storage service dependencies are unavailable. Install optional dependencies to run storage tests."
-        )
-
-    def reset_storage_service():  # type: ignore[no-redef]
-        return None
-
-from app.utils import metrics
+import pytest_asyncio
+from httpx import AsyncClient
 
 
-def _reset_stub_database() -> None:
-    if _GLOBAL_DATABASE is None:  # pragma: no cover - real SQLAlchemy path
-        return
-    for table in BaseModel.metadata.sorted_tables:
-        model = _GLOBAL_DATABASE.resolve_table(table.name)
-        if model is not None:
-            _GLOBAL_DATABASE.delete_all(model)
+def _ensure_sqlalchemy() -> None:
+    """Expose the bundled lightweight SQLAlchemy implementation if needed."""
+
+    try:  # pragma: no cover - exercised implicitly when SQLAlchemy is available
+        import sqlalchemy  # noqa: F401
+    except ModuleNotFoundError:
+        pkg = import_module("sqlalchemy_pkg_backup")
+        sys.modules.setdefault("sqlalchemy", pkg)
+
+        for name in (
+            "ext",
+            "ext.asyncio",
+            "orm",
+            "engine",
+            "sql",
+            "dialects",
+            "dialects.postgresql",
+            "types",
+            "pool",
+        ):
+            sys.modules.setdefault(f"sqlalchemy.{name}", import_module(f"sqlalchemy_pkg_backup.{name}"))
+
+
+_ensure_sqlalchemy()
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+try:  # pragma: no cover - StaticPool only exists in real SQLAlchemy
+    from sqlalchemy.pool import StaticPool
+except (ImportError, AttributeError):  # pragma: no cover - fallback for stub implementation
+    class StaticPool:  # type: ignore[too-many-ancestors]
+        """Placeholder used when running against the in-repo SQLAlchemy stub."""
+
+        pass
+
+
+from backend.app import models as app_models
+from backend.app.core.database import get_session
+from backend.app.main import app
+from backend.app.models.base import BaseModel
+from backend.app.utils import metrics
+
+# Importing ``backend.app.models`` ensures all model metadata is registered.
+_ = app_models
+
+_SORTED_TABLES = tuple(BaseModel.metadata.sorted_tables)
 
 
 @pytest.fixture(scope="session")
 def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
+    """Create a dedicated event loop for the entire test session."""
+
     loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
+    try:
+        yield loop
+    finally:
+        loop.close()
 
 
-if _MISSING_DEPS:
-    @pytest.fixture
-    def async_session_factory() -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
-        pytest.skip("Database fixtures require fastapi, pydantic, and sqlalchemy")
-        yield  # pragma: no cover
-else:
+async def _truncate_all(session: AsyncSession) -> None:
+    """Remove all rows from every mapped table in metadata order."""
 
-    @pytest_asyncio.fixture
-    async def async_session_factory() -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
-        _reset_stub_database()
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
-        async with engine.begin() as conn:
-            await conn.run_sync(BaseModel.metadata.create_all)
-        factory = async_sessionmaker(engine, expire_on_commit=False)
+    await session.rollback()
+    for table in reversed(_SORTED_TABLES):
+        await session.execute(table.delete())
+    await session.commit()
+
+
+async def _reset_database(factory: async_sessionmaker[AsyncSession]) -> None:
+    """Clear all persisted data using a fresh session."""
+
+    async with factory() as session:
+        await _truncate_all(session)
+
+
+@pytest_asyncio.fixture(scope="session")
+async def flow_session_factory() -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
+    """Provide a shared async session factory backed by SQLite."""
+
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(BaseModel.metadata.create_all)
+
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture(scope="session")
+async def async_session_factory(
+    flow_session_factory: async_sessionmaker[AsyncSession],
+) -> async_sessionmaker[AsyncSession]:
+    """Alias for the shared async session factory."""
+
+    return flow_session_factory
+
+
+@pytest_asyncio.fixture
+async def session(
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> AsyncGenerator[AsyncSession, None]:
+    """Yield a database session and clean up after each test."""
+
+    async with async_session_factory() as db_session:
         try:
-            yield factory
+            yield db_session
         finally:
-            await engine.dispose()
-            _reset_stub_database()
-
-
-@pytest.fixture(autouse=True)
-def reset_metrics() -> Iterator[None]:
-    metrics.reset_metrics()
-    yield
-    metrics.reset_metrics()
-
-
-if _MISSING_DEPS:
-    @pytest.fixture
-    def session(async_session_factory: async_sessionmaker[AsyncSession]) -> AsyncGenerator[AsyncSession, None]:
-        pytest.skip("Database fixtures require fastapi, pydantic, and sqlalchemy")
-        yield  # pragma: no cover
-else:
-
-    @pytest_asyncio.fixture
-    async def session(async_session_factory: async_sessionmaker[AsyncSession]) -> AsyncGenerator[AsyncSession, None]:
-        async with async_session_factory() as session:
-            try:
-                yield session
-            finally:
-                await session.rollback()
-                for table in reversed(BaseModel.metadata.sorted_tables):
-                    await session.execute(table.delete())
-                await session.commit()
+            await _truncate_all(db_session)
 
 
 @pytest.fixture
-def session_factory(async_session_factory: async_sessionmaker[AsyncSession]) -> Callable[[], AsyncGenerator[AsyncSession, None]]:
-    @asynccontextmanager
-    async def _context() -> AsyncGenerator[AsyncSession, None]:
-        async with async_session_factory() as session:
-            yield session
+def session_factory(
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> Callable[[], AsyncGenerator[AsyncSession, None]]:
+    """Return an async context manager that yields a clean session."""
 
-    def _factory() -> AsyncGenerator[AsyncSession, None]:
-        return _context()
+    @asynccontextmanager
+    async def _factory() -> AsyncGenerator[AsyncSession, None]:
+        async with async_session_factory() as db_session:
+            try:
+                yield db_session
+            finally:
+                await _truncate_all(db_session)
 
     return _factory
 
 
-@pytest.fixture
-def storage_service(tmp_path, monkeypatch):
+@pytest.fixture(autouse=True)
+def reset_metrics() -> Iterator[None]:
+    """Reset application metrics before and after every test."""
+
+    metrics.reset_metrics()
     try:
-        base_path = tmp_path / "storage"
-        base_path.mkdir()
-        monkeypatch.setenv("STORAGE_LOCAL_PATH", str(base_path))
-        reset_storage_service()
-        service = get_storage_service()
-    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency missing
-        pytest.skip(str(exc))
-        return None
-    try:
-        yield service
+        yield
     finally:
-        reset_storage_service()
+        metrics.reset_metrics()
 
 
 @pytest_asyncio.fixture
-async def client(async_session_factory: async_sessionmaker[AsyncSession], storage_service) -> AsyncGenerator[AsyncClient, None]:
-    if app is None:  # pragma: no cover - triggered only when optional deps missing
-        raise ModuleNotFoundError(
-            "FastAPI application dependencies are unavailable. Install optional dependencies to run API tests."
-        ) from _APP_IMPORT_ERROR
+async def app_client(
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> AsyncGenerator[AsyncClient, None]:
+    """Provide an HTTPX client with the database dependency overridden."""
 
-    async def _get_session() -> AsyncGenerator[AsyncSession, None]:
-        async with async_session_factory() as session:
-            yield session
+    async def _override_get_session() -> AsyncGenerator[AsyncSession, None]:
+        async with async_session_factory() as db_session:
+            yield db_session
 
-    app.dependency_overrides[get_session] = _get_session
+    app.dependency_overrides[get_session] = _override_get_session
     async with AsyncClient(
         app=app,
         base_url="http://testserver",
         headers={"X-Role": "admin"},
-    ) as http_client:
-        yield http_client
+    ) as client:
+        yield client
+
     app.dependency_overrides.pop(get_session, None)
+    await _reset_database(async_session_factory)
+

--- a/backend/tests/pwp/test_buildable_metrics.py
+++ b/backend/tests/pwp/test_buildable_metrics.py
@@ -62,9 +62,9 @@ except ModuleNotFoundError:  # pragma: no cover - fallback stub for offline test
     sys.modules.setdefault("structlog.processors", processors_module)
     sys.modules.setdefault("structlog.stdlib", stdlib_module)
 
-from app.utils import metrics
+from backend.app.utils import metrics
 
-from tests.pwp.test_buildable_golden import (
+from backend.tests.pwp.test_buildable_golden import (
     DEFAULT_REQUEST_DEFAULTS,
     DEFAULT_REQUEST_OVERRIDES,
     buildable_client,

--- a/backend/tests/pwp/test_buildable_postgis_flag.py
+++ b/backend/tests/pwp/test_buildable_postgis_flag.py
@@ -7,10 +7,10 @@ pytest.importorskip("pytest_asyncio")
 
 from sqlalchemy import select
 
-from app.core.config import settings
-from app.models.rkp import RefParcel
-from app.schemas.buildable import BuildableDefaults
-from app.services.buildable import ResolvedZone, calculate_buildable, load_layers_for_zone
+from backend.app.core.config import settings
+from backend.app.models.rkp import RefParcel
+from backend.app.schemas.buildable import BuildableDefaults
+from backend.app.services.buildable import ResolvedZone, calculate_buildable, load_layers_for_zone
 from scripts.seed_screening import seed_screening_sample_data
 
 

--- a/backend/tests/pwp/test_buildable_request_aliases.py
+++ b/backend/tests/pwp/test_buildable_request_aliases.py
@@ -13,8 +13,8 @@ import pytest_asyncio  # noqa: F401
 
 from httpx import AsyncClient
 
-from app.core.config import settings
-from app.schemas.buildable import (
+from backend.app.core.config import settings
+from backend.app.schemas.buildable import (
     BuildableCalculation,
     BuildableDefaults,
     BuildableMetrics,
@@ -24,7 +24,7 @@ from app.schemas.buildable import (
 
 @pytest.mark.asyncio
 async def test_buildable_request_accepts_camel_case(
-    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    app_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(settings, "BUILDABLE_TYP_FLOOR_TO_FLOOR_M", 4.8)
     monkeypatch.setattr(settings, "BUILDABLE_EFFICIENCY_RATIO", 0.79)
@@ -58,10 +58,10 @@ async def test_buildable_request_accepts_camel_case(
         )
 
     monkeypatch.setattr(
-        "app.api.v1.screen.calculate_buildable", _fake_calculate_buildable
+        "backend.app.api.v1.screen.calculate_buildable", _fake_calculate_buildable
     )
 
-    response = await client.post(
+    response = await app_client.post(
         "/api/v1/screen/buildable",
         json={
             "address": "123 Example Ave",

--- a/backend/tests/pwp/test_buildable_rule_precedence.py
+++ b/backend/tests/pwp/test_buildable_rule_precedence.py
@@ -69,9 +69,9 @@ if "structlog" not in sys.modules:  # pragma: no cover - test shim for optional 
     sys.modules.setdefault("structlog.processors", structlog_module.processors)
     sys.modules.setdefault("structlog.stdlib", structlog_module.stdlib)
 
-from app.models.rkp import RefParcel, RefRule, RefZoningLayer
-from app.schemas.buildable import BuildableDefaults
-from app.services.buildable import ResolvedZone, calculate_buildable
+from backend.app.models.rkp import RefParcel, RefRule, RefZoningLayer
+from backend.app.schemas.buildable import BuildableDefaults
+from backend.app.services.buildable import ResolvedZone, calculate_buildable
 
 
 def test_ingested_rule_overrides_seed_defaults(session_factory) -> None:

--- a/backend/tests/test_api/test_costs.py
+++ b/backend/tests/test_api/test_costs.py
@@ -8,12 +8,12 @@ pytest.importorskip("fastapi")
 pytest.importorskip("pydantic")
 pytest.importorskip("sqlalchemy")
 
-from app.models.rkp import RefCostIndex
-from app.utils import metrics
+from backend.app.models.rkp import RefCostIndex
+from backend.app.utils import metrics
 
 
 @pytest.mark.asyncio
-async def test_latest_cost_index(client, session):
+async def test_latest_cost_index(app_client, session):
     """Latest cost index endpoint returns the most recent period."""
 
     session.add_all(
@@ -44,7 +44,7 @@ async def test_latest_cost_index(client, session):
     )
     await session.commit()
 
-    response = await client.get(
+    response = await app_client.get(
         "/api/v1/costs/indices/latest",
         params={"series_name": "concrete", "provider": "official"},
     )
@@ -58,10 +58,10 @@ async def test_latest_cost_index(client, session):
 
 
 @pytest.mark.asyncio
-async def test_latest_cost_index_not_found(client):
+async def test_latest_cost_index_not_found(app_client):
     """A 404 is returned when the series is absent."""
 
-    response = await client.get(
+    response = await app_client.get(
         "/api/v1/costs/indices/latest",
         params={"series_name": "missing"},
     )

--- a/backend/tests/test_api/test_feasibility.py
+++ b/backend/tests/test_api/test_feasibility.py
@@ -21,8 +21,8 @@ SELECTED_RULE_IDS = ["ura-plot-ratio", "bca-site-coverage", "scdf-access"]
 
 
 @pytest.mark.asyncio
-async def test_fetch_feasibility_rules(client: AsyncClient) -> None:
-    response = await client.post("/api/v1/feasibility/rules", json=PROJECT_PAYLOAD)
+async def test_fetch_feasibility_rules(app_client: AsyncClient) -> None:
+    response = await app_client.post("/api/v1/feasibility/rules", json=PROJECT_PAYLOAD)
     assert response.status_code == 200
     payload = response.json()
 
@@ -42,13 +42,13 @@ async def test_fetch_feasibility_rules(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_submit_feasibility_assessment(client: AsyncClient) -> None:
+async def test_submit_feasibility_assessment(app_client: AsyncClient) -> None:
     payload = {
         "project": PROJECT_PAYLOAD,
         "selectedRuleIds": SELECTED_RULE_IDS,
     }
 
-    response = await client.post("/api/v1/feasibility/assessment", json=payload)
+    response = await app_client.post("/api/v1/feasibility/assessment", json=payload)
     assert response.status_code == 200
     assessment = response.json()
 
@@ -77,13 +77,13 @@ async def test_submit_feasibility_assessment(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_submit_assessment_with_unknown_rule(client: AsyncClient) -> None:
+async def test_submit_assessment_with_unknown_rule(app_client: AsyncClient) -> None:
     payload = {
         "project": PROJECT_PAYLOAD,
         "selectedRuleIds": ["unknown-rule"],
     }
 
-    response = await client.post("/api/v1/feasibility/assessment", json=payload)
+    response = await app_client.post("/api/v1/feasibility/assessment", json=payload)
     assert response.status_code == 400
     detail = response.json()["detail"]
     assert "Unknown rule identifiers" in detail

--- a/backend/tests/test_api/test_finance_metrics.py
+++ b/backend/tests/test_api/test_finance_metrics.py
@@ -12,12 +12,12 @@ pytest.importorskip("sqlalchemy")
 
 from httpx import AsyncClient
 
-from app.models.rkp import RefCostIndex
-from app.utils import metrics
+from backend.app.models.rkp import RefCostIndex
+from backend.app.utils import metrics
 
 
 @pytest.mark.asyncio
-async def test_finance_metrics_surface_in_health(client: AsyncClient, session) -> None:
+async def test_finance_metrics_surface_in_health(app_client: AsyncClient, session) -> None:
     session.add_all(
         [
             RefCostIndex(
@@ -68,7 +68,7 @@ async def test_finance_metrics_surface_in_health(client: AsyncClient, session) -
         },
     }
 
-    response = await client.post("/api/v1/finance/feasibility", json=payload)
+    response = await app_client.post("/api/v1/finance/feasibility", json=payload)
     assert response.status_code == 200
     body = response.json()
 
@@ -78,7 +78,7 @@ async def test_finance_metrics_surface_in_health(client: AsyncClient, session) -
 
     scenario_id = body["scenario_id"]
 
-    export_response = await client.get(
+    export_response = await app_client.get(
         "/api/v1/finance/export",
         params={"scenario_id": scenario_id},
     )
@@ -89,7 +89,7 @@ async def test_finance_metrics_surface_in_health(client: AsyncClient, session) -
     metrics_output = metrics.render_latest_metrics().decode()
     assert "finance_export_duration_ms" in metrics_output
 
-    health_response = await client.get("/health/metrics")
+    health_response = await app_client.get("/health/metrics")
     assert health_response.status_code == 200
     metrics_text = health_response.read().decode()
     assert "finance_feasibility_total" in metrics_text

--- a/backend/tests/test_api/test_finance_project_scope.py
+++ b/backend/tests/test_api/test_finance_project_scope.py
@@ -12,12 +12,12 @@ pytest.importorskip("sqlalchemy")
 
 from httpx import AsyncClient
 
-from app.models.finance import FinProject
+from backend.app.models.finance import FinProject
 
 
 @pytest.mark.asyncio
 async def test_finance_feasibility_rejects_foreign_fin_project(
-    client: AsyncClient, async_session_factory
+    app_client: AsyncClient, async_session_factory
 ) -> None:
     async with async_session_factory() as setup_session:
         local_project = FinProject(
@@ -61,7 +61,7 @@ async def test_finance_feasibility_rejects_foreign_fin_project(
         },
     }
 
-    response = await client.post("/api/v1/finance/feasibility", json=payload)
+    response = await app_client.post("/api/v1/finance/feasibility", json=payload)
     assert response.status_code in (403, 404)
 
     async with async_session_factory() as verify_session:

--- a/backend/tests/test_api/test_nonreg_smoke.py
+++ b/backend/tests/test_api/test_nonreg_smoke.py
@@ -15,13 +15,13 @@ pytest.importorskip("fastapi")
 pytest.importorskip("pydantic")
 pytest.importorskip("sqlalchemy")
 
-from scripts import seed_nonreg
-from app.models.rkp import RefProduct
+from backend.scripts import seed_nonreg
+from backend.app.models.rkp import RefProduct
 
 
 @pytest.mark.asyncio
 async def test_nonreg_reference_endpoints_expose_provenance(
-    client, async_session_factory
+    app_client, async_session_factory
 ) -> None:
     """Endpoints should return seeded data with provenance metadata."""
 
@@ -41,13 +41,13 @@ async def test_nonreg_reference_endpoints_expose_provenance(
         )
         await session.commit()
 
-    ergonomics_response = await client.get("/api/v1/ergonomics")
+    ergonomics_response = await app_client.get("/api/v1/ergonomics")
     assert ergonomics_response.status_code == 200
     ergonomics_payload = ergonomics_response.json()
     assert len(ergonomics_payload) >= 1
     assert any(entry.get("source") for entry in ergonomics_payload)
 
-    products_response = await client.get("/api/v1/products", params={"category": "bathroom"})
+    products_response = await app_client.get("/api/v1/products", params={"category": "bathroom"})
     assert products_response.status_code == 200
     products_payload = products_response.json()
     assert len(products_payload) == 1
@@ -55,13 +55,13 @@ async def test_nonreg_reference_endpoints_expose_provenance(
     assert product["vendor"] == "Acme Fixtures"
     assert product["specifications"].get("provenance") == {"catalog": "2024"}
 
-    standards_response = await client.get("/api/v1/standards")
+    standards_response = await app_client.get("/api/v1/standards")
     assert standards_response.status_code == 200
     standards_payload = standards_response.json()
     assert len(standards_payload) >= 1
     assert any(entry.get("provenance") for entry in standards_payload)
 
-    cost_response = await client.get(
+    cost_response = await app_client.get(
         "/api/v1/costs/indices/latest",
         params={"series_name": "construction_all_in", "provider": "Public"},
     )

--- a/backend/tests/test_api/test_openapi_generation.py
+++ b/backend/tests/test_api/test_openapi_generation.py
@@ -10,9 +10,9 @@ pytest.importorskip("sqlalchemy")
 
 from fastapi.testclient import TestClient
 
-from app.api.v1 import TAGS_METADATA  # noqa: E402  (import after dependency checks)
-from app.core.config import settings  # noqa: E402
-from app.main import app  # noqa: E402
+from backend.app.api.v1 import TAGS_METADATA  # noqa: E402  (import after dependency checks)
+from backend.app.core.config import settings  # noqa: E402
+from backend.app.main import app  # noqa: E402
 
 
 def test_openapi_includes_expected_paths() -> None:

--- a/backend/tests/test_api/test_standards.py
+++ b/backend/tests/test_api/test_standards.py
@@ -8,12 +8,12 @@ pytest.importorskip("fastapi")
 pytest.importorskip("pydantic")
 pytest.importorskip("sqlalchemy")
 
-from app.models.rkp import RefMaterialStandard
-from app.utils import metrics
+from backend.app.models.rkp import RefMaterialStandard
+from backend.app.utils import metrics
 
 
 @pytest.mark.asyncio
-async def test_standards_lookup(client, session):
+async def test_standards_lookup(app_client, session):
     """The standards lookup endpoint returns matching results."""
 
     record = RefMaterialStandard(
@@ -28,7 +28,7 @@ async def test_standards_lookup(client, session):
     session.add(record)
     await session.commit()
 
-    response = await client.get("/api/v1/standards", params={"standard_code": "SS EN 206"})
+    response = await app_client.get("/api/v1/standards", params={"standard_code": "SS EN 206"})
     assert response.status_code == 200
     payload = response.json()
     assert len(payload) == 1

--- a/backend/tests/test_core/test_geometry.py
+++ b/backend/tests/test_core/test_geometry.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import pytest
 
-from app.core.geometry import GeometrySerializer, GraphBuilder
-from app.core.models.geometry import Fixture, GeometryGraph, Relationship, Space
-from app.core.overlay import merge_graphs
+from backend.app.core.geometry import GeometrySerializer, GraphBuilder
+from backend.app.core.models.geometry import Fixture, GeometryGraph, Relationship, Space
+from backend.app.core.overlay import merge_graphs
 
 
 @pytest.fixture

--- a/backend/tests/test_core/test_rules_engine.py
+++ b/backend/tests/test_core/test_rules_engine.py
@@ -1,7 +1,7 @@
 import pytest
 
-from app.core.models.geometry import Door, GeometryGraph, Level, Space
-from app.core.rules.engine import RulesEngine
+from backend.app.core.models.geometry import Door, GeometryGraph, Level, Space
+from backend.app.core.rules.engine import RulesEngine
 
 
 RULE_PACK = {

--- a/backend/tests/test_exporters/test_roundtrip.py
+++ b/backend/tests/test_exporters/test_roundtrip.py
@@ -1,8 +1,8 @@
 import pytest
 
-from app.core.export import ExportFormat, ExportOptions, LayerMapping, LocalExportStorage, generate_project_export
-from app.core.models.geometry import CanonicalGeometry, GeometryNode
-from app.models.overlay import OverlaySourceGeometry, OverlaySuggestion
+from backend.app.core.export import ExportFormat, ExportOptions, LayerMapping, LocalExportStorage, generate_project_export
+from backend.app.core.models.geometry import CanonicalGeometry, GeometryNode
+from backend.app.models.overlay import OverlaySourceGeometry, OverlaySuggestion
 
 
 async def _seed_project(async_session_factory, project_id: int = 1) -> int:

--- a/backend/tests/test_flows/test_ergonomics_flow.py
+++ b/backend/tests/test_flows/test_ergonomics_flow.py
@@ -6,7 +6,7 @@ pytest.importorskip("sqlalchemy")
 
 from sqlalchemy import select
 
-from app.models.rkp import RefErgonomics
+from backend.app.models.rkp import RefErgonomics
 from flows.ergonomics import DEFAULT_ERGONOMICS_METRICS, fetch_seeded_metrics, seed_ergonomics_metrics
 
 

--- a/backend/tests/test_flows/test_ingestion_flow.py
+++ b/backend/tests/test_flows/test_ingestion_flow.py
@@ -8,9 +8,9 @@ pytest.importorskip("sqlalchemy")
 
 from sqlalchemy import select
 
-from app.flows.ingestion import material_standard_ingestion_flow
-from app.models.rkp import RefAlert, RefMaterialStandard
-from app.utils import metrics
+from backend.app.flows.ingestion import material_standard_ingestion_flow
+from backend.app.models.rkp import RefAlert, RefMaterialStandard
+from backend.app.utils import metrics
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_flows/test_normalize_rules_flow.py
+++ b/backend/tests/test_flows/test_normalize_rules_flow.py
@@ -8,7 +8,7 @@ pytest.importorskip("sqlalchemy")
 
 from sqlalchemy import select
 
-from app.models.rkp import RefClause, RefDocument, RefRule, RefSource
+from backend.app.models.rkp import RefClause, RefDocument, RefRule, RefSource
 from flows.normalize_rules import normalize_reference_rules
 
 

--- a/backend/tests/test_flows/test_parse_segment_flow.py
+++ b/backend/tests/test_flows/test_parse_segment_flow.py
@@ -10,8 +10,8 @@ pytest.importorskip("sqlalchemy")
 
 from sqlalchemy import select
 
-from app.models.rkp import RefClause, RefDocument, RefSource
-from app.services.reference_storage import ReferenceStorage
+from backend.app.models.rkp import RefClause, RefDocument, RefSource
+from backend.app.services.reference_storage import ReferenceStorage
 from flows.parse_segment import parse_reference_documents
 
 

--- a/backend/tests/test_flows/test_products_flow.py
+++ b/backend/tests/test_flows/test_products_flow.py
@@ -6,7 +6,7 @@ pytest.importorskip("sqlalchemy")
 
 from sqlalchemy import select
 
-from app.models.rkp import RefProduct
+from backend.app.models.rkp import RefProduct
 from flows.products import sync_vendor_products
 
 

--- a/backend/tests/test_flows/test_watch_fetch_flow.py
+++ b/backend/tests/test_flows/test_watch_fetch_flow.py
@@ -13,9 +13,9 @@ pytest.importorskip("sqlalchemy")
 
 from sqlalchemy import select
 
-from app.models.rkp import RefDocument, RefSource
-from app.services.reference_sources import FetchedDocument, HTTPResponse, ReferenceSourceFetcher
-from app.services.reference_storage import ReferenceStorage
+from backend.app.models.rkp import RefDocument, RefSource
+from backend.app.services.reference_sources import FetchedDocument, HTTPResponse, ReferenceSourceFetcher
+from backend.app.services.reference_storage import ReferenceStorage
 from flows.watch_fetch import watch_reference_sources
 from scripts.seed_screening import seed_screening_sample_data
 

--- a/backend/tests/test_scripts/test_seed_screening.py
+++ b/backend/tests/test_scripts/test_seed_screening.py
@@ -8,7 +8,7 @@ pytest.importorskip("sqlalchemy")
 
 from sqlalchemy import select
 
-from app.models.rkp import RefSource
+from backend.app.models.rkp import RefSource
 from scripts.seed_screening import SeedSummary, seed_screening_sample_data
 
 

--- a/backend/tests/test_services/test_alerts.py
+++ b/backend/tests/test_services/test_alerts.py
@@ -6,8 +6,8 @@ import pytest
 
 pytest.importorskip("sqlalchemy")
 
-from app.services import alerts, ingestion
-from app.utils import metrics
+from backend.app.services import alerts, ingestion
+from backend.app.utils import metrics
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_services/test_buildable.py
+++ b/backend/tests/test_services/test_buildable.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import pytest
 
-from app.models.rkp import RefRule
-from app.schemas.buildable import BuildableDefaults
-from app.services.buildable import ResolvedZone, calculate_buildable
+from backend.app.models.rkp import RefRule
+from backend.app.schemas.buildable import BuildableDefaults
+from backend.app.services.buildable import ResolvedZone, calculate_buildable
 
 pytest.importorskip("sqlalchemy")
 pytest.importorskip("pytest_asyncio")

--- a/backend/tests/test_services/test_finance_calculator.py
+++ b/backend/tests/test_services/test_finance_calculator.py
@@ -4,8 +4,8 @@ from decimal import Decimal
 
 import pytest
 
-from app.models.rkp import RefCostIndex
-from app.services.finance import calculator
+from backend.app.models.rkp import RefCostIndex
+from backend.app.services.finance import calculator
 
 
 def test_npv_basic_case() -> None:

--- a/backend/tests/test_services/test_normalize.py
+++ b/backend/tests/test_services/test_normalize.py
@@ -6,7 +6,7 @@ import pytest
 
 pytest.importorskip("sqlalchemy")
 
-from app.services.normalize import NormalizedRule, RuleNormalizer
+from backend.app.services.normalize import NormalizedRule, RuleNormalizer
 
 
 def test_rule_normalizer_extracts_parking_and_slope() -> None:

--- a/backend/tests/test_services/test_pwp.py
+++ b/backend/tests/test_services/test_pwp.py
@@ -8,9 +8,9 @@ import pytest
 
 pytest.importorskip("sqlalchemy")
 
-from app.models.rkp import RefCostIndex
-from app.services.pwp import adjust_pro_forma_cost
-from app.utils import metrics
+from backend.app.models.rkp import RefCostIndex
+from backend.app.services.pwp import adjust_pro_forma_cost
+from backend.app.utils import metrics
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_utils/test_logging.py
+++ b/backend/tests/test_utils/test_logging.py
@@ -7,8 +7,8 @@ import logging
 
 import pytest
 
-from app.core.config import settings
-from app.utils.logging import configure_logging, get_logger, log_event
+from backend.app.core.config import settings
+from backend.app.utils.logging import configure_logging, get_logger, log_event
 
 
 def test_log_event_emits_json_with_timestamp(caplog: pytest.LogCaptureFixture) -> None:

--- a/backend/tests/test_utils/test_validators.py
+++ b/backend/tests/test_utils/test_validators.py
@@ -8,7 +8,7 @@ BACKEND_ROOT = str(Path(__file__).resolve().parents[2])
 if BACKEND_ROOT not in sys.path:
     sys.path.append(BACKEND_ROOT)
 
-from app.utils.validators import validate_singapore_address
+from backend.app.utils.validators import validate_singapore_address
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_workflows/test_aec_pipeline.py
+++ b/backend/tests/test_workflows/test_aec_pipeline.py
@@ -15,21 +15,21 @@ pytest.importorskip('sqlalchemy')
 
 from sqlalchemy import select
 
-from app.api.v1.imports import _build_parse_summary
-from app.core.geometry.builder import GraphBuilder
-from app.core.metrics.roi import compute_project_roi
-from app.core.models.geometry import CanonicalGeometry, GeometryNode
-from app.core.export import (
+from backend.app.api.v1.imports import _build_parse_summary
+from backend.app.core.geometry.builder import GraphBuilder
+from backend.app.core.metrics.roi import compute_project_roi
+from backend.app.core.models.geometry import CanonicalGeometry, GeometryNode
+from backend.app.core.export import (
     ExportFormat,
     ExportOptions,
     LayerMapping,
     LocalExportStorage,
     generate_project_export,
 )
-from app.models.audit import AuditLog
-from app.models.imports import ImportRecord
-from app.models.overlay import OverlaySourceGeometry, OverlaySuggestion
-from app.models.rkp import RefRule, RefZoningLayer
+from backend.app.models.audit import AuditLog
+from backend.app.models.imports import ImportRecord
+from backend.app.models.overlay import OverlaySourceGeometry, OverlaySuggestion
+from backend.app.models.rkp import RefRule, RefZoningLayer
 from jobs.overlay_run import run_overlay_for_project
 
 SAMPLE_PATH = Path(__file__).resolve().parents[1] / "samples" / "sample_floorplan.json"

--- a/tests/buildable/test_postgis_parity.py
+++ b/tests/buildable/test_postgis_parity.py
@@ -7,10 +7,10 @@ pytest.importorskip("pytest_asyncio")
 
 from sqlalchemy import select
 
-from app.core.config import settings
-from app.models.rkp import RefParcel
-from app.schemas.buildable import BuildableDefaults
-from app.services.buildable import (
+from backend.app.core.config import settings
+from backend.app.models.rkp import RefParcel
+from backend.app.schemas.buildable import BuildableDefaults
+from backend.app.services.buildable import (
     ResolvedZone,
     calculate_buildable,
     load_layers_for_zone,

--- a/tests/entitlements/test_api.py
+++ b/tests/entitlements/test_api.py
@@ -10,7 +10,7 @@ pytest.importorskip("sqlalchemy")
 
 from httpx import AsyncClient
 
-from app.utils import metrics
+from backend.app.utils import metrics
 from backend.scripts.seed_entitlements_sg import seed_entitlements
 
 

--- a/tests/entitlements/test_rbac.py
+++ b/tests/entitlements/test_rbac.py
@@ -10,8 +10,8 @@ pytest.importorskip("sqlalchemy")
 
 from httpx import AsyncClient
 
-from app.services.entitlements import EntitlementsService
-from app.utils import metrics
+from backend.app.services.entitlements import EntitlementsService
+from backend.app.utils import metrics
 from backend.scripts.seed_entitlements_sg import seed_entitlements
 
 

--- a/tests/finance/test_api_integration.py
+++ b/tests/finance/test_api_integration.py
@@ -24,9 +24,9 @@ if _PYDANTIC_MAJOR < 2:
 
 from httpx import AsyncClient
 
-from app.models.rkp import RefCostIndex
-from app.services.finance import calculator
-from app.schemas.finance import DscrInputs
+from backend.app.models.rkp import RefCostIndex
+from backend.app.services.finance import calculator
+from backend.app.schemas.finance import DscrInputs
 from backend.scripts.seed_finance_demo import seed_finance_demo
 
 

--- a/tests/finance/test_calculator_unit.py
+++ b/tests/finance/test_calculator_unit.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 
 import pytest
 
-from app.services.finance import calculator
+from backend.app.services.finance import calculator
 
 
 def test_npv_handles_negative_cashflow_months() -> None:

--- a/tests/finance/test_finance_smoke.py
+++ b/tests/finance/test_finance_smoke.py
@@ -13,10 +13,10 @@ pytest.importorskip("sqlalchemy")
 
 from httpx import AsyncClient
 
-from app.models.rkp import RefCostIndex
-from app.schemas.finance import DscrInputs
-from app.services.finance import calculator
-from app.utils import metrics
+from backend.app.models.rkp import RefCostIndex
+from backend.app.schemas.finance import DscrInputs
+from backend.app.services.finance import calculator
+from backend.app.utils import metrics
 from backend.scripts.seed_finance_demo import seed_finance_demo
 
 

--- a/tests/reference/test_reference_rbac.py
+++ b/tests/reference/test_reference_rbac.py
@@ -16,7 +16,9 @@ VIEWER_HEADERS = {"X-Role": "viewer"}
 
 
 @pytest.mark.asyncio
-async def test_ergonomics_requires_valid_role(app_client: AsyncClient) -> None:
+async def test_ergonomics_requires_valid_role(
+    app_client: AsyncClient, reference_data
+) -> None:
     ok_response = await app_client.get(
         "/api/v1/ergonomics/",
         headers=VIEWER_HEADERS,
@@ -31,7 +33,9 @@ async def test_ergonomics_requires_valid_role(app_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_cost_indices_require_valid_role(app_client: AsyncClient) -> None:
+async def test_cost_indices_require_valid_role(
+    app_client: AsyncClient, reference_data
+) -> None:
     params = {"series_name": "construction_all_in", "jurisdiction": "SG"}
 
     ok_response = await app_client.get(

--- a/tests/reference/test_seed_nonreg_cli.py
+++ b/tests/reference/test_seed_nonreg_cli.py
@@ -9,7 +9,7 @@ from typing import Dict
 
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from app.models.base import BaseModel
+from backend.app.models.base import BaseModel
 from backend.scripts import seed_nonreg
 
 


### PR DESCRIPTION
## Summary
- replace backend test fixtures with a single async SQLite session factory and shared FastAPI client
- update backend and top-level tests to import from backend.app and rely on the shared fixtures
- extend reference test setup to patch flow session factories and seed non-regulated data on demand
- expose the bundled SQLAlchemy implementation under the canonical module name so offline test runs import cleanly

## Testing
- python -m pyflakes backend/tests tests *(fails: pyflakes unavailable in offline environment)*
- python -m compileall -q backend/tests
- pytest tests/finance/test_calculator_unit.py::test_npv_handles_negative_cashflow_months -q
- pytest tests/flows/test_reference_flows_cli.py::test_prefect_shim_flow_decorator_preserves_callable -q

------
https://chatgpt.com/codex/tasks/task_e_68d32a9260188320994c20ce450a72a7