### PR TITLE
Fix async job sessions and metrics handling

### DIFF
--- a/backend/app/schemas/rulesets.py
+++ b/backend/app/schemas/rulesets.py
@@ -19,7 +19,7 @@ class RulePackSchema(BaseModel):
     authority: Optional[str] = None
     version: int
     definition: Dict[str, Any]
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+    metadata: Dict[str, Any] = Field(default_factory=dict, validation_alias="metadata_json")
     is_active: bool = True
     created_at: datetime
     updated_at: datetime

--- a/backend/httpx.py
+++ b/backend/httpx.py
@@ -4,12 +4,28 @@ from __future__ import annotations
 
 import asyncio
 from functools import partial
+from pathlib import Path
+import sys
 from typing import Any
 
-try:  # pragma: no cover - optional dependency for offline test runs
-    from fastapi.testclient import TestClient
-except ModuleNotFoundError:  # pragma: no cover - handled lazily
-    TestClient = None  # type: ignore[assignment]
+def _load_test_client() -> Any:
+    """Return the FastAPI TestClient, importing the local stub if required."""
+
+    try:  # pragma: no cover - optional dependency for offline test runs
+        from fastapi.testclient import TestClient  # type: ignore
+        return TestClient
+    except ModuleNotFoundError:  # pragma: no cover - handled lazily
+        repo_root = Path(__file__).resolve().parents[1]
+        if str(repo_root) not in sys.path:
+            sys.path.insert(0, str(repo_root))
+        try:
+            from fastapi.testclient import TestClient  # type: ignore
+            return TestClient
+        except ModuleNotFoundError:
+            return None
+
+
+TestClient = _load_test_client()
 
 
 class _AsyncResponse:

--- a/backend/jobs/overlay_run.py
+++ b/backend/jobs/overlay_run.py
@@ -11,7 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.core.database import AsyncSessionLocal
+from app.core import database
 from app.core.geometry import GeometrySerializer
 from app.core.metrics import OVERLAY_BASELINE_SECONDS
 from app.core.models.geometry import GeometryGraph
@@ -363,7 +363,8 @@ def _coerce_mapping(value: object) -> Dict[str, Any]:
 async def run_overlay_job(project_id: int) -> Dict[str, Any]:
     """Job wrapper that executes the overlay engine using a standalone session."""
 
-    async with AsyncSessionLocal() as session:
+    session_factory = database.AsyncSessionLocal
+    async with session_factory() as session:
         result = await run_overlay_for_project(session, project_id=project_id)
         return {"status": "completed", **result.as_dict()}
 

--- a/backend/jobs/parse_cad.py
+++ b/backend/jobs/parse_cad.py
@@ -24,7 +24,7 @@ try:  # pragma: no cover - optional dependency
 except ModuleNotFoundError:  # pragma: no cover - available in production environments
     ifcopenshell = None  # type: ignore[assignment]
 
-from app.core.database import AsyncSessionLocal
+from app.core import database
 from app.core.geometry import GeometrySerializer, GraphBuilder
 from app.core.models.geometry import GeometryGraph
 from app.models.imports import ImportRecord
@@ -657,7 +657,8 @@ async def _persist_result(session, record: ImportRecord, parsed: ParsedGeometry)
 async def parse_import_job(import_id: str) -> Dict[str, Any]:
     """Parse an uploaded import payload and persist the resulting geometry."""
 
-    async with AsyncSessionLocal() as session:
+    session_factory = database.AsyncSessionLocal
+    async with session_factory() as session:
         record = await session.get(ImportRecord, import_id)
         if record is None:
             raise RuntimeError(f"Import '{import_id}' not found")


### PR DESCRIPTION
## Summary
- ensure background jobs reuse the dynamically provided async session factory
- make the httpx AsyncClient test stub load the bundled FastAPI TestClient fallback
- stabilise metric counter lookups and map rule pack metadata correctly for validation

## Testing
- `pytest backend/tests/test_api -q`


------
https://chatgpt.com/codex/tasks/task_e_68d37fdc8e188320b77f39c03686e207