### PR TITLE
Add contributor guide and local verification workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Optimal Build
+
+Thanks for your interest in contributing! This guide covers the basics to get
+your environment ready, keep your changes clean, and run the full suite of
+checks before opening a pull request.
+
+## Initial setup
+
+1. Create and activate a virtual environment.
+2. Upgrade pip and install pre-commit.
+3. Install the repository's pre-commit hooks.
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -U pip pre-commit
+pre-commit install
+```
+
+## Before pushing changes
+
+Always run the local quality gates before you push a branch. The verify
+target executes formatting checks, linting, and the test suite in one go.
+
+```bash
+make verify
+```
+
+If you prefer, you can run the individual commands as needed:
+
+```bash
+make format
+make lint
+make test
+```
+
+## One-time full run
+
+Run all pre-commit hooks across the repository at least once to ensure there
+are no latent issues before you start iterating.
+
+```bash
+pre-commit run --all-files
+```

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install format lint test test-cov smoke-buildable clean build deploy init-db db.upgrade seed-data logs down reset dev dev-stop import-sample run-overlay export-approved test-aec seed-nonreg sync-products venv env-check
+.PHONY: help install format format-check lint lint-prod test test-cov smoke-buildable clean build deploy init-db db.upgrade seed-data logs down reset dev dev-stop import-sample run-overlay export-approved test-aec seed-nonreg sync-products venv env-check verify
 
 DEV_RUNTIME_DIR ?= .devstack
 DEV_RUNTIME_DIR_ABS := $(abspath $(DEV_RUNTIME_DIR))
@@ -107,12 +107,26 @@ format: ## Format code (tests only)
 	@[ -d backend/tests ] && black backend/tests || true
 	@[ -d tests ] && black tests || true
 
+format-check: ## Check formatting (tests only)
+	@[ -d backend/tests ] && black --check backend/tests || true
+	@[ -d tests ] && black --check tests || true
+
 lint: ## Run linting (tests only)
 	@[ -d backend/tests ] && flake8 backend/tests || true
 	@[ -d tests ] && flake8 tests || true
 
+lint-prod: ## Run linting for backend production code (optional)
+	@[ -d backend/app ] && flake8 backend/app || true
+	@[ -d backend/flows ] && flake8 backend/flows || true
+	@[ -d backend/jobs ] && flake8 backend/jobs || true
+
 test: ## Run tests (tests only)
 	pytest -q
+
+verify: ## Run formatting checks, linting, and tests
+	$(MAKE) format-check
+	$(MAKE) lint
+	$(MAKE) test
 
 smoke-buildable: ## Run the buildable latency smoke test and report the observed P90
 	cd backend && $(PY) -m pytest -s tests/pwp/test_buildable_latency.py

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -162,7 +162,8 @@ async def _reset_database(factory: async_sessionmaker[AsyncSession]) -> None:
 
 @pytest_asyncio.fixture(scope="session")
 async def flow_session_factory() -> AsyncGenerator[
-    async_sessionmaker[AsyncSession], None
+    async_sessionmaker[AsyncSession],
+    None,
 ]:
     """Provide a shared async session factory backed by SQLite."""
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,5 @@ python_classes = Test*
 python_functions = test_*
 testpaths = tests
 norecursedirs = backend .git .venv
+asyncio_mode = auto
 


### PR DESCRIPTION
## Summary
- add a CONTRIBUTING guide that explains how to bootstrap the repo and run checks
- extend the Makefile with format-check, lint-prod, and verify helpers
- ensure pytest auto-detects asyncio fixtures and keep tests formatted for black

## Testing
- make format-check
- make lint *(fails: flake8 is not installed in the execution environment)*
- make test


------
https://chatgpt.com/codex/tasks/task_e_68d49420fc6083208d2a07176e7af972