### PR TITLE
Ensure jurisdictions fall back to uppercase names

### DIFF
--- a/core/tests/test_registry_display_name.py
+++ b/core/tests/test_registry_display_name.py
@@ -64,3 +64,37 @@ def test_ensure_jurisdiction_falls_back_to_uppercase_code() -> None:
             session.close()
 
     assert stored.name == "XX"
+
+
+def test_ensure_jurisdiction_handles_missing_display_name_attribute() -> None:
+    """Parsers that omit ``display_name`` should still be uppercased."""
+
+    class DummyParser:
+        code = "yy"
+
+        def fetch_raw(self, since):  # pragma: no cover - not used in test
+            raise NotImplementedError
+
+        def parse(self, records):  # pragma: no cover - not used in test
+            raise NotImplementedError
+
+        def map_overrides_path(self):  # pragma: no cover - not used in test
+            return None
+
+    engine = get_engine("sqlite:///:memory:")
+    session_factory = create_session_factory(engine)
+    canonical_models.RegstackBase.metadata.create_all(engine)
+
+    session = session_factory()
+    try:
+        ensure_jurisdiction(session, DummyParser())
+        stored = session.execute(
+            select(canonical_models.JurisdictionORM).where(
+                canonical_models.JurisdictionORM.code == "yy"
+            )
+        ).scalar_one()
+    finally:
+        if hasattr(session, "close"):
+            session.close()
+
+    assert stored.name == "YY"

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -51,12 +51,13 @@ def ensure_jurisdiction(session, parser: JurisdictionParser) -> None:
         canonical_models.JurisdictionORM.code == parser.code
     )
     if not session.execute(stmt).scalar_one_or_none():
+        display_name = getattr(parser, "display_name", None)
+        name = display_name or parser.code.upper()
+
         session.add(
             canonical_models.JurisdictionORM(
                 code=parser.code,
-                name=(
-                    getattr(parser, "display_name", None) or parser.code.upper()
-                ),
+                name=name,
             )
         )
 


### PR DESCRIPTION
## Summary
- ensure `ensure_jurisdiction` derives a non-null name when the parser omits a display name
- add regression coverage for parsers that provide `None` or omit `display_name`

## Testing
- pytest core/tests/test_registry_display_name.py

------
https://chatgpt.com/codex/tasks/task_e_68d6929a0da88320be61e961eddf37c3