### PR TITLE
Update backend tests to use app namespace imports

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -33,7 +33,11 @@ def _ensure_sqlalchemy() -> None:
             "types",
             "pool",
         ):
-            sys.modules.setdefault(f"sqlalchemy.{name}", import_module(f"sqlalchemy_pkg_backup.{name}"))
+            try:
+                module = import_module(f"sqlalchemy_pkg_backup.{name}")
+            except ModuleNotFoundError:
+                continue
+            sys.modules.setdefault(f"sqlalchemy.{name}", module)
 
 
 _ensure_sqlalchemy()
@@ -49,13 +53,13 @@ except (ImportError, AttributeError):  # pragma: no cover - fallback for stub im
         pass
 
 
-from backend.app import models as app_models
-from backend.app.core.database import get_session
-from backend.app.main import app
-from backend.app.models.base import BaseModel
-from backend.app.utils import metrics
+from app import models as app_models
+from app.core.database import get_session
+from app.main import app
+from app.models.base import BaseModel
+from app.utils import metrics
 
-# Importing ``backend.app.models`` ensures all model metadata is registered.
+# Importing ``app.models`` ensures all model metadata is registered.
 _ = app_models
 
 _SORTED_TABLES = tuple(BaseModel.metadata.sorted_tables)

--- a/backend/tests/pwp/test_buildable_golden.py
+++ b/backend/tests/pwp/test_buildable_golden.py
@@ -13,8 +13,8 @@ import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy import select
 
-from backend.app.core.config import settings
-from backend.app.models.rkp import RefClause, RefDocument, RefRule, RefSource
+from app.core.config import settings
+from app.models.rkp import RefClause, RefDocument, RefRule, RefSource
 from scripts.seed_screening import seed_screening_sample_data
 
 

--- a/backend/tests/pwp/test_buildable_latency.py
+++ b/backend/tests/pwp/test_buildable_latency.py
@@ -12,8 +12,8 @@ pytest.importorskip("pytest_asyncio")
 import pytest_asyncio
 from httpx import AsyncClient
 
-from backend.app.core.config import settings
-from backend.app.utils import metrics
+from app.core.config import settings
+from app.utils import metrics
 from scripts.seed_screening import seed_screening_sample_data
 
 

--- a/backend/tests/pwp/test_buildable_metrics.py
+++ b/backend/tests/pwp/test_buildable_metrics.py
@@ -62,7 +62,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback stub for offline test
     sys.modules.setdefault("structlog.processors", processors_module)
     sys.modules.setdefault("structlog.stdlib", stdlib_module)
 
