### PR TITLE
Ensure app and backend model imports share definitions

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,8 +1,56 @@
 """Model package exports."""
 
-from .base import Base  # noqa: F401
+from __future__ import annotations
 
-# Import model modules so their metadata is registered with SQLAlchemy.
-from . import audit, entitlements, finance, imports, overlay, rkp, rulesets  # noqa: F401  pylint: disable=unused-import
+import sys
+from types import ModuleType
 
-__all__ = ["Base"]
+
+def _counterpart(name: str) -> str | None:
+    """Return the alternate import path for ``app``/``backend.app`` modules."""
+
+    if name.startswith("backend."):
+        return name.removeprefix("backend.")
+    if name.startswith("app."):
+        return f"backend.{name}"
+    return None
+
+
+_ALIAS = _counterpart(__name__)
+if _ALIAS and _ALIAS in sys.modules:
+    _existing: ModuleType = sys.modules[_ALIAS]
+    globals().update(_existing.__dict__)
+    sys.modules[__name__] = _existing
+else:
+    from .base import Base  # noqa: F401
+
+    # Import model modules so their metadata is registered with SQLAlchemy.
+    from . import (  # noqa: F401  pylint: disable=unused-import
+        audit,
+        entitlements,
+        finance,
+        imports,
+        overlay,
+        rkp,
+        rulesets,
+    )
+
+    _SUBMODULES: dict[str, ModuleType] = {
+        "audit": audit,
+        "entitlements": entitlements,
+        "finance": finance,
+        "imports": imports,
+        "overlay": overlay,
+        "rkp": rkp,
+        "rulesets": rulesets,
+    }
+
+    for _name, _module in _SUBMODULES.items():
+        _module_alias = _counterpart(f"{__name__}.{_name}")
+        if _module_alias and _module_alias not in sys.modules:
+            sys.modules[_module_alias] = _module
+
+    __all__ = ["Base"]
+
+    if _ALIAS:
+        sys.modules[_ALIAS] = sys.modules[__name__]


### PR DESCRIPTION
## Summary
- ensure the backend app models package reuses an already loaded alias to avoid double registration
- register aliases for the package and its submodules so `app.*` and `backend.app.*` resolve to the same modules

## Testing
- `pytest -q tests/buildable/test_postgis_parity.py`
- `pytest -q tests/finance/test_calculator_unit.py`


------
https://chatgpt.com/codex/tasks/task_e_68d37a6823c48320af211d0cffa7ce26