### PR TITLE
Fix dev target shell syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,8 +219,8 @@ dev: ## Start supporting services, the backend API, and frontends
 		echo "Backend API already running (PID $$(cat $(DEV_BACKEND_PID)))."; \
 	else \
 		rm -f $(DEV_BACKEND_PID); \
-		: > $(DEV_BACKEND_LOG); \
-		# Prefer an externally provided DATABASE_URL; otherwise fall back to local SQLite file.
+                : > $(DEV_BACKEND_LOG); \
+                : "Prefer an externally provided DATABASE_URL; otherwise fall back to local SQLite file."; \
 		(cd backend; \
 			EFFECTIVE_DB_URL=$${DATABASE_URL:-$(DEV_SQLITE_URL)}; \
 			SQLALCHEMY_DATABASE_URI="$$EFFECTIVE_DB_URL" DATABASE_URL="$$EFFECTIVE_DB_URL" \


### PR DESCRIPTION
## Summary
- replace the inline comment in the dev recipe with a no-op command so the shell script parses correctly
- allow `make dev` to run without a Docker Compose CLI

## Testing
- make dev

------
https://chatgpt.com/codex/tasks/task_e_68d4a442b6308320b1bddd58ee8195b9