### PR TITLE
Remove unused Optional import from validators

### DIFF
--- a/backend/app/utils/validators.py
+++ b/backend/app/utils/validators.py
@@ -1,7 +1,6 @@
 """Validation utilities."""
 
 import re
-from typing import Optional
 
 
 def validate_singapore_address(address: str) -> bool:


### PR DESCRIPTION
## Summary
- remove the unused Optional import from backend app validators so flake8 F401 no longer triggers

## Testing
- black app/utils tests *(fails: path 'app/utils' does not exist in this repository)*
- flake8 *(fails: flake8 is not installed in the execution environment)*
- cd backend && flake8 app tests *(fails: flake8 is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d486e08938832094f728d18a83ddfa