-from backend.app.utils import metrics
+from app.utils import metrics
 
 from backend.tests.pwp.test_buildable_golden import (
     DEFAULT_REQUEST_DEFAULTS,

--- a/backend/tests/pwp/test_buildable_postgis_flag.py
+++ b/backend/tests/pwp/test_buildable_postgis_flag.py
@@ -7,10 +7,10 @@ pytest.importorskip("pytest_asyncio")
 
 from sqlalchemy import select
 
-from backend.app.core.config import settings
-from backend.app.models.rkp import RefParcel
-from backend.app.schemas.buildable import BuildableDefaults
-from backend.app.services.buildable import ResolvedZone, calculate_buildable, load_layers_for_zone
+from app.core.config import settings
+from app.models.rkp import RefParcel
+from app.schemas.buildable import BuildableDefaults
+from app.services.buildable import ResolvedZone, calculate_buildable, load_layers_for_zone
 from scripts.seed_screening import seed_screening_sample_data
 
 

--- a/backend/tests/pwp/test_buildable_request_aliases.py
+++ b/backend/tests/pwp/test_buildable_request_aliases.py
@@ -13,8 +13,8 @@ import pytest_asyncio  # noqa: F401
 
 from httpx import AsyncClient
 
-from backend.app.core.config import settings
-from backend.app.schemas.buildable import (
+from app.core.config import settings
+from app.schemas.buildable import (
     BuildableCalculation,
     BuildableDefaults,
     BuildableMetrics,
@@ -58,7 +58,7 @@ async def test_buildable_request_accepts_camel_case(
         )
 
     monkeypatch.setattr(
-        "backend.app.api.v1.screen.calculate_buildable", _fake_calculate_buildable
+        "app.api.v1.screen.calculate_buildable", _fake_calculate_buildable
     )
 
     response = await app_client.post(

--- a/backend/tests/pwp/test_buildable_rule_precedence.py
+++ b/backend/tests/pwp/test_buildable_rule_precedence.py
@@ -69,9 +69,9 @@ if "structlog" not in sys.modules:  # pragma: no cover - test shim for optional 
     sys.modules.setdefault("structlog.processors", structlog_module.processors)
     sys.modules.setdefault("structlog.stdlib", structlog_module.stdlib)
 
-from backend.app.models.rkp import RefParcel, RefRule, RefZoningLayer
-from backend.app.schemas.buildable import BuildableDefaults
-from backend.app.services.buildable import ResolvedZone, calculate_buildable
+from app.models.rkp import RefParcel, RefRule, RefZoningLayer
+from app.schemas.buildable import BuildableDefaults
+from app.services.buildable import ResolvedZone, calculate_buildable
 
 
 def test_ingested_rule_overrides_seed_defaults(session_factory) -> None:

--- a/backend/tests/test_api/test_audit.py
+++ b/backend/tests/test_api/test_audit.py
@@ -12,9 +12,9 @@ pytest.importorskip("pytest_asyncio")
 import pytest_asyncio
 from httpx import AsyncClient
 
-from backend.app.core.geometry import GeometrySerializer
-from backend.app.core.models.geometry import GeometryGraph, Level, Relationship, Space
-from backend.app.models.overlay import OverlaySourceGeometry
+from app.core.geometry import GeometrySerializer
+from app.core.models.geometry import GeometryGraph, Level, Relationship, Space
+from app.models.overlay import OverlaySourceGeometry
 
 PROJECT_ID = 5812
 

--- a/backend/tests/test_api/test_costs.py
+++ b/backend/tests/test_api/test_costs.py
@@ -8,8 +8,8 @@ pytest.importorskip("fastapi")
 pytest.importorskip("pydantic")
 pytest.importorskip("sqlalchemy")
 
-from backend.app.models.rkp import RefCostIndex
-from backend.app.utils import metrics
+from app.models.rkp import RefCostIndex
+from app.utils import metrics
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_api/test_finance_metrics.py
+++ b/backend/tests/test_api/test_finance_metrics.py
@@ -12,8 +12,8 @@ pytest.importorskip("sqlalchemy")
 
 from httpx import AsyncClient
 
-from backend.app.models.rkp import RefCostIndex
-from backend.app.utils import metrics
+from app.models.rkp import RefCostIndex
+from app.utils import metrics
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_api/test_finance_project_scope.py
+++ b/backend/tests/test_api/test_finance_project_scope.py
@@ -12,7 +12,7 @@ pytest.importorskip("sqlalchemy")
 
 from httpx import AsyncClient
 
-from backend.app.models.finance import FinProject
+from app.models.finance import FinProject
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_api/test_imports.py
+++ b/backend/tests/test_api/test_imports.py
@@ -13,8 +13,8 @@ pytest.importorskip("sqlalchemy")
 
 from httpx import AsyncClient
 
-from backend.app.models.imports import ImportRecord
-from backend.app.services.storage import get_storage_service
+from app.models.imports import ImportRecord
+from app.services.storage import get_storage_service
 from backend.jobs import job_queue
 
 SAMPLES_DIR = Path(__file__).resolve().parent.parent / "samples"

--- a/backend/tests/test_api/test_nonreg_smoke.py
+++ b/backend/tests/test_api/test_nonreg_smoke.py
@@ -16,7 +16,7 @@ pytest.importorskip("pydantic")
 pytest.importorskip("sqlalchemy")
 
 from backend.scripts import seed_nonreg
-from backend.app.models.rkp import RefProduct
+from app.models.rkp import RefProduct
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_api/test_openapi_generation.py
+++ b/backend/tests/test_api/test_openapi_generation.py
@@ -10,9 +10,9 @@ pytest.importorskip("sqlalchemy")
 
 from fastapi.testclient import TestClient
 
-from backend.app.api.v1 import TAGS_METADATA  # noqa: E402  (import after dependency checks)
-from backend.app.core.config import settings  # noqa: E402
-from backend.app.main import app  # noqa: E402
+from app.api.v1 import TAGS_METADATA  # noqa: E402  (import after dependency checks)
+from app.core.config import settings  # noqa: E402
+from app.main import app  # noqa: E402
 
 
 def test_openapi_includes_expected_paths() -> None:

--- a/backend/tests/test_api/test_overlay.py
+++ b/backend/tests/test_api/test_overlay.py
@@ -11,8 +11,8 @@ pytest.importorskip("sqlalchemy")
 from httpx import AsyncClient
 from sqlalchemy import select
 
-from backend.app.models.audit import AuditLog
-from backend.app.models.overlay import OverlayRunLock, OverlaySourceGeometry, OverlaySuggestion
+from app.models.audit import AuditLog
+from app.models.overlay import OverlayRunLock, OverlaySourceGeometry, OverlaySuggestion
 from backend.jobs import job_queue
 
 PROJECT_ID = 4120

--- a/backend/tests/test_api/test_roi.py
+++ b/backend/tests/test_api/test_roi.py
@@ -12,9 +12,9 @@ pytest.importorskip("pytest_asyncio")
 import pytest_asyncio
 from httpx import AsyncClient
 
-from backend.app.core.geometry import GeometrySerializer
-from backend.app.core.models.geometry import GeometryGraph, Level, Relationship, Space
-from backend.app.models.overlay import OverlaySourceGeometry
+from app.core.geometry import GeometrySerializer
+from app.core.models.geometry import GeometryGraph, Level, Relationship, Space
+from app.models.overlay import OverlaySourceGeometry
 
 PROJECT_ID = 5821
 

--- a/backend/tests/test_api/test_rules.py
+++ b/backend/tests/test_api/test_rules.py
@@ -13,10 +13,10 @@ import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy import select
 
-from backend.app.core.database import get_session
-from backend.app.main import app
-from backend.app.models.rkp import RefClause, RefDocument, RefRule, RefSource
-from backend.app.utils import metrics
+from app.core.database import get_session
+from app.main import app
+from app.models.rkp import RefClause, RefDocument, RefRule, RefSource
+from app.utils import metrics
 from scripts.seed_screening import seed_screening_sample_data
 
 

--- a/backend/tests/test_api/test_rulesets.py
+++ b/backend/tests/test_api/test_rulesets.py
@@ -8,8 +8,8 @@ pytest.importorskip("pytest_asyncio")
 import pytest_asyncio
 from httpx import AsyncClient
 
-from backend.app.core.models.geometry import Door, GeometryGraph, Level, Space
-from backend.app.models.rulesets import RulePack
+from app.core.models.geometry import Door, GeometryGraph, Level, Space
+from app.models.rulesets import RulePack
 
 
 PACK_DEFINITION = {

--- a/backend/tests/test_api/test_standards.py
+++ b/backend/tests/test_api/test_standards.py
@@ -8,8 +8,8 @@ pytest.importorskip("fastapi")
 pytest.importorskip("pydantic")
 pytest.importorskip("sqlalchemy")
 
-from backend.app.models.rkp import RefMaterialStandard
-from backend.app.utils import metrics
+from app.models.rkp import RefMaterialStandard
+from app.utils import metrics
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_core/test_geometry.py
+++ b/backend/tests/test_core/test_geometry.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import pytest
 
-from backend.app.core.geometry import GeometrySerializer, GraphBuilder
-from backend.app.core.models.geometry import Fixture, GeometryGraph, Relationship, Space
-from backend.app.core.overlay import merge_graphs
+from app.core.geometry import GeometrySerializer, GraphBuilder
+from app.core.models.geometry import Fixture, GeometryGraph, Relationship, Space
+from app.core.overlay import merge_graphs
 
 
 @pytest.fixture

--- a/backend/tests/test_core/test_rules_engine.py
+++ b/backend/tests/test_core/test_rules_engine.py
@@ -1,7 +1,7 @@
 import pytest
 
-from backend.app.core.models.geometry import Door, GeometryGraph, Level, Space
-from backend.app.core.rules.engine import RulesEngine
+from app.core.models.geometry import Door, GeometryGraph, Level, Space
+from app.core.rules.engine import RulesEngine
 
 
 RULE_PACK = {

--- a/backend/tests/test_exporters/test_roundtrip.py
+++ b/backend/tests/test_exporters/test_roundtrip.py
@@ -1,8 +1,8 @@
 import pytest
 
-from backend.app.core.export import ExportFormat, ExportOptions, LayerMapping, LocalExportStorage, generate_project_export
-from backend.app.core.models.geometry import CanonicalGeometry, GeometryNode
-from backend.app.models.overlay import OverlaySourceGeometry, OverlaySuggestion
+from app.core.export import ExportFormat, ExportOptions, LayerMapping, LocalExportStorage, generate_project_export
+from app.core.models.geometry import CanonicalGeometry, GeometryNode
+from app.models.overlay import OverlaySourceGeometry, OverlaySuggestion
 
 
 async def _seed_project(async_session_factory, project_id: int = 1) -> int:

--- a/backend/tests/test_flows/test_ergonomics_flow.py
+++ b/backend/tests/test_flows/test_ergonomics_flow.py
@@ -6,7 +6,7 @@ pytest.importorskip("sqlalchemy")
 
 from sqlalchemy import select
 
-from backend.app.models.rkp import RefErgonomics
+from app.models.rkp import RefErgonomics
 from flows.ergonomics import DEFAULT_ERGONOMICS_METRICS, fetch_seeded_metrics, seed_ergonomics_metrics
 
 

--- a/backend/tests/test_flows/test_ingestion_flow.py
+++ b/backend/tests/test_flows/test_ingestion_flow.py
@@ -8,9 +8,9 @@ pytest.importorskip("sqlalchemy")
 
 from sqlalchemy import select
 
-from backend.app.flows.ingestion import material_standard_ingestion_flow
-from backend.app.models.rkp import RefAlert, RefMaterialStandard
-from backend.app.utils import metrics
+from app.flows.ingestion import material_standard_ingestion_flow
+from app.models.rkp import RefAlert, RefMaterialStandard
+from app.utils import metrics
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_flows/test_normalize_rules_flow.py
+++ b/backend/tests/test_flows/test_normalize_rules_flow.py
@@ -8,7 +8,7 @@ pytest.importorskip("sqlalchemy")
 
 from sqlalchemy import select
 
-from backend.app.models.rkp import RefClause, RefDocument, RefRule, RefSource
+from app.models.rkp import RefClause, RefDocument, RefRule, RefSource
 from flows.normalize_rules import normalize_reference_rules
 
 

--- a/backend/tests/test_flows/test_parse_segment_flow.py
+++ b/backend/tests/test_flows/test_parse_segment_flow.py
@@ -10,8 +10,8 @@ pytest.importorskip("sqlalchemy")
 
 from sqlalchemy import select
 
-from backend.app.models.rkp import RefClause, RefDocument, RefSource
-from backend.app.services.reference_storage import ReferenceStorage
+from app.models.rkp import RefClause, RefDocument, RefSource
+from app.services.reference_storage import ReferenceStorage
 from flows.parse_segment import parse_reference_documents
 
 

--- a/backend/tests/test_flows/test_products_flow.py
+++ b/backend/tests/test_flows/test_products_flow.py
@@ -6,7 +6,7 @@ pytest.importorskip("sqlalchemy")
 
 from sqlalchemy import select
 
-from backend.app.models.rkp import RefProduct
+from app.models.rkp import RefProduct
 from flows.products import sync_vendor_products
 
 

--- a/backend/tests/test_flows/test_watch_fetch_flow.py
+++ b/backend/tests/test_flows/test_watch_fetch_flow.py
@@ -13,9 +13,9 @@ pytest.importorskip("sqlalchemy")
 
 from sqlalchemy import select
 
-from backend.app.models.rkp import RefDocument, RefSource
-from backend.app.services.reference_sources import FetchedDocument, HTTPResponse, ReferenceSourceFetcher
-from backend.app.services.reference_storage import ReferenceStorage
+from app.models.rkp import RefDocument, RefSource
+from app.services.reference_sources import FetchedDocument, HTTPResponse, ReferenceSourceFetcher
+from app.services.reference_storage import ReferenceStorage
 from flows.watch_fetch import watch_reference_sources
 from scripts.seed_screening import seed_screening_sample_data
 

--- a/backend/tests/test_scripts/test_seed_screening.py
+++ b/backend/tests/test_scripts/test_seed_screening.py
@@ -8,7 +8,7 @@ pytest.importorskip("sqlalchemy")
 
 from sqlalchemy import select
 
-from backend.app.models.rkp import RefSource
+from app.models.rkp import RefSource
 from scripts.seed_screening import SeedSummary, seed_screening_sample_data
 
 

--- a/backend/tests/test_services/test_alerts.py
+++ b/backend/tests/test_services/test_alerts.py
@@ -6,8 +6,8 @@ import pytest
 
 pytest.importorskip("sqlalchemy")
 
-from backend.app.services import alerts, ingestion
-from backend.app.utils import metrics
+from app.services import alerts, ingestion
+from app.utils import metrics
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_services/test_buildable.py
+++ b/backend/tests/test_services/test_buildable.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import pytest
 
-from backend.app.models.rkp import RefRule
-from backend.app.schemas.buildable import BuildableDefaults
-from backend.app.services.buildable import ResolvedZone, calculate_buildable
+from app.models.rkp import RefRule
+from app.schemas.buildable import BuildableDefaults
+from app.services.buildable import ResolvedZone, calculate_buildable
 
 pytest.importorskip("sqlalchemy")
 pytest.importorskip("pytest_asyncio")

--- a/backend/tests/test_services/test_finance_calculator.py
+++ b/backend/tests/test_services/test_finance_calculator.py
@@ -4,8 +4,8 @@ from decimal import Decimal
 
 import pytest
 
-from backend.app.models.rkp import RefCostIndex
-from backend.app.services.finance import calculator
+from app.models.rkp import RefCostIndex
+from app.services.finance import calculator
 
 
 def test_npv_basic_case() -> None:

--- a/backend/tests/test_services/test_normalize.py
+++ b/backend/tests/test_services/test_normalize.py
@@ -6,7 +6,7 @@ import pytest
 
 pytest.importorskip("sqlalchemy")
 
-from backend.app.services.normalize import NormalizedRule, RuleNormalizer
+from app.services.normalize import NormalizedRule, RuleNormalizer
 
 
 def test_rule_normalizer_extracts_parking_and_slope() -> None:

--- a/backend/tests/test_services/test_pwp.py
+++ b/backend/tests/test_services/test_pwp.py
@@ -8,9 +8,9 @@ import pytest
 
 pytest.importorskip("sqlalchemy")
 
-from backend.app.models.rkp import RefCostIndex
-from backend.app.services.pwp import adjust_pro_forma_cost
-from backend.app.utils import metrics
+from app.models.rkp import RefCostIndex
+from app.services.pwp import adjust_pro_forma_cost
+from app.utils import metrics
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_utils/test_logging.py
+++ b/backend/tests/test_utils/test_logging.py
@@ -7,8 +7,8 @@ import logging
 
 import pytest
 
-from backend.app.core.config import settings
-from backend.app.utils.logging import configure_logging, get_logger, log_event
+from app.core.config import settings
+from app.utils.logging import configure_logging, get_logger, log_event
 
 
 def test_log_event_emits_json_with_timestamp(caplog: pytest.LogCaptureFixture) -> None:

--- a/backend/tests/test_utils/test_validators.py
+++ b/backend/tests/test_utils/test_validators.py
@@ -8,7 +8,7 @@ BACKEND_ROOT = str(Path(__file__).resolve().parents[2])
 if BACKEND_ROOT not in sys.path:
     sys.path.append(BACKEND_ROOT)
 
-from backend.app.utils.validators import validate_singapore_address
+from app.utils.validators import validate_singapore_address
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_workflows/test_aec_pipeline.py
+++ b/backend/tests/test_workflows/test_aec_pipeline.py
@@ -15,21 +15,21 @@ pytest.importorskip('sqlalchemy')
 
 from sqlalchemy import select
 
-from backend.app.api.v1.imports import _build_parse_summary
-from backend.app.core.geometry.builder import GraphBuilder
-from backend.app.core.metrics.roi import compute_project_roi
-from backend.app.core.models.geometry import CanonicalGeometry, GeometryNode
-from backend.app.core.export import (
+from app.api.v1.imports import _build_parse_summary
+from app.core.geometry.builder import GraphBuilder
+from app.core.metrics.roi import compute_project_roi
+from app.core.models.geometry import CanonicalGeometry, GeometryNode
+from app.core.export import (
     ExportFormat,
     ExportOptions,
     LayerMapping,
     LocalExportStorage,
     generate_project_export,
 )
-from backend.app.models.audit import AuditLog
-from backend.app.models.imports import ImportRecord
-from backend.app.models.overlay import OverlaySourceGeometry, OverlaySuggestion
-from backend.app.models.rkp import RefRule, RefZoningLayer
+from app.models.audit import AuditLog
+from app.models.imports import ImportRecord
+from app.models.overlay import OverlaySourceGeometry, OverlaySuggestion
+from app.models.rkp import RefRule, RefZoningLayer
 from jobs.overlay_run import run_overlay_for_project
 
 SAMPLE_PATH = Path(__file__).resolve().parents[1] / "samples" / "sample_floorplan.json"


### PR DESCRIPTION
## Summary
- update backend test modules to import models, services, and utilities via the `app` namespace so they share the same module cache as the application

## Testing
- PYTHONPATH=. pytest backend/tests/test_flows/test_watch_fetch_flow.py -q
- PYTHONPATH=. pytest backend/tests/test_api/test_openapi_generation.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d34ab8afb88320b09da3a564ae3590