### PR TITLE
Ensure job decorators use backend job queue

### DIFF
--- a/backend/app/api/v1/imports.py
+++ b/backend/app/api/v1/imports.py
@@ -19,13 +19,12 @@ from app.models.imports import ImportRecord
 from app.schemas.imports import DetectedFloor, ImportResult, ParseStatusResponse
 from app.services.storage import get_storage_service
 from app.utils.logging import get_logger
-from jobs import job_queue
-from jobs.parse_cad import detect_dxf_metadata, detect_ifc_metadata, parse_import_job
-from jobs.raster_vector import vectorize_floorplan
+from backend.jobs import job_queue
+from backend.jobs.parse_cad import detect_dxf_metadata, detect_ifc_metadata, parse_import_job
+from backend.jobs.raster_vector import vectorize_floorplan
 
 router = APIRouter()
 logger = get_logger(__name__)
-
 
 def _extract_unit_id(unit: Any) -> str | None:
     """Return a unit identifier from diverse payload representations."""

--- a/backend/app/api/v1/overlay.py
+++ b/backend/app/api/v1/overlay.py
@@ -19,8 +19,8 @@ from app.models.overlay import (
     OverlaySuggestion,
 )
 from app.schemas.overlay import OverlayDecisionPayload, OverlaySuggestion as OverlaySuggestionSchema
-from jobs import job_queue
-from jobs.overlay_run import run_overlay_job
+from backend.jobs import job_queue
+from backend.jobs.overlay_run import run_overlay_job
 
 
 router = APIRouter(prefix="/overlay")

--- a/backend/httpx.py
+++ b/backend/httpx.py
@@ -9,7 +9,14 @@ from typing import Any
 try:  # pragma: no cover - optional dependency for offline test runs
     from fastapi.testclient import TestClient
 except ModuleNotFoundError:  # pragma: no cover - handled lazily
-    TestClient = None  # type: ignore[assignment]
+    import sys
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.append(str(repo_root))
+
+    from fastapi.testclient import TestClient  # type: ignore[assignment]
 
 
 class _AsyncResponse:

--- a/backend/jobs/overlay_run.py
+++ b/backend/jobs/overlay_run.py
@@ -22,7 +22,7 @@ from app.models.overlay import (
     OverlaySourceGeometry,
     OverlaySuggestion,
 )
-from jobs import job
+from backend.jobs import job
 
 ENGINE_VERSION = "2024.1"
 

--- a/backend/jobs/parse_cad.py
+++ b/backend/jobs/parse_cad.py
@@ -30,7 +30,7 @@ from app.core.models.geometry import GeometryGraph
 from app.models.imports import ImportRecord
 from app.services.overlay_ingest import ingest_parsed_import_geometry
 from app.services.storage import get_storage_service
-from jobs import job
+from backend.jobs import job
 
 
 @dataclass(slots=True)

--- a/backend/jobs/raster_vector.py
+++ b/backend/jobs/raster_vector.py
@@ -15,7 +15,7 @@ try:  # pragma: no cover - optional dependency
 except ModuleNotFoundError:  # pragma: no cover - available in production environments
     fitz = None  # type: ignore[assignment]
 
-from jobs import job
+from backend.jobs import job
 
 
 Point = Tuple[float, float]

--- a/backend/tests/test_jobs/test_parse_cad_samples.py
+++ b/backend/tests/test_jobs/test_parse_cad_samples.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 import pytest
 
-from jobs.parse_cad import _parse_dxf_payload, _parse_ifc_payload
-from jobs.raster_vector import _vectorize_pdf
+from backend.jobs.parse_cad import _parse_dxf_payload, _parse_ifc_payload
+from backend.jobs.raster_vector import _vectorize_pdf
 
 SAMPLES_DIR = Path(__file__).resolve().parents[3] / "samples"
 

--- a/backend/tests/test_jobs/test_raster_vector.py
+++ b/backend/tests/test_jobs/test_raster_vector.py
@@ -9,7 +9,7 @@ import pytest
 
 pytest.importorskip("fitz")
 
-from jobs.raster_vector import vectorize_floorplan
+from backend.jobs.raster_vector import vectorize_floorplan
 
 SAMPLE_PDF = Path(__file__).resolve().parents[3] / "samples" / "pdf" / "floor_simple.pdf"
 

--- a/backend/tests/test_workflows/test_aec_pipeline.py
+++ b/backend/tests/test_workflows/test_aec_pipeline.py
@@ -30,7 +30,7 @@ from app.models.audit import AuditLog
 from app.models.imports import ImportRecord
 from app.models.overlay import OverlaySourceGeometry, OverlaySuggestion
 from app.models.rkp import RefRule, RefZoningLayer
-from jobs.overlay_run import run_overlay_for_project
+from backend.jobs.overlay_run import run_overlay_for_project
 
 SAMPLE_PATH = Path(__file__).resolve().parents[1] / "samples" / "sample_floorplan.json"
 GOLDEN_MANIFEST_PATH = Path(__file__).resolve().parents[1] / "samples" / "golden_export_manifest.json"

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -15,11 +15,11 @@ backend.
 
 from __future__ import annotations
 
-from jobs import celery_app, job_queue  # noqa: F401  (re-exported for workers)
+from backend.jobs import celery_app, job_queue  # noqa: F401  (re-exported for workers)
 
 # Import job modules to register tasks with the configured backend.
-from jobs import overlay_run as _overlay_run  # noqa: F401
-from jobs import parse_cad as _parse_cad  # noqa: F401
-from jobs import raster_vector as _raster_vector  # noqa: F401
+from backend.jobs import overlay_run as _overlay_run  # noqa: F401
+from backend.jobs import parse_cad as _parse_cad  # noqa: F401
+from backend.jobs import raster_vector as _raster_vector  # noqa: F401
 
 __all__ = ["celery_app", "job_queue"]

--- a/jobs/__init__.py
+++ b/jobs/__init__.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper exposing :mod:`backend.jobs` as :mod:`jobs`."""
+"""Compatibility shim that exposes :mod:`backend.jobs` as ``jobs``."""
 
 from __future__ import annotations
 
@@ -7,6 +7,6 @@ import sys
 
 _backend_jobs = import_module("backend.jobs")
 
-# Reuse the backend implementation so imports like ``from jobs import job``
-# continue to resolve without installing the package.
+# Replace this module entry so ``import jobs`` returns ``backend.jobs`` directly.
 sys.modules[__name__] = _backend_jobs
+


### PR DESCRIPTION
## Summary
- import the parse jobs directly from `backend.jobs` so API routes use the same JobQueue instance as the decorators
- adjust the job modules, worker entrypoint, and tests to reference the backend package directly while keeping the lightweight shim for compatibility
- leave the JobQueue proxy override in place so monkeypatched enqueue implementations still delegate to the backend registry

## Testing
- `pytest backend/tests/test_api/test_imports.py::test_parse_endpoints_return_summary -q`
- `pytest backend/tests/test_api/test_imports.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d35c017c84832093f6d90b2836fc46