### PR TITLE
Use DATABASE_URL when provided for dev backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,11 @@ dev: ## Start supporting services, the backend API, and frontends
 	else \
 		rm -f $(DEV_BACKEND_PID); \
 		: > $(DEV_BACKEND_LOG); \
-			(cd backend && DEV_SQLITE_URL=$(DEV_SQLITE_URL) SQLALCHEMY_DATABASE_URI=$(DEV_SQLITE_URL) DATABASE_URL=$(DEV_SQLITE_URL) nohup $(BACKEND_CMD) > $(DEV_BACKEND_LOG) 2>&1 & echo $$! > $(DEV_BACKEND_PID)); \
+		# Prefer an externally provided DATABASE_URL; otherwise fall back to local SQLite file.
+		(cd backend && EFFECTIVE_DB_URL=$${DATABASE_URL:-$(DEV_SQLITE_URL)} \
+			SQLALCHEMY_DATABASE_URI=$$EFFECTIVE_DB_URL \
+			DATABASE_URL=$$EFFECTIVE_DB_URL \
+			nohup $(BACKEND_CMD) > $(DEV_BACKEND_LOG) 2>&1 & echo $$! > $(DEV_BACKEND_PID)); \
 		echo "Backend API started (PID $$(cat $(DEV_BACKEND_PID))). Logs: $(DEV_BACKEND_LOG)"; \
 	fi
 	@if [ -f $(DEV_FRONTEND_PID) ] && kill -0 $$(cat $(DEV_FRONTEND_PID)) 2>/dev/null; then \


### PR DESCRIPTION
## Summary
- prefer DATABASE_URL when launching the dev backend so teams can point at a shared database
- fall back to the existing SQLite URL when DATABASE_URL is not set

## Testing
- not run (Makefile change only)


------
https://chatgpt.com/codex/tasks/task_e_68d4a134295c83208003be51a079b96a