### PR TITLE
Ensure make test bootstraps virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,10 @@ lint: ## Run linting
 	cd frontend && npm run lint
 
 test: ## Run tests
+	@if [ ! -x $(PY) ]; then \
+		echo "Virtualenv not found; running 'make venv'..."; \
+		$(MAKE) venv; \
+	fi
 	cd backend && $(PY) -m pytest tests
 	cd backend && $(PY) -m pytest ../tests
 	cd frontend && npm test


### PR DESCRIPTION
## Summary
- run `make venv` automatically when the virtualenv is missing before executing tests
- keep existing backend and frontend test commands unchanged

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d3f22379dc8320858470e987517305