### PR TITLE
Tooling: test-scoped lint/format + pre-commit; asyncio_mode auto; CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint (tests)
+on:
+  pull_request:
+  push:
+    branches: [ main, master ]
+
+jobs:
+  lint-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install black flake8 flake8-bugbear pytest
+      - name: Black check (tests only)
+        run: |
+          if [ -d backend/tests ]; then black --check backend/tests; fi
+          if [ -d tests ]; then black --check tests; fi
+      - name: flake8 (tests only)
+        run: |
+          if [ -d backend/tests ]; then flake8 backend/tests; fi
+          if [ -d tests ]; then flake8 tests; fi
+      - name: Pytest (quick)
+        run: pytest -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,21 @@
 repos:
-  - repo: local
-    hooks:
-      - id: audit-migrations
-        name: audit-migrations
-        entry: python3 scripts/audit_migrations.py
-        language: system
-        pass_filenames: false
+- repo: local
+  hooks:
+    - id: audit-migrations
+      name: audit-migrations
+      entry: python3 scripts/audit_migrations.py
+      language: system
+      pass_filenames: false
+
+- repo: https://github.com/psf/black
+  rev: 24.8.0
+  hooks:
+    - id: black
+      files: ^(backend/tests|tests)/
+
+- repo: https://github.com/PyCQA/flake8
+  rev: 7.1.1
+  hooks:
+    - id: flake8
+      additional_dependencies: [flake8-bugbear]
+      files: ^(backend/tests|tests)/

--- a/Makefile
+++ b/Makefile
@@ -103,24 +103,16 @@ $(PIP) install $(PIP_INSTALL_FLAGS) aiosqlite==0.21.0; \
 
 install: venv ## Install dependencies (alias)
 
-format: ## Format code
-	@[ -d backend/tests ] && (cd backend && $(PY) -m black tests && $(PY) -m isort tests) || true
-	@[ -d tests ] && $(PY) -m black tests || true
-	cd frontend && npm run format
+format: ## Format code (tests only)
+	@[ -d backend/tests ] && black backend/tests || true
+	@[ -d tests ] && black tests || true
 
-lint: ## Run linting
-	@[ -d backend/tests ] && (cd backend && $(PY) -m flake8 tests) || true
-	@[ -d tests ] && $(PY) -m flake8 tests || true
-	cd frontend && npm run lint
+lint: ## Run linting (tests only)
+	@[ -d backend/tests ] && flake8 backend/tests || true
+	@[ -d tests ] && flake8 tests || true
 
-test: ## Run tests
-	@if [ ! -x $(PY) ]; then \
-		echo "Virtualenv not found; running 'make venv'..."; \
-		$(MAKE) venv; \
-	fi
-	cd backend && $(PY) -m pytest tests
-	cd backend && $(PY) -m pytest ../tests
-	cd frontend && npm test
+test: ## Run tests (tests only)
+	pytest -q
 
 smoke-buildable: ## Run the buildable latency smoke test and report the observed P90
 	cd backend && $(PY) -m pytest -s tests/pwp/test_buildable_latency.py

--- a/tests/buildable/test_postgis_parity.py
+++ b/tests/buildable/test_postgis_parity.py
@@ -67,6 +67,7 @@ async def _parcel_metrics(
         settings.BUILDABLE_USE_POSTGIS = previous_flag
 
 
+@pytest.mark.asyncio
 async def test_postgis_flag_produces_identical_metrics(async_session_factory) -> None:
     async with async_session_factory() as session:
         await seed_screening_sample_data(session, commit=True)


### PR DESCRIPTION
## Summary
- scope the Makefile format/lint/test targets to Python tests only
- add black and flake8 (with bugbear) to pre-commit, limited to backend/tests and tests
- configure pytest asyncio mode to auto and add a test-focused lint workflow

## Testing
- not run (tooling-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d48fdfa07483209c760301373a8203