### PR TITLE
Fix inline overlay job session handling and metrics utilities

### DIFF
--- a/backend/app/schemas/rulesets.py
+++ b/backend/app/schemas/rulesets.py
@@ -29,6 +29,31 @@ class RulePackSchema(BaseModel):
 
         from_attributes = True
 
+    @classmethod
+    def model_validate(
+        cls,
+        obj: Any,
+        *,
+        from_attributes: bool = False,
+    ) -> "RulePackSchema":
+        if from_attributes and not isinstance(obj, dict):
+            data: Dict[str, Any] = {}
+            for name in cls.model_fields:
+                if name == "metadata":
+                    if hasattr(obj, "metadata_json"):
+                        value = getattr(obj, "metadata_json")
+                    else:
+                        value = getattr(obj, "metadata", {})
+                    if isinstance(value, dict):
+                        data[name] = dict(value)
+                    else:
+                        data[name] = {}
+                    continue
+                if hasattr(obj, name):
+                    data[name] = getattr(obj, name)
+            return cls(**data)
+        return super().model_validate(obj, from_attributes=from_attributes)
+
 
 class RulePackSummary(BaseModel):
     """Compact metadata about a rule pack."""

--- a/backend/app/utils/metrics.py
+++ b/backend/app/utils/metrics.py
@@ -191,7 +191,11 @@ def reset_metrics() -> None:
 def counter_value(counter: Counter, labels: Dict[str, str]) -> float:
     """Return the current value for a labelled counter."""
 
-    sample = counter.labels(**labels)
+    label_names: Iterable[str] = getattr(counter, "_labelnames", ())
+    if label_names:
+        sample = counter.labels(**labels)
+    else:
+        sample = counter
     value_holder = getattr(sample, "_value", None)
     if value_holder is not None and hasattr(value_holder, "get"):
         return float(value_holder.get())


### PR DESCRIPTION
## Summary
- ensure the overlay background job honours FastAPI session overrides when running inline
- guard the metrics counter helper so unlabeled counters can be queried
- allow the rule pack schema to read metadata from ORM instances without clashing with SQLAlchemy metadata

## Testing
- pytest backend/tests/test_api

------
https://chatgpt.com/codex/tasks/task_e_68d3825f249883208fa94b3654944a78