### PR TITLE
Fix importlib util usage in compat test wrappers

### DIFF
--- a/backend/tests/finance/test_calculator_unit.py
+++ b/backend/tests/finance/test_calculator_unit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from functools import wraps
-from importlib import util
+import importlib.util
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Callable, cast
@@ -17,10 +17,10 @@ def _find_repo_root(current: Path) -> Path:
 
 
 def _load_module(name: str, file_path: Path) -> ModuleType:
-    spec = util.spec_from_file_location(name, file_path)
+    spec = importlib.util.spec_from_file_location(name, file_path)
     if spec is None or spec.loader is None:
         raise ImportError(f"Cannot load {name!r} from {file_path}")
-    module = util.module_from_spec(spec)
+    module = importlib.util.module_from_spec(spec)
     loader = cast(Any, spec.loader)
     loader.exec_module(module)
     sys.modules[name] = module

--- a/backend/tests/flows/test_reference_flows_cli.py
+++ b/backend/tests/flows/test_reference_flows_cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from functools import wraps
-from importlib import util
+import importlib.util
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Callable, cast
@@ -18,10 +18,10 @@ def _find_repo_root(current: Path) -> Path:
 
 
 def _load_module(name: str, file_path: Path) -> ModuleType:
-    spec = util.spec_from_file_location(name, file_path)
+    spec = importlib.util.spec_from_file_location(name, file_path)
     if spec is None or spec.loader is None:
         raise ImportError(f"Cannot load {name!r} from {file_path}")
-    module = util.module_from_spec(spec)
+    module = importlib.util.module_from_spec(spec)
     loader = cast(Any, spec.loader)
     loader.exec_module(module)
     sys.modules[name] = module


### PR DESCRIPTION
## Summary
- switch the compat test shims to import `importlib.util` explicitly so Python 3.12 exposes `importlib.util`
- update module loading helpers to use the fully qualified `importlib.util` helpers

## Testing
- `pytest backend/tests/finance/test_calculator_unit.py -q`
- `pytest backend/tests/flows/test_reference_flows_cli.py::test_watch_fetch_cli_invocation_via_python_m -q` *(fails: `ModuleNotFoundError: No module named 'sqlalchemy'` when the CLI runs under python -m)*

------
https://chatgpt.com/codex/tasks/task_e_68d35792b0b0832081aeee83221ad3dd