### PR TITLE
Fix lint configuration and pytest asyncio event loop scope

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,11 @@
 [flake8]
 extend-ignore = E203,W503
 max-line-length = 130
+
+# Do not lint virtualenvs, caches, compiled stuff, or vendored third-party code.
+exclude = .git,__pycache__,.venv,venv,*/site-packages/*,node_modules,dist,build,.mypy_cache,.pytest_cache
+
+# Tests often place imports after local path/setup; suppress E402 only there.
 per-file-ignores =
     backend/tests/*:E402
     tests/*:E402

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import asyncio
 from importlib import import_module
 from pathlib import Path
 from types import ModuleType
@@ -24,6 +25,18 @@ except ModuleNotFoundError:  # pragma: no cover - fallback stub when plugin miss
     sys.modules.setdefault("pytest_asyncio", pytest_asyncio)
 
 from backend.tests import conftest as backend_conftest  # noqa: F401 - ensure fallback stubs are registered
+
+
+@pytest_asyncio.fixture(scope="session")
+def event_loop():
+    """Provide a session-scoped event loop compatible with session fixtures."""
+
+    loop = asyncio.new_event_loop()
+    try:
+        yield loop
+    finally:
+        loop.close()
+
 
 pytest_plugins = ["backend.tests.conftest"]
 


### PR DESCRIPTION
## Summary
- stop flake8 from traversing virtualenv, caches, and vendored directories
- provide a session-scoped asyncio event loop fixture for pytest

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d4887951e0832089cb6e45bc7c9017