### PR TITLE
Handle missing jurisdiction display names

### DIFF
--- a/core/tests/test_registry_display_name.py
+++ b/core/tests/test_registry_display_name.py
@@ -29,3 +29,38 @@ def test_ensure_jurisdiction_uses_display_name() -> None:
             session.close()
 
     assert stored.name == getattr(registered.parser, "display_name")
+
+
+def test_ensure_jurisdiction_falls_back_to_uppercase_code() -> None:
+    """Parsers without display names should fall back to uppercase codes."""
+
+    class DummyParser:
+        code = "xx"
+        display_name = None
+
+        def fetch_raw(self, since):  # pragma: no cover - not used in test
+            raise NotImplementedError
+
+        def parse(self, records):  # pragma: no cover - not used in test
+            raise NotImplementedError
+
+        def map_overrides_path(self):  # pragma: no cover - not used in test
+            return None
+
+    engine = get_engine("sqlite:///:memory:")
+    session_factory = create_session_factory(engine)
+    canonical_models.RegstackBase.metadata.create_all(engine)
+
+    session = session_factory()
+    try:
+        ensure_jurisdiction(session, DummyParser())
+        stored = session.execute(
+            select(canonical_models.JurisdictionORM).where(
+                canonical_models.JurisdictionORM.code == "xx"
+            )
+        ).scalar_one()
+    finally:
+        if hasattr(session, "close"):
+            session.close()
+
+    assert stored.name == "XX"

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -54,7 +54,9 @@ def ensure_jurisdiction(session, parser: JurisdictionParser) -> None:
         session.add(
             canonical_models.JurisdictionORM(
                 code=parser.code,
-                name=getattr(parser, "display_name", parser.code.upper()),
+                name=(
+                    getattr(parser, "display_name", None) or parser.code.upper()
+                ),
             )
         )
 


### PR DESCRIPTION
## Summary
- fall back to the parser code when no display name is provided during ingestion
- add a regression test ensuring jurisdictions default to an uppercase code

## Testing
- pytest core/tests/test_registry_display_name.py

------
https://chatgpt.com/codex/tasks/task_e_68d68aee8fc88320a232c5701260e29c