### PR TITLE
Add SG BCA fixtures and regression tests

### DIFF
--- a/jurisdictions/sg_bca/tests/fixtures/datastore_page_1.json
+++ b/jurisdictions/sg_bca/tests/fixtures/datastore_page_1.json
@@ -1,0 +1,36 @@
+{
+  "help": "https://data.gov.sg/api/3/action/help_show?name=datastore_search",
+  "success": true,
+  "result": {
+    "resource_id": "realistic-resource-id",
+    "records": [
+      {
+        "circular_no": "2025-04",
+        "circular_date": "2025-04-10",
+        "effective_date": "2025-05-01",
+        "subject": "Revisions to accessible fire exits",
+        "weblink": "https://www1.bca.gov.sg/circulars/2025-04",
+        "description": "Section 1.1 Fire Safety - ensure accessible fire exits are available on every floor.",
+        "version": "Revision 4",
+        "category": "Fire Safety",
+        "keywords": ["Universal Design", "Accessibility"],
+        "tags": "Fire Safety;Accessibility",
+        "agency": "Building and Construction Authority"
+      },
+      {
+        "circular_no": "2025-03",
+        "circular_date": "2025-03-12",
+        "effective_date": "2025-03-20",
+        "subject": "Updated inspection regime for mechanical ventilation",
+        "description": "Monthly inspections are now required for all mechanical ventilation systems.",
+        "weblink": "https://www1.bca.gov.sg/circulars/2025-03",
+        "categories": ["Compliance", "Fire Safety"],
+        "document_type": "Circular",
+        "topic": "Inspection"
+      }
+    ],
+    "total": 3,
+    "offset": 0,
+    "limit": 2
+  }
+}

--- a/jurisdictions/sg_bca/tests/fixtures/datastore_page_2.json
+++ b/jurisdictions/sg_bca/tests/fixtures/datastore_page_2.json
@@ -1,0 +1,25 @@
+{
+  "help": "https://data.gov.sg/api/3/action/help_show?name=datastore_search",
+  "success": true,
+  "result": {
+    "resource_id": "realistic-resource-id",
+    "records": [
+      {
+        "circular_no": "",
+        "circular_date": "2025-01-15",
+        "subject": "Record missing identifier",
+        "description": "This circular is missing the circular number and should be skipped."
+      },
+      {
+        "circular_no": "2024-12",
+        "circular_date": "2024-12-15",
+        "subject": "Legacy guidance to be archived",
+        "description": "This record predates the fetch window and should not appear in results.",
+        "weblink": "https://www1.bca.gov.sg/circulars/2024-12"
+      }
+    ],
+    "total": 3,
+    "offset": 2,
+    "limit": 2
+  }
+}


### PR DESCRIPTION
## Summary
- add recorded SG BCA datastore fixtures for exercising the fetcher and parser
- harden the fetcher to validate response structure before emitting provenance records
- cover happy path, credential failure, malformed payload, and ingestion dedupe behaviour in new tests

## Testing
- pytest jurisdictions/sg_bca/tests

------
https://chatgpt.com/codex/tasks/task_e_68d60d7c2b0083208e77336671339b54