### PR TITLE
Improve SG BCA parser to use upstream metadata

### DIFF
--- a/jurisdictions/sg_bca/fetch.py
+++ b/jurisdictions/sg_bca/fetch.py
@@ -1,8 +1,9 @@
 """Mock fetcher for SG BCA regulations."""
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from typing import Iterable, List
 
 from core.canonical_models import ProvenanceRecord
@@ -22,19 +23,54 @@ class Fetcher:
         self.config = config or FetchConfig()
 
     def fetch_raw(self, since: date) -> List[ProvenanceRecord]:
-        """Return a single sample record newer than ``since``."""
+        """Return a representative sample record newer than ``since``."""
 
-        sample_text = (
-            "Section 1.1 Fire Safety - A smoke detector must be installed in every "
-            "residential unit to ensure compliance with fire evacuation procedures."
-        )
+        regulations = [
+            {
+                "external_id": "sg-bca-2025-fire-safety",
+                "title": "Fire Code 2025 Section 1.1 Smoke Detectors",
+                "body": (
+                    "Section 1.1 Fire Safety - A smoke detector must be installed in every "
+                    "residential unit to ensure compliance with evacuation procedures."
+                ),
+                "issued_on": "2025-01-15",
+                "effective_on": "2025-04-01",
+                "version": "2025 Edition",
+                "metadata": {
+                    "document_type": "Code of Practice",
+                    "division": "Fire Safety & Shelter Department",
+                },
+                "categories": ["Fire Safety"],
+                "keywords": ["smoke detector", "residential"],
+            },
+            {
+                "external_id": "sg-bca-2025-accessibility",
+                "title": "Universal Design Guide 2025",
+                "body": (
+                    "Chapter 2 Accessibility - Entrances must incorporate universal design "
+                    "principles to provide barrier-free access."
+                ),
+                "issued_on": "2025-02-01",
+                "effective_on": "2025-06-01",
+                "version": "2025 Edition",
+                "metadata": {
+                    "document_type": "Design Guide",
+                    "division": "Building Plan & Management Department",
+                },
+                "categories": ["Accessibility"],
+                "keywords": ["universal design", "inclusive"],
+            },
+        ]
+
+        payload = {"regulations": regulations}
+
         return [
             ProvenanceRecord(
-                regulation_external_id="sg-bca-2025-fire-safety",
+                regulation_external_id="sg-bca-batch-2025",
                 source_uri=self.config.source_uri,
-                fetched_at=datetime.utcnow(),
+                fetched_at=datetime.now(UTC),
                 fetch_parameters={"since": since.isoformat()},
-                raw_content=sample_text,
+                raw_content=json.dumps(payload),
             )
         ]
 

--- a/jurisdictions/sg_bca/parse.py
+++ b/jurisdictions/sg_bca/parse.py
@@ -1,15 +1,21 @@
 """Parser implementation for the Singapore BCA mock plug-in."""
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Iterable, List
+from typing import Dict, Iterable, List, Sequence, Set
 
 from core.canonical_models import CanonicalReg, ProvenanceRecord
+from core.mapping import GLOBAL_MAPPING_FILE, load_yaml, merge_mappings
 from core.registry import JurisdictionParser
 
 from . import fetch
+
+
+class ParserError(RuntimeError):
+    """Raised when the upstream payload cannot be transformed."""
 
 
 @dataclass(slots=True)
@@ -22,22 +28,260 @@ class SGBCAPARSER:
         return fetch.fetch(since)
 
     def parse(self, records: Iterable[ProvenanceRecord]) -> Iterable[CanonicalReg]:
+        keyword_index = self._build_keyword_index()
         regulations: List[CanonicalReg] = []
         for record in records:
