### PR TITLE
Add compat wrappers for relocated finance and flow tests

### DIFF
--- a/backend/tests/finance/test_calculator_unit.py
+++ b/backend/tests/finance/test_calculator_unit.py
@@ -1,0 +1,52 @@
+"""Compat wrapper for relocated finance tests."""
+
+from __future__ import annotations
+
+import sys
+from functools import wraps
+from importlib import util
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable, cast
+
+def _find_repo_root(current: Path) -> Path:
+    for parent in current.parents:
+        if (parent / ".git").exists():
+            return parent
+    return current.parents[-1]
+
+
+def _load_module(name: str, file_path: Path) -> ModuleType:
+    spec = util.spec_from_file_location(name, file_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load {name!r} from {file_path}")
+    module = util.module_from_spec(spec)
+    loader = cast(Any, spec.loader)
+    loader.exec_module(module)
+    sys.modules[name] = module
+    return module
+
+
+ROOT = _find_repo_root(Path(__file__).resolve())
+MODULE_NAME = "tests.finance.test_calculator_unit"
+MODULE_PATH = ROOT / "tests" / "finance" / "test_calculator_unit.py"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+_IMPL = _load_module(MODULE_NAME, MODULE_PATH)
+
+
+def _mirror(func: Callable[..., Any]) -> Callable[..., Any]:
+    @wraps(func)
+    def _wrapper(*args: Any, **kwargs: Any) -> Any:
+        return func(*args, **kwargs)
+
+    return _wrapper
+
+
+for _name in dir(_IMPL):
+    if _name.startswith("test_"):
+        globals()[_name] = _mirror(getattr(_IMPL, _name))
+
+__all__ = [name for name in globals() if name.startswith("test_")]
+

--- a/backend/tests/flows/test_reference_flows_cli.py
+++ b/backend/tests/flows/test_reference_flows_cli.py
@@ -1,0 +1,53 @@
+"""Compat wrapper for relocated flow tests."""
+
+from __future__ import annotations
+
+import sys
+from functools import wraps
+from importlib import util
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable, cast
+
+
+def _find_repo_root(current: Path) -> Path:
+    for parent in current.parents:
+        if (parent / ".git").exists():
+            return parent
+    return current.parents[-1]
+
+
+def _load_module(name: str, file_path: Path) -> ModuleType:
+    spec = util.spec_from_file_location(name, file_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load {name!r} from {file_path}")
+    module = util.module_from_spec(spec)
+    loader = cast(Any, spec.loader)
+    loader.exec_module(module)
+    sys.modules[name] = module
+    return module
+
+
+ROOT = _find_repo_root(Path(__file__).resolve())
+MODULE_NAME = "tests.flows.test_reference_flows_cli"
+MODULE_PATH = ROOT / "tests" / "flows" / "test_reference_flows_cli.py"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+_IMPL = _load_module(MODULE_NAME, MODULE_PATH)
+
+
+def _mirror(func: Callable[..., Any]) -> Callable[..., Any]:
+    @wraps(func)
+    def _wrapper(*args: Any, **kwargs: Any) -> Any:
+        return func(*args, **kwargs)
+
+    return _wrapper
+
+
+for _name in dir(_IMPL):
+    if _name.startswith("test_"):
+        globals()[_name] = _mirror(getattr(_IMPL, _name))
+
+__all__ = [name for name in globals() if name.startswith("test_")]
+


### PR DESCRIPTION
## Summary
- ensure the backend test configuration adds the repository root to `sys.path` before loading optional async fixtures
- provide compatibility shims in `backend/tests` that mirror the relocated finance and flow tests from the top-level `tests` package

## Testing
- pytest -q backend/tests/finance/test_calculator_unit.py::test_npv_handles_negative_cashflow_months
- pytest -q backend/tests/flows/test_reference_flows_cli.py::test_prefect_shim_flow_decorator_preserves_callable

------
https://chatgpt.com/codex/tasks/task_e_68d357a71c548320b911152d5d5b1b52