### PR TITLE
Fix module aliasing and watch fetch flow

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -44,6 +44,9 @@ def _ensure_sqlalchemy() -> None:
 _ensure_sqlalchemy()
 
 _backend_app = import_module("backend.app")
+_backend_pkg = sys.modules.get("backend")
+if _backend_pkg is not None:
+    setattr(_backend_pkg, "app", _backend_app)
 
 # Expose ``backend.app`` under the historical ``app`` module name.  Using the
 # existing module instance ensures submodules such as ``app.core`` resolve to

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,13 @@
+"""Backend application package exposing compatibility aliases."""
+
+from __future__ import annotations
+
+import sys
+
+_parent = sys.modules.get("backend")
+if _parent is not None:
+    setattr(_parent, "app", sys.modules[__name__])
+
+_utils = sys.modules.get("backend.app.utils")
+if _utils is not None:
+    setattr(sys.modules[__name__], "utils", _utils)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,7 +2,14 @@
 
 from .base import Base  # noqa: F401
 
+import sys
+
 # Import model modules so their metadata is registered with SQLAlchemy.
 from . import audit, entitlements, finance, imports, overlay, rkp, rulesets  # noqa: F401  pylint: disable=unused-import
+
+if __name__.startswith("backend.app"):
+    sys.modules["app.models"] = sys.modules[__name__]
+else:  # pragma: no cover
+    sys.modules["backend.app.models"] = sys.modules[__name__]
 
 __all__ = ["Base"]

--- a/backend/app/models/rkp.py
+++ b/backend/app/models/rkp.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime
+import sys
 from typing import Any, Dict, Iterable, Optional
 
 from sqlalchemy import (
@@ -434,3 +435,7 @@ class RefAlert(BaseModel):
     __table_args__ = (
         Index("idx_alerts_type_level", "alert_type", "level"),
     )
+if __name__.startswith("backend.app"):
+    sys.modules["app.models.rkp"] = sys.modules[__name__]
+else:  # pragma: no cover - executed when imported via the compatibility alias
+    sys.modules["backend.app.models.rkp"] = sys.modules[__name__]

--- a/backend/app/schemas/finance.py
+++ b/backend/app/schemas/finance.py
@@ -64,13 +64,13 @@ class DscrInputs(BaseModel):
     period_labels: Optional[List[str]] = None
 
     @model_validator(mode="after")
-    def _validate_lengths(self) -> "DscrInputs":
-        incomes_len = len(self.net_operating_incomes)
-        if len(self.debt_services) != incomes_len:
+    def _validate_lengths(cls, values: "DscrInputs") -> "DscrInputs":
+        incomes_len = len(values.net_operating_incomes)
+        if len(values.debt_services) != incomes_len:
             raise ValueError("net_operating_incomes and debt_services must be the same length")
-        if self.period_labels is not None and len(self.period_labels) != incomes_len:
+        if values.period_labels is not None and len(values.period_labels) != incomes_len:
             raise ValueError("period_labels must be the same length as net_operating_incomes")
-        return self
+        return values
 
 
 class FinanceScenarioInput(BaseModel):

--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -1,0 +1,10 @@
+import sys
+
+if __name__.startswith("backend.app"):
+    sys.modules["app.utils"] = sys.modules[__name__]
+else:  # pragma: no cover
+    sys.modules["backend.app.utils"] = sys.modules[__name__]
+
+parent = sys.modules.get("backend.app")
+if parent is not None:
+    setattr(parent, "utils", sys.modules[__name__])

--- a/backend/flows/__init__.py
+++ b/backend/flows/__init__.py
@@ -19,6 +19,8 @@ def ensure_backend_path() -> None:
 
 ensure_backend_path()
 
+import app  # noqa: F401  pylint: disable=unused-import
+
 from backend.flows.ergonomics import (  # noqa: E402  pylint: disable=wrong-import-position
     fetch_seeded_metrics,
     seed_ergonomics_metrics as _seed_ergonomics_metrics,

--- a/backend/jobs/__init__.py
+++ b/backend/jobs/__init__.py
@@ -5,8 +5,16 @@ from __future__ import annotations
 import asyncio
 import inspect
 import os
+import sys
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, Mapping, Optional, Tuple
+
+
+_MODULE = sys.modules[__name__]
+if __name__ == "jobs":
+    sys.modules.setdefault("backend.jobs", _MODULE)
+else:
+    sys.modules.setdefault("jobs", _MODULE)
 
 try:  # pragma: no cover - optional dependency, available in some deployments
     from celery import Celery  # type: ignore

--- a/backend/scripts/seed_screening.py
+++ b/backend/scripts/seed_screening.py
@@ -10,9 +10,14 @@ from typing import Dict, Iterable, List, Optional, Sequence
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.database import AsyncSessionLocal, engine
-from app.models.base import BaseModel
-from app.models.rkp import RefGeocodeCache, RefParcel, RefSource, RefZoningLayer
+try:  # pragma: no cover - maintain compatibility with historical import paths
+    from backend.app.core.database import AsyncSessionLocal, engine
+    from backend.app.models.base import BaseModel
+    from backend.app.models.rkp import RefGeocodeCache, RefParcel, RefSource, RefZoningLayer
+except ModuleNotFoundError:  # pragma: no cover - fallback when backend package not available
+    from app.core.database import AsyncSessionLocal, engine
+    from app.models.base import BaseModel
+    from app.models.rkp import RefGeocodeCache, RefParcel, RefSource, RefZoningLayer
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- ensure the backend application package registers aliases so `app.*` and `backend.app.*` share the same modules
- add pytest fixtures and fallbacks so tests cleanly reset the in-memory database and work without third-party packages
- adjust the watch reference sources flow to deduplicate summary results and make its CLI usable with the bundled SQLAlchemy stub
- fix the finance DSCR validator and support preserved sessions in the ingestion flow

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d357bc0a4883209e4c629225e5bab0