### PR TITLE
Allow clearing entitlements fields via API updates

### DIFF
--- a/backend/app/api/v1/entitlements.py
+++ b/backend/app/api/v1/entitlements.py
@@ -134,15 +134,7 @@ async def update_roadmap_item(
     item = await service.update_roadmap_item(
         item_id=item_id,
         project_id=project_id,
-        approval_type_id=data.get("approval_type_id"),
-        sequence_order=data.get("sequence_order"),
-        status=data.get("status"),
-        target_submission_date=data.get("target_submission_date"),
-        target_decision_date=data.get("target_decision_date"),
-        actual_submission_date=data.get("actual_submission_date"),
-        actual_decision_date=data.get("actual_decision_date"),
-        notes=data.get("notes"),
-        metadata=data.get("metadata"),
+        **data,
     )
     await session.commit()
     await session.refresh(item)

--- a/tests/entitlements/test_rbac.py
+++ b/tests/entitlements/test_rbac.py
@@ -11,7 +11,7 @@ pytest.importorskip("sqlalchemy")
 from httpx import AsyncClient
 
 from backend.app.services.entitlements import EntitlementsService
-from backend.app.utils import metrics
+from app.utils import metrics
 from backend.scripts.seed_entitlements_sg import seed_entitlements
 
 


### PR DESCRIPTION
## Summary
- allow the entitlements service update helpers to honour explicitly provided null values while keeping status guardrails
- adjust the roadmap API to forward update payloads directly and align test imports with the runtime metrics module
- expand the entitlements API workflow test to cover clearing nullable date and string fields

## Testing
- pytest tests/entitlements

------
https://chatgpt.com/codex/tasks/task_e_68d35c06d7788320a173d8eaa92b980f