### PR TITLE
Fix overlay decision loading and parse job session factory

### DIFF
--- a/backend/app/api/v1/overlay.py
+++ b/backend/app/api/v1/overlay.py
@@ -94,7 +94,14 @@ async def decide_overlay(
 ) -> Dict[str, object]:
     """Persist a decision on a generated overlay suggestion."""
 
-    suggestion = await session.get(OverlaySuggestion, payload.suggestion_id)
+    stmt = (
+        select(OverlaySuggestion)
+        .where(OverlaySuggestion.id == payload.suggestion_id)
+        .options(selectinload(OverlaySuggestion.decision))
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    suggestion = result.scalar_one_or_none()
     if suggestion is None or suggestion.project_id != project_id:
         raise HTTPException(status_code=404, detail="Overlay suggestion not found")
 

--- a/backend/jobs/parse_cad.py
+++ b/backend/jobs/parse_cad.py
@@ -24,7 +24,7 @@ try:  # pragma: no cover - optional dependency
 except ModuleNotFoundError:  # pragma: no cover - available in production environments
     ifcopenshell = None  # type: ignore[assignment]
 
-from app.core.database import AsyncSessionLocal
+from app.core import database as app_database
 from app.core.geometry import GeometrySerializer, GraphBuilder
 from app.core.models.geometry import GeometryGraph
 from app.models.imports import ImportRecord
@@ -657,7 +657,8 @@ async def _persist_result(session, record: ImportRecord, parsed: ParsedGeometry)
 async def parse_import_job(import_id: str) -> Dict[str, Any]:
     """Parse an uploaded import payload and persist the resulting geometry."""
 
-    async with AsyncSessionLocal() as session:
+    session_factory = getattr(app_database, "AsyncSessionLocal")
+    async with session_factory() as session:
         record = await session.get(ImportRecord, import_id)
         if record is None:
             raise RuntimeError(f"Import '{import_id}' not found")


### PR DESCRIPTION
## Summary
- fetch overlay suggestions with eager decision loading to avoid async lazy-load errors when saving decisions
- reference the app database module for the parse job session factory so tests can override it

## Testing
- pytest -q backend/tests/test_api/test_imports.py::test_parse_endpoints_return_summary
- pytest -q backend/tests/test_api/test_overlay.py::test_overlay_run_and_decisions
- pytest -q backend/tests/test_api/test_roi.py::test_roi_metrics_after_workflow
- pytest -q backend/tests/test_api/test_audit.py::test_audit_chain_and_diffs
- pytest -q backend/tests/finance/test_calculator_unit.py::test_npv_handles_negative_cashflow_months
- pytest -q backend/tests/flows/test_reference_flows_cli.py::test_prefect_shim_flow_decorator_preserves_callable


------
https://chatgpt.com/codex/tasks/task_e_68d396a2b5dc8320a084a80c2beea6c5