### PR TITLE
Ensure compatibility wrappers expose required modules

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,51 @@
+"""Compatibility wrapper exposing :mod:`backend.app` as :mod:`app`.
+
+This project historically imported modules using the short ``app`` package
+name (for example ``from app.core.config import settings``).  In the current
+repository layout the actual package lives under ``backend.app`` which breaks
+those imports when the backend code is executed without installing the project
+as a package.  Providing this lightweight wrapper keeps the original import
+paths working by aliasing ``app`` to ``backend.app`` at import time.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+import sys
+
+
+def _ensure_sqlalchemy() -> None:
+    """Expose the bundled lightweight SQLAlchemy implementation if needed."""
+
+    try:  # pragma: no cover - exercised implicitly when SQLAlchemy is available
+        import sqlalchemy  # noqa: F401
+    except ModuleNotFoundError:
+        pkg = import_module("sqlalchemy_pkg_backup")
+        sys.modules.setdefault("sqlalchemy", pkg)
+
+        for name in (
+            "ext",
+            "ext.asyncio",
+            "orm",
+            "engine",
+            "sql",
+            "dialects",
+            "dialects.postgresql",
+            "types",
+            "pool",
+        ):
+            try:
+                module = import_module(f"sqlalchemy_pkg_backup.{name}")
+            except ModuleNotFoundError:
+                continue
+            sys.modules.setdefault(f"sqlalchemy.{name}", module)
+
+
+_ensure_sqlalchemy()
+
+_backend_app = import_module("backend.app")
+
+# Expose ``backend.app`` under the historical ``app`` module name.  Using the
+# existing module instance ensures submodules such as ``app.core`` resolve to
+# the backend implementations without duplicating any package contents.
+sys.modules[__name__] = _backend_app

--- a/jobs/__init__.py
+++ b/jobs/__init__.py
@@ -1,0 +1,12 @@
+"""Compatibility wrapper exposing :mod:`backend.jobs` as :mod:`jobs`."""
+
+from __future__ import annotations
+
+from importlib import import_module
+import sys
+
+_backend_jobs = import_module("backend.jobs")
+
+# Reuse the backend implementation so imports like ``from jobs import job``
+# continue to resolve without installing the package.
+sys.modules[__name__] = _backend_jobs


### PR DESCRIPTION
## Summary
- extend the `app` compatibility wrapper to register the bundled SQLAlchemy fallback when the dependency is missing
- add a `jobs` compatibility module so legacy `jobs` imports resolve to `backend.jobs`

## Testing
- python - <<'PY'
import app
import backend.app.main
print('ok')
PY

------
https://chatgpt.com/codex/tasks/task_e_68d3540372448320b9ef8729f35f2fa7