### PR TITLE
Ensure CAD upload requests set X-Role header

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -402,9 +402,13 @@ export class ApiClient {
       formData.append('infer_walls', 'true')
     }
 
+    const headers = new Headers()
+    headers.set('X-Role', this.defaultRole ?? 'admin')
+
     const response = await fetch(this.buildUrl('api/v1/import'), {
       method: 'POST',
       body: formData,
+      headers,
     })
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- add explicit header handling for CAD upload requests
- ensure the X-Role header is set using the default role or admin fallback

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d67c266be08320a9a308066074ba1d