### PR TITLE
Update default API role fallback

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -276,7 +276,7 @@ export class ApiClient {
     const roleCandidates = [
       import.meta.env?.VITE_API_ROLE,
       typeof window !== 'undefined' ? window.localStorage?.getItem('app:api-role') ?? undefined : undefined,
-      'reviewer',
+      'admin',
     ] as Array<string | undefined>
 
     this.defaultRole =


### PR DESCRIPTION
## Summary
- update the ApiClient default role fallback to use `admin`
- retain the existing environment and localStorage precedence so related helpers continue to function

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d67c2842608320b099d19e6234ffc8