-            regulations.append(
-                CanonicalReg(
-                    jurisdiction_code=self.code,
-                    external_id=record.regulation_external_id,
-                    title="Smoke detector requirements",
-                    text=record.raw_content,
-                    metadata={"source_uri": record.source_uri},
-                    global_tags=["fire_safety"],
+            payload = self._load_payload(record)
+            for index, upstream in enumerate(payload, start=1):
+                regulation = self._convert_regulation(
+                    record, upstream, index, keyword_index
                 )
-            )
+                regulations.append(regulation)
         return regulations
 
     def map_overrides_path(self) -> Path | None:
         return Path(__file__).resolve().parent / "map_overrides.yaml"
+
+    # ------------------------------------------------------------------
+    # Helpers
+    def _load_payload(self, record: ProvenanceRecord) -> List[Dict]:
+        """Deserialize a provenance payload into a list of regulations."""
+
+        try:
+            raw_payload = json.loads(record.raw_content)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise ParserError(
+                " | ".join(
+                    [
+                        f"Record {record.regulation_external_id} contains invalid JSON",
+                        f"error: {exc.msg}",
+                    ]
+                )
+            ) from exc
+
+        if isinstance(raw_payload, dict):
+            for key in ("regulations", "results", "items", "documents"):
+                candidate = raw_payload.get(key)
+                if isinstance(candidate, list):
+                    raw_payload = candidate
+                    break
+            else:
+                raise ParserError(
+                    f"Record {record.regulation_external_id} is missing a 'regulations' list"
+                )
+
+        if not isinstance(raw_payload, list):
+            raise ParserError(
+                f"Record {record.regulation_external_id} payload must be a list of regulations"
+            )
+
+        typed_payload: List[Dict] = []
+        for idx, item in enumerate(raw_payload, start=1):
+            if not isinstance(item, dict):
+                raise ParserError(
+                    f"Record {record.regulation_external_id} regulation #{idx} must be a mapping"
+                )
+            typed_payload.append(item)
+        return typed_payload
+
+    def _convert_regulation(
+        self,
+        record: ProvenanceRecord,
+        upstream: Dict,
+        index: int,
+        keyword_index: Dict[str, Set[str]],
+    ) -> CanonicalReg:
+        """Transform an upstream regulation payload into a canonical record."""
+
+        external_id = self._require_str_field(
+            upstream, "external_id", record, index
+        )
+        title = self._require_str_field(upstream, "title", record, index)
+        text = upstream.get("body") or upstream.get("text") or upstream.get("content")
+        if not isinstance(text, str) or not text.strip():
+            raise ParserError(
+                self._error_prefix(record, index, upstream)
+                + "missing mandatory field 'body/text'"
+            )
+
+        issued_on = self._parse_date_field(
+            upstream.get("issued_on") or upstream.get("issued"),
+            "issued_on",
+            record,
+            upstream,
+            index,
+        )
+        effective_on = self._parse_date_field(
+            upstream.get("effective_on") or upstream.get("effective"),
+            "effective_on",
+            record,
+            upstream,
+            index,
+        )
+
+        version = upstream.get("version") or upstream.get("revision")
+        if version is not None and not isinstance(version, str):
+            raise ParserError(
+                self._error_prefix(record, index, upstream)
+                + "expected 'version' to be a string"
+            )
+
+        categories = self._coerce_list_of_str(
+            upstream.get("categories"), "categories", record, upstream, index
+        )
+        keywords = self._coerce_list_of_str(
+            upstream.get("keywords"), "keywords", record, upstream, index
+        )
+
+        metadata_payload = upstream.get("metadata") or {}
+        if not isinstance(metadata_payload, dict):
+            raise ParserError(
+                self._error_prefix(record, index, upstream)
+                + "expected 'metadata' to be an object"
+            )
+
+        metadata = dict(metadata_payload)
+        if categories:
+            metadata["upstream_categories"] = categories
+        if keywords:
+            metadata["upstream_keywords"] = keywords
+        metadata.setdefault("source_uri", record.source_uri)
+        metadata["provenance_record_id"] = record.regulation_external_id
+        if record.fetch_parameters:
+            metadata.setdefault("fetch_parameters", record.fetch_parameters)
+
+        tags = self._map_tags(categories, keywords, keyword_index)
+
+        return CanonicalReg(
+            jurisdiction_code=self.code,
+            external_id=external_id,
+            title=title,
+            text=text,
+            issued_on=issued_on,
+            effective_on=effective_on,
+            version=version,
+            metadata=metadata,
+            global_tags=tags,
+        )
+
+    def _require_str_field(
+        self,
+        payload: Dict,
+        field: str,
+        record: ProvenanceRecord,
+        index: int,
+    ) -> str:
+        value = payload.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise ParserError(
+                self._error_prefix(record, index, payload)
+                + f"missing mandatory field '{field}'"
+            )
+        return value.strip()
+
+    def _parse_date_field(
+        self,
+        raw_value: object,
+        field: str,
+        record: ProvenanceRecord,
+        payload: Dict,
+        index: int,
+    ) -> date | None:
+        if raw_value in (None, ""):
+            return None
+        if not isinstance(raw_value, str):
+            raise ParserError(
+                self._error_prefix(record, index, payload)
+                + f"expected '{field}' to be an ISO formatted string"
+            )
+        try:
+            return date.fromisoformat(raw_value)
+        except ValueError as exc:
+            raise ParserError(
+                self._error_prefix(record, index, payload)
+                + f"invalid '{field}' value '{raw_value}': expected ISO date"
+            ) from exc
+
+    def _coerce_list_of_str(
+        self,
+        raw_values: object,
+        field: str,
+        record: ProvenanceRecord,
+        payload: Dict,
+        index: int,
+    ) -> List[str]:
+        if raw_values is None:
+            return []
+        if not isinstance(raw_values, Sequence) or isinstance(raw_values, (str, bytes)):
+            raise ParserError(
+                self._error_prefix(record, index, payload)
+                + f"expected '{field}' to be an array of strings"
+            )
+        values: List[str] = []
+        for position, value in enumerate(raw_values, start=1):
+            if not isinstance(value, str) or not value.strip():
+                raise ParserError(
+                    self._error_prefix(record, index, payload)
+                    + f"expected '{field}'[{position}] to be a non-empty string"
+                )
+            values.append(value.strip())
+        return values
+
+    def _build_keyword_index(self) -> Dict[str, Set[str]]:
+        override_path = self.map_overrides_path()
+        global_map = load_yaml(GLOBAL_MAPPING_FILE)
+        override_map: Dict = {}
+        if override_path is not None:
+            override_map = load_yaml(override_path)
+        merged = merge_mappings(global_map, override_map)
+
+        categories = merged.get("categories", {})
+        keyword_index: Dict[str, Set[str]] = {}
+        for key, payload in categories.items():
+            keywords = set()
+            for keyword in payload.get("keywords", []) or []:
+                if isinstance(keyword, str):
+                    keywords.add(keyword.lower())
+            keywords.add(key.lower())
+            keywords.add(key.replace("_", " ").lower())
+            keyword_index[key] = keywords
+        return keyword_index
+
+    def _map_tags(
+        self,
+        categories: Sequence[str],
+        keywords: Sequence[str],
+        keyword_index: Dict[str, Set[str]],
+    ) -> List[str]:
+        tags: Set[str] = set()
+        normalized_terms = [value.lower() for value in (*categories, *keywords)]
+
+        for category in categories:
+            slug = category.lower().replace("-", "_").replace(" ", "_")
+            if slug in keyword_index:
+                tags.add(slug)
+
+        for canonical, known_keywords in keyword_index.items():
+            for term in normalized_terms:
+                for keyword in known_keywords:
+                    if keyword in term or term in keyword:
+                        tags.add(canonical)
+                        break
+                if canonical in tags:
+                    break
+
+        return sorted(tags)
+
+    def _error_prefix(
+        self,
+        record: ProvenanceRecord,
+        index: int,
+        payload: Dict,
+    ) -> str:
+        reference = payload.get("external_id")
+        if isinstance(reference, str) and reference:
+            return f"Record {record.regulation_external_id} ({reference}): "
+        return f"Record {record.regulation_external_id} regulation #{index}: "
 
 
 PARSER: JurisdictionParser = SGBCAPARSER()

--- a/jurisdictions/sg_bca/tests/test_parser.py
+++ b/jurisdictions/sg_bca/tests/test_parser.py
@@ -1,14 +1,16 @@
 """Tests for the SG BCA plug-in."""
 from __future__ import annotations
 
-from datetime import date
+import json
+from datetime import UTC, date, datetime
 
+import pytest
 from sqlalchemy import select
 
 from core import canonical_models
 from core.mapping import load_and_apply_mappings
 from core.util import create_session_factory, get_engine, session_scope
-from jurisdictions.sg_bca.parse import PARSER
+from jurisdictions.sg_bca.parse import PARSER, ParserError
 
 
 def test_parse_and_persist():
@@ -19,6 +21,25 @@ def test_parse_and_persist():
     since = date(2025, 1, 1)
     raw_records = list(PARSER.fetch_raw(since))
     regs = list(PARSER.parse(raw_records))
+
+    assert len(regs) == 2
+
+    fire = next(reg for reg in regs if reg.external_id == "sg-bca-2025-fire-safety")
+    access = next(
+        reg for reg in regs if reg.external_id == "sg-bca-2025-accessibility"
+    )
+
+    assert fire.title == "Fire Code 2025 Section 1.1 Smoke Detectors"
+    assert fire.issued_on == date(2025, 1, 15)
+    assert fire.effective_on == date(2025, 4, 1)
+    assert fire.version == "2025 Edition"
+    assert fire.metadata["division"] == "Fire Safety & Shelter Department"
+    assert fire.metadata["source_uri"] == raw_records[0].source_uri
+    assert fire.metadata["upstream_keywords"] == ["smoke detector", "residential"]
+    assert fire.global_tags == ["fire_safety"]
+
+    assert access.global_tags == ["accessibility"]
+
     mapped = load_and_apply_mappings(regs, PARSER.map_overrides_path())
 
     with session_scope(session_factory) as session:
@@ -29,14 +50,13 @@ def test_parse_and_persist():
 
     with session_scope(session_factory) as session:
         stored = session.execute(
-            select(canonical_models.RegulationORM).limit(1)
-        ).scalar_one()
-        count = len(
-            session.execute(select(canonical_models.RegulationORM)).all()
-        )
+            select(canonical_models.RegulationORM)
+        ).scalars().all()
 
-    assert count == 1
-    assert stored.global_tags == ["fire_safety"]
+    assert len(stored) == 2
+    tags_by_external = {row.external_id: row.global_tags for row in stored}
+    assert tags_by_external["sg-bca-2025-fire-safety"] == ["fire_safety"]
+    assert tags_by_external["sg-bca-2025-accessibility"] == ["accessibility"]
 
 
 def _persist(
@@ -47,3 +67,19 @@ def _persist(
     from scripts.ingest import upsert_regulations
 
     upsert_regulations(session, regs, raw_records)
+
+
+def test_parse_missing_mandatory_field() -> None:
+    payload = {"regulations": [{"external_id": "sg-bca-test", "body": "text"}]}
+    record = canonical_models.ProvenanceRecord(
+        regulation_external_id="batch",
+        source_uri="https://example.gov.sg/bca/mock-regulation",
+        fetched_at=datetime.now(UTC),
+        fetch_parameters={},
+        raw_content=json.dumps(payload),
+    )
+
+    with pytest.raises(ParserError) as excinfo:
+        list(PARSER.parse([record]))
+
+    assert "missing mandatory field 'title'" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- parse the SG BCA payload to extract regulation metadata, dates, versions, and map categories/keywords into global tags with helpful validation errors
- update the mock fetcher to emit a realistic multi-regulation payload used by the parser
- extend the SG BCA parser tests to cover metadata propagation, persistence, and error handling

## Testing
- pytest jurisdictions/sg_bca/tests/test_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68d5f9210c088320b3c4bb55ad149d8d