### PR TITLE
Ensure uvicorn uses ASGI3 module path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ BACKEND_PORT ?= 9400
 FRONTEND_PORT ?= 4400
 ADMIN_PORT ?= 4401
 
-BACKEND_CMD ?= $(UVICORN) --app-dir backend app.main:app --reload --host 0.0.0.0 --port $(BACKEND_PORT)
+UVICORN_INTERFACE ?= asgi3
+BACKEND_CMD ?= $(UVICORN) --interface $(UVICORN_INTERFACE) backend.app.main:app --reload --host 0.0.0.0 --port $(BACKEND_PORT)
 FRONTEND_CMD ?= npm run dev -- --port $(FRONTEND_PORT)
 ADMIN_CMD ?= npm run dev -- --port $(ADMIN_PORT)
 INCLUDE_ADMIN ?= 1


### PR DESCRIPTION
## Summary
- keep the new `UVICORN_INTERFACE` configuration defaulting to `asgi3`
- run the backend via the fully qualified `backend.app.main:app` module path so uvicorn loads the FastAPI app correctly

## Testing
- make venv
- make dev-stop || true
- lsof -ti :9400 | xargs -r kill -9 *(fails: lsof unavailable in container)*
- export DATABASE_URL="postgresql+asyncpg://postgres:dev@localhost:5432/postgres"
- make dev *(fails downstream because FastAPI/Starlette wheels require unavailable pydantic-core)*
- curl -i http://localhost:9400/openapi.json *(fails: backend dependency installation incomplete)*
- curl -i http://localhost:9400/docs *(fails: backend dependency installation incomplete)*
- curl -i http://localhost:9400/health *(fails: backend dependency installation incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_68d4aefc6bc483209663598288a987a9