### PR TITLE
Use node test discovery

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview --host 127.0.0.1 --port 4173",
     "lint": "eslint --ext .ts,.tsx src",
-    "test": "find tests -type f -name '*.test.*' -print0 | xargs -0r node --test",
+    "test": "node --test",
     "test:e2e": "node scripts/run-e2e.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- simplify the frontend test script to rely on Node's built-in test discovery

## Testing
- npm --prefix frontend test
- make test
- make dev

------
https://chatgpt.com/codex/tasks/task_e_68d47df2cf4c8320a7a7f1cd1bf85b1e