### PR TITLE
Add optional jurisdiction display names to ingestion pipeline

### DIFF
--- a/core/registry.py
+++ b/core/registry.py
@@ -15,6 +15,7 @@ class JurisdictionParser(Protocol):
     """Protocol describing jurisdiction plug-ins."""
 
     code: str
+    display_name: str | None
 
     def fetch_raw(self, since: date) -> Iterable[ProvenanceRecord]:
         """Return raw regulation payloads with provenance metadata."""
@@ -32,6 +33,7 @@ class RegisteredJurisdiction:
 
     code: str
     parser: JurisdictionParser
+    display_name: str | None = None
 
 
 class RegistryError(RuntimeError):
@@ -65,4 +67,5 @@ def load_jurisdiction(code: str) -> RegisteredJurisdiction:
                 f"Jurisdiction '{code}' is missing required attributes: {missing_attrs}"
             )
 
-    return RegisteredJurisdiction(code=code, parser=parser)
+    display_name = getattr(parser, "display_name", None)
+    return RegisteredJurisdiction(code=code, parser=parser, display_name=display_name)

--- a/core/tests/test_registry_display_name.py
+++ b/core/tests/test_registry_display_name.py
@@ -1,0 +1,31 @@
+"""Tests for jurisdiction metadata handling during ingestion."""
+
+from __future__ import annotations
+
+from core import canonical_models
+from core.registry import load_jurisdiction
+from scripts.ingest import ensure_jurisdiction
+from core.util import create_session_factory, get_engine
+from sqlalchemy import select
+
+
+def test_ensure_jurisdiction_uses_display_name() -> None:
+    """Ensure friendly parser names are persisted to the database."""
+
+    registered = load_jurisdiction("sg_bca")
+    engine = get_engine("sqlite:///:memory:")
+    session_factory = create_session_factory(engine)
+    canonical_models.RegstackBase.metadata.create_all(engine)
+
+    session = session_factory()
+    try:
+        ensure_jurisdiction(session, registered.parser)
+        stored = session.execute(
+            select(canonical_models.JurisdictionORM)
+            .where(canonical_models.JurisdictionORM.code == registered.parser.code)
+        ).scalar_one()
+    finally:
+        if hasattr(session, "close"):
+            session.close()
+
+    assert stored.name == getattr(registered.parser, "display_name")

--- a/jurisdictions/sg_bca/parse.py
+++ b/jurisdictions/sg_bca/parse.py
@@ -24,6 +24,7 @@ class SGBCAPARSER:
     """Concrete parser for the SG BCA jurisdiction."""
 
     code: str = "sg_bca"
+    display_name: str = "Singapore Building and Construction Authority"
     _mapping_definition: dict | None = field(default=None, init=False, repr=False)
 
     def fetch_raw(self, since: date) -> Iterable[ProvenanceRecord]:


### PR DESCRIPTION
## Summary
- allow jurisdiction parsers to declare an optional display name in the registry
- persist parser display names when seeding jurisdictions during ingestion
- expose the Singapore BCA display name and cover it with a regression test

## Testing
- pytest core/tests/test_registry_display_name.py

------
https://chatgpt.com/codex/tasks/task_e_68d686fe10348320a3ce639b3087a80c