### PR TITLE
Fix watch fetch concurrency and finance relationship

### DIFF
--- a/backend/app/api/v1/finance.py
+++ b/backend/app/api/v1/finance.py
@@ -351,7 +351,7 @@ async def run_finance_feasibility(
         results: List[FinResult] = [
             FinResult(
                 project_id=payload.project_id,
-                scenario_id=scenario.id,
+                scenario=scenario,
                 name="escalated_cost",
                 value=escalated_cost,
                 unit=payload.scenario.currency,
@@ -363,7 +363,7 @@ async def run_finance_feasibility(
             ),
             FinResult(
                 project_id=payload.project_id,
-                scenario_id=scenario.id,
+                scenario=scenario,
                 name="npv",
                 value=npv_rounded,
                 unit=payload.scenario.currency,
@@ -374,7 +374,7 @@ async def run_finance_feasibility(
             ),
             FinResult(
                 project_id=payload.project_id,
-                scenario_id=scenario.id,
+                scenario=scenario,
                 name="irr",
                 value=irr_value,
                 unit="ratio",
@@ -395,7 +395,6 @@ async def run_finance_feasibility(
             )
 
         session.add_all(results)
-        scenario.results.extend(results)
 
         await session.flush()
         await session.commit()

--- a/backend/app/models/finance.py
+++ b/backend/app/models/finance.py
@@ -211,7 +211,9 @@ class FinResult(BaseModel):
     unit: Mapped[str | None] = mapped_column(String(20))
     metadata_json: Mapped[dict] = mapped_column("metadata", JSONType, default=dict, nullable=False)
 
-    scenario: Mapped[FinScenario] = relationship("FinScenario", back_populates="results")
+    scenario: Mapped[FinScenario] = relationship(
+        "FinScenario", back_populates="results", uselist=False
+    )
 
     __table_args__ = (
         Index("idx_fin_results_project_name", "project_id", "name"),

--- a/backend/flows/__init__.py
+++ b/backend/flows/__init__.py
@@ -7,6 +7,13 @@ from pathlib import Path
 from collections.abc import Callable
 from typing import Any, cast
 
+
+try:  # pragma: no cover - exercised when SQLAlchemy is unavailable
+    import sqlalchemy  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - fallback to bundled stub for CLI entrypoints
+    import app as _app_for_sqlalchemy_stub  # noqa: F401  pylint: disable=unused-import
+    import sqlalchemy  # type: ignore[import-not-found]
+
 _BACKEND_ROOT = Path(__file__).resolve().parent.parent
 
 


### PR DESCRIPTION
## Summary
- run the watch reference sources flow and summarisation in a single async event loop to avoid driver concurrency issues
- load the SQLAlchemy stub when needed and prune duplicate sources/documents in the watch flow for stubbed environments
- attach finance results via the scenario relationship with a scalar mapping

## Testing
- pytest backend/tests/flows/test_reference_flows_cli.py
- pytest backend/tests/test_api/test_finance_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68d39c866cf08320a51c85659d99854f