### PR TITLE
Limit formatting and linting to tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -28,7 +28,14 @@ exclude =
     sqlalchemy_pkg_backup,
     mako,
     importlib,
-    yaml
+    yaml,
+    # (OPTIONAL) exclude backend application code; we lint tests only here
+    backend/app,
+    backend/flows,
+    backend/jobs,
+    backend/migrations,
+    backend/scripts,
+    backend/test_db_connection.py
 
 # Tests often place imports after path/setup; suppress E402 only there.
 # Also quiet E302/W391 in tests to avoid churn on spacing/EOF-newline trivia.

--- a/Makefile
+++ b/Makefile
@@ -104,11 +104,13 @@ $(PIP) install $(PIP_INSTALL_FLAGS) aiosqlite==0.21.0; \
 install: venv ## Install dependencies (alias)
 
 format: ## Format code
-	cd backend && $(PY) -m black . && $(PY) -m isort .
+	@[ -d backend/tests ] && (cd backend && $(PY) -m black tests && $(PY) -m isort tests) || true
+	@[ -d tests ] && $(PY) -m black tests || true
 	cd frontend && npm run format
 
 lint: ## Run linting
-	cd backend && $(PY) -m flake8 app tests && $(PY) -m mypy app
+	@[ -d backend/tests ] && (cd backend && $(PY) -m flake8 tests) || true
+	@[ -d tests ] && $(PY) -m flake8 tests || true
 	cd frontend && npm run lint
 
 test: ## Run tests


### PR DESCRIPTION
## Summary
- scope the Makefile format target to black/isort only the backend and repository test directories
- narrow linting to flake8 on test directories while retaining the frontend commands
- update the root flake8 configuration to exclude backend application code so only tests are linted

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d48a81aba083209062d5720f498131