### PR TITLE
Implement SG BCA live fetcher

### DIFF
--- a/jurisdictions/sg_bca/README.md
+++ b/jurisdictions/sg_bca/README.md
@@ -1,0 +1,29 @@
+# Singapore BCA fetcher
+
+The SG BCA integration downloads circulars from the Building and Construction Authority's dataset that is published through the [`data.gov.sg` CKAN API](https://data.gov.sg/). The live service requires credentials that are issued by the Singapore government to approved consumers.
+
+## Configuration
+
+The fetcher reads its configuration from the following environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `SG_BCA_DATASTORE_RESOURCE_ID` | **Required.** CKAN resource identifier for the BCA circular dataset. |
+| `SG_BCA_BASE_URL` | Optional override for the CKAN endpoint. Defaults to `https://data.gov.sg/api/action/datastore_search`. |
+| `SG_BCA_API_KEY` | Optional API key used when the upstream requires authentication. |
+| `SG_BCA_API_KEY_HEADER` | Header name to carry the API key. Defaults to `api-key`. |
+| `SG_BCA_PAGE_SIZE` | Page size for pagination requests. Defaults to `100`. |
+| `SG_BCA_TIMEOUT` | HTTP timeout (seconds). Defaults to `10`. |
+| `SG_BCA_MAX_RETRIES` | Number of retry attempts for transient errors. Defaults to `3`. |
+| `SG_BCA_BACKOFF_FACTOR` | Exponential backoff base (seconds). Defaults to `0.5`. |
+| `SG_BCA_RATE_LIMIT_PER_MINUTE` | Optional throttle for outbound requests. |
+| `SG_BCA_DATE_FIELD` | Optional override for the date field in the dataset (defaults to `circular_date`). |
+| `SG_BCA_EXTERNAL_ID_FIELD` | Optional override for the external identifier field (defaults to `circular_no`). |
+
+The fetcher will raise a `FetchError` if the `resource_id` is not provided.
+
+## Operational guidance
+
+* **Authentication:** Production deployments normally require a `data.gov.sg` API key. Request one via the Singapore Government Technology Agency (GovTech) developer portal.
+* **Scheduling:** The BCA dataset is typically updated once or twice a week. Running the ingest task twice daily (e.g. 08:00 and 20:00 SGT) keeps the local cache current while staying within rate limits.
+* **Monitoring:** The fetcher emits structured log messages with the prefix `sg_bca.fetch`. Ensure your logging pipeline captures warnings and retry events so operators can investigate repeated failures.

--- a/jurisdictions/sg_bca/fetch.py
+++ b/jurisdictions/sg_bca/fetch.py
@@ -1,42 +1,263 @@
-"""Mock fetcher for SG BCA regulations."""
+"""HTTP fetcher for the Singapore BCA circular feed.
+
+The Building and Construction Authority (BCA) publishes circulars through the
+Singapore ``data.gov.sg`` CKAN API.  This module downloads the upstream payload,
+converts it into :class:`~core.canonical_models.ProvenanceRecord` instances, and
+exposes a small amount of operational configuration that can be driven via
+environment variables.  See ``README.md`` in this package for deployment
+guidance.
+"""
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date, datetime
-from typing import Iterable, List
+from datetime import date, datetime, time, timezone
+import json
+import os
+import time as time_module
+from typing import Iterable, List, MutableMapping, Sequence
+
+import httpx
+import structlog
+from structlog.stdlib import BoundLogger
 
 from core.canonical_models import ProvenanceRecord
+
+LOGGER: BoundLogger = structlog.get_logger(__name__)
+
+
+class FetchError(RuntimeError):
+    """Raised when the SG BCA fetcher cannot retrieve data from upstream."""
 
 
 @dataclass(slots=True)
 class FetchConfig:
-    """Configuration for the mocked fetcher."""
+    """Configuration for the SG BCA fetcher.
 
-    source_uri: str = "https://example.gov.sg/bca/mock-regulation"
+    The defaults target the public ``data.gov.sg`` datastore API.  The resource
+    identifier is not bundled with the source because it changes over time and
+    frequently requires credentials.  Use ``from_env`` to build a configuration
+    from the process environment.
+    """
+
+    base_url: str = "https://data.gov.sg/api/action/datastore_search"
+    resource_id: str | None = None
+    api_key: str | None = None
+    api_key_header: str = "api-key"
+    page_size: int = 100
+    timeout: float = 10.0
+    max_retries: int = 3
+    backoff_factor: float = 0.5
+    rate_limit_per_minute: int | None = None
+    date_field: str = "circular_date"
+    external_id_field: str = "circular_no"
+
+    @classmethod
+    def from_env(cls) -> "FetchConfig":
+        """Instantiate configuration using well-known environment variables."""
+
+        env = os.environ
+        resource_id = env.get("SG_BCA_DATASTORE_RESOURCE_ID")
+        if not resource_id:
+            raise FetchError(
+                "Missing SG_BCA_DATASTORE_RESOURCE_ID environment variable."
+            )
+
+        config = cls(
+            base_url=env.get("SG_BCA_BASE_URL", cls.base_url),
+            resource_id=resource_id,
+            api_key=env.get("SG_BCA_API_KEY"),
+            api_key_header=env.get("SG_BCA_API_KEY_HEADER", cls.api_key_header),
+            page_size=int(env.get("SG_BCA_PAGE_SIZE", cls.page_size)),
+            timeout=float(env.get("SG_BCA_TIMEOUT", cls.timeout)),
+            max_retries=int(env.get("SG_BCA_MAX_RETRIES", cls.max_retries)),
+            backoff_factor=float(env.get("SG_BCA_BACKOFF_FACTOR", cls.backoff_factor)),
+            rate_limit_per_minute=(
+                int(rate)
+                if (rate := env.get("SG_BCA_RATE_LIMIT_PER_MINUTE"))
+                else None
+            ),
+            date_field=env.get("SG_BCA_DATE_FIELD", cls.date_field),
+            external_id_field=env.get(
+                "SG_BCA_EXTERNAL_ID_FIELD", cls.external_id_field
+            ),
+        )
+        return config
 
 
 class Fetcher:
-    """Return deterministic provenance records for offline testing."""
+    """Download circular metadata from BCA and convert to provenance records."""
 
-    def __init__(self, config: FetchConfig | None = None) -> None:
-        self.config = config or FetchConfig()
+    def __init__(
+        self,
+        config: FetchConfig | None = None,
+        *,
+        transport: httpx.BaseTransport | None = None,
+        logger: BoundLogger | None = None,
+    ) -> None:
+        self.config = config or FetchConfig.from_env()
+        self._transport = transport
+        self._logger = logger or LOGGER
+        self._last_request: float | None = None
 
     def fetch_raw(self, since: date) -> List[ProvenanceRecord]:
-        """Return a single sample record newer than ``since``."""
+        """Fetch all records newer than ``since`` from the configured API."""
 
-        sample_text = (
-            "Section 1.1 Fire Safety - A smoke detector must be installed in every "
-            "residential unit to ensure compliance with fire evacuation procedures."
+        if not self.config.resource_id:
+            raise FetchError("SG BCA fetcher configured without a resource id")
+
+        since_dt = datetime.combine(since, time.min)
+        records: List[ProvenanceRecord] = []
+
+        self._logger.info(
+            "sg_bca.fetch.start", since=since.isoformat(), resource=self.config.resource_id
         )
-        return [
-            ProvenanceRecord(
-                regulation_external_id="sg-bca-2025-fire-safety",
-                source_uri=self.config.source_uri,
-                fetched_at=datetime.utcnow(),
-                fetch_parameters={"since": since.isoformat()},
-                raw_content=sample_text,
+
+        with self._create_client() as client:
+            offset = 0
+            total: int | None = None
+            while True:
+                params = {
+                    "resource_id": self.config.resource_id,
+                    "limit": self.config.page_size,
+                    "offset": offset,
+                }
+                payload = self._request_with_retry(client, params)
+                result = payload.get("result") or {}
+                rows: Sequence[MutableMapping[str, object]] = result.get(
+                    "records", []
+                )
+                if total is None:
+                    total = result.get("total")
+
+                if not rows:
+                    break
+
+                for row in rows:
+                    record = self._normalise_row(row)
+                    if not record:
+                        continue
+                    if record["issued_at"] and record["issued_at"] < since_dt:
+                        continue
+                    records.append(self._to_provenance(row, record, since))
+
+                offset += self.config.page_size
+                if total is not None and offset >= int(total):
+                    break
+
+        self._logger.info("sg_bca.fetch.complete", count=len(records))
+        return records
+
+    # ------------------------------------------------------------------
+    def _create_client(self) -> httpx.Client:
+        headers = {"User-Agent": "optimal-build/sg-bca-fetcher"}
+        if self.config.api_key and self.config.api_key_header:
+            headers[self.config.api_key_header] = self.config.api_key
+        return httpx.Client(
+            base_url=self.config.base_url,
+            headers=headers,
+            timeout=self.config.timeout,
+            transport=self._transport,
+        )
+
+    def _request_with_retry(
+        self, client: httpx.Client, params: MutableMapping[str, object]
+    ) -> dict:
+        last_exc: Exception | None = None
+        for attempt in range(1, self.config.max_retries + 1):
+            try:
+                self._enforce_rate_limit()
+                response = client.get("", params=params)
+                response.raise_for_status()
+                payload = response.json()
+                self._logger.debug(
+                    "sg_bca.fetch.page",
+                    attempt=attempt,
+                    offset=params["offset"],
+                    received=len((payload.get("result") or {}).get("records", [])),
+                )
+                return payload
+            except Exception as exc:  # pragma: no cover - exception branch
+                last_exc = exc
+                wait_time = self.config.backoff_factor * (2 ** (attempt - 1))
+                self._logger.warning(
+                    "sg_bca.fetch.retry",
+                    attempt=attempt,
+                    wait=wait_time,
+                    error=str(exc),
+                )
+                if attempt == self.config.max_retries:
+                    break
+                if wait_time > 0:
+                    time_module.sleep(wait_time)
+
+        raise FetchError("Failed to fetch SG BCA data") from last_exc
+
+    def _enforce_rate_limit(self) -> None:
+        if not self.config.rate_limit_per_minute:
+            return
+        min_interval = 60.0 / self.config.rate_limit_per_minute
+        now = time_module.monotonic()
+        if self._last_request is not None:
+            sleep_for = min_interval - (now - self._last_request)
+            if sleep_for > 0:
+                time_module.sleep(sleep_for)
+        self._last_request = time_module.monotonic()
+
+    def _normalise_row(
+        self, row: MutableMapping[str, object]
+    ) -> dict[str, datetime | str | None]:
+        issued_raw = self._coerce_str(row.get(self.config.date_field))
+        issued_at = self._parse_datetime(issued_raw)
+        external_id = self._coerce_str(row.get(self.config.external_id_field))
+        if not external_id:
+            self._logger.warning(
+                "sg_bca.fetch.row_missing_external_id", row=row
             )
-        ]
+            return {}
+        return {"issued_at": issued_at, "external_id": external_id}
+
+    def _to_provenance(
+        self,
+        row: MutableMapping[str, object],
+        normalised: dict[str, datetime | str | None],
+        since: date,
+    ) -> ProvenanceRecord:
+        source_uri = self._coerce_str(row.get("weblink")) or self.config.base_url
+        return ProvenanceRecord(
+            regulation_external_id=str(normalised["external_id"]),
+            source_uri=source_uri,
+            fetched_at=datetime.now(timezone.utc),
+            fetch_parameters={
+                "since": since.isoformat(),
+                "resource_id": self.config.resource_id,
+            },
+            raw_content=json.dumps(row, sort_keys=True, ensure_ascii=False),
+        )
+
+    @staticmethod
+    def _coerce_str(value: object) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            value = value.strip()
+            return value or None
+        return str(value)
+
+    @staticmethod
+    def _parse_datetime(value: str | None) -> datetime | None:
+        if not value:
+            return None
+        normalised = value.replace("Z", "")
+        for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S"):
+            try:
+                return datetime.strptime(normalised, fmt)
+            except ValueError:
+                continue
+        try:
+            return datetime.fromisoformat(normalised)
+        except ValueError:
+            LOGGER.warning("sg_bca.fetch.unparsed_date", raw=value)
+            return None
 
 
 def fetch(since: date) -> Iterable[ProvenanceRecord]:

--- a/jurisdictions/sg_bca/parse.py
+++ b/jurisdictions/sg_bca/parse.py
@@ -1,4 +1,4 @@
-"""Parser implementation for the Singapore BCA mock plug-in."""
+"""Parser implementation for the Singapore BCA data.gov.sg circulars feed."""
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/jurisdictions/sg_bca/tests/test_parser.py
+++ b/jurisdictions/sg_bca/tests/test_parser.py
@@ -9,15 +9,16 @@ from core import canonical_models
 from core.mapping import load_and_apply_mappings
 from core.util import create_session_factory, get_engine, session_scope
 from jurisdictions.sg_bca.parse import PARSER
+from jurisdictions.sg_bca import fetch
 
 
-def test_parse_and_persist():
+def test_parse_and_persist(monkeypatch):
     engine = get_engine("sqlite:///:memory:")
     canonical_models.RegstackBase.metadata.create_all(engine)
     session_factory = create_session_factory(engine)
 
     since = date(2025, 1, 1)
-    raw_records = list(PARSER.fetch_raw(since))
+    raw_records = list(_run_fetch(monkeypatch, since))
     regs = list(PARSER.parse(raw_records))
     mapped = load_and_apply_mappings(regs, PARSER.map_overrides_path())
 
@@ -47,3 +48,72 @@ def _persist(
     from scripts.ingest import upsert_regulations
 
     upsert_regulations(session, regs, raw_records)
+
+
+def _run_fetch(monkeypatch, since: date):
+    sample_rows = [
+        {
+            "circular_no": "2025-01",
+            "circular_date": "2025-02-02",
+            "subject": "Smoke detector requirements",
+            "weblink": "https://www1.bca.gov.sg/circulars/2025-01",
+            "description": "Section 1.1 Fire Safety - A smoke detector must be installed.",
+        },
+        {
+            "circular_no": "2024-10",
+            "circular_date": "2024-12-15",
+            "subject": "Legacy guidance",
+            "weblink": "https://www1.bca.gov.sg/circulars/2024-10",
+            "description": "Archived guidance",
+        },
+    ]
+
+    total = len(sample_rows)
+
+    class DummyResponse:
+        def __init__(self, payload: dict) -> None:
+            self._payload = payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return self._payload
+
+    class DummyClient:
+        def __init__(self, *_, **__):
+            self.calls: list[dict[str, object]] = []
+
+        def __enter__(self) -> "DummyClient":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def get(self, url: str, params: dict[str, object]):
+            self.calls.append(params)
+            offset = int(params.get("offset", 0) or 0)
+            limit = int(params.get("limit", 100) or 100)
+            page = sample_rows[offset : offset + limit]
+            return DummyResponse(
+                {
+                    "result": {
+                        "records": page,
+                        "total": total,
+                    }
+                }
+            )
+
+    test_config = fetch.FetchConfig(
+        resource_id="test-resource",
+        page_size=1,
+    )
+
+    class MockedFetcher(fetch.Fetcher):
+        def __init__(self, config: fetch.FetchConfig | None = None) -> None:
+            super().__init__(config=config or test_config)
+
+    monkeypatch.setattr(fetch, "Fetcher", MockedFetcher)
+    monkeypatch.setattr(fetch.httpx, "Client", DummyClient, raising=False)
+
+    return PARSER.fetch_raw(since)


### PR DESCRIPTION
## Summary
- replace the mock SG BCA fetcher with an HTTP client that talks to the data.gov.sg datastore API, including retries, rate limiting, and structured logs
- add environment-driven configuration for API credentials, base URL, pagination, and record parsing, plus supporting documentation
- update tests to exercise the fetcher via a stubbed HTTP client and ensure the parser continues to round-trip data

## Testing
- pytest jurisdictions/sg_bca/tests/test_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68d5f91e7df08320afe3440cbd033b8e