### PR TITLE
Configure flake8 for tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+extend-ignore = E203,W503
+max-line-length = 130
+per-file-ignores =
+    backend/tests/*:E402
+    tests/*:E402


### PR DESCRIPTION
## Summary
- add a repository-level flake8 configuration for test-specific rules
- ignore E203 and W503 for black compatibility and raise max line length to 130 for tests
- add per-file E402 ignores for tests under backend/tests and tests/

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d485752cd48320b23ac571019da8d8