### PR TITLE
Add stub project table for tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -58,9 +58,21 @@ from app.core.database import get_session
 from app.main import app
 from app.models.base import BaseModel
 from app.utils import metrics
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
 
 # Importing ``app.models`` ensures all model metadata is registered.
 _ = app_models
+
+
+if "projects" not in getattr(BaseModel.metadata, "tables", {}):
+    class _ProjectStub(BaseModel):
+        """Minimal project table used for tests that only require an ID."""
+
+        __tablename__ = "projects"
+
+        id: Mapped[int] = mapped_column(Integer, primary_key=True)
+        name: Mapped[str] = mapped_column(String(120), nullable=False, default="Test Project")
 
 _SORTED_TABLES = tuple(BaseModel.metadata.sorted_tables)
 


### PR DESCRIPTION
## Summary
- register a minimal `projects` table stub in the backend test configuration to satisfy finance model foreign keys during setup
- ensure the stub only applies when the table is otherwise absent

## Testing
- `pytest -q tests/finance/test_calculator_unit.py::test_npv_handles_negative_cashflow_months`
- `pytest -q tests/flows/test_reference_flows_cli.py::test_prefect_shim_flow_decorator_preserves_callable`


------
https://chatgpt.com/codex/tasks/task_e_68d353e015f08320ad44f29790b8f66a