### PR TITLE
Ensure ensure_jurisdiction falls back when display_name is None

### DIFF
--- a/core/tests/test_registry_display_name.py
+++ b/core/tests/test_registry_display_name.py
@@ -66,6 +66,43 @@ def test_ensure_jurisdiction_falls_back_to_uppercase_code() -> None:
     assert stored.name == "XX"
 
 
+def test_ensure_jurisdiction_treats_none_display_name_as_missing() -> None:
+    """Explicit ``None`` values should also trigger the uppercase fallback."""
+
+    class DummyParser:
+        code = "zz"
+
+        def __init__(self) -> None:
+            self.display_name = None
+
+        def fetch_raw(self, since):  # pragma: no cover - not used in test
+            raise NotImplementedError
+
+        def parse(self, records):  # pragma: no cover - not used in test
+            raise NotImplementedError
+
+        def map_overrides_path(self):  # pragma: no cover - not used in test
+            return None
+
+    engine = get_engine("sqlite:///:memory:")
+    session_factory = create_session_factory(engine)
+    canonical_models.RegstackBase.metadata.create_all(engine)
+
+    session = session_factory()
+    try:
+        ensure_jurisdiction(session, DummyParser())
+        stored = session.execute(
+            select(canonical_models.JurisdictionORM).where(
+                canonical_models.JurisdictionORM.code == "zz"
+            )
+        ).scalar_one()
+    finally:
+        if hasattr(session, "close"):
+            session.close()
+
+    assert stored.name == "ZZ"
+
+
 def test_ensure_jurisdiction_handles_missing_display_name_attribute() -> None:
     """Parsers that omit ``display_name`` should still be uppercased."""
 

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -51,8 +51,7 @@ def ensure_jurisdiction(session, parser: JurisdictionParser) -> None:
         canonical_models.JurisdictionORM.code == parser.code
     )
     if not session.execute(stmt).scalar_one_or_none():
-        display_name = getattr(parser, "display_name", None)
-        name = display_name or parser.code.upper()
+        name = getattr(parser, "display_name", None) or parser.code.upper()
 
         session.add(
             canonical_models.JurisdictionORM(


### PR DESCRIPTION
## Summary
- ensure ensure_jurisdiction derives a fallback name when a parser exposes display_name=None
- add coverage to confirm explicit None display names use the uppercase code

## Testing
- pytest core/tests/test_registry_display_name.py

------
https://chatgpt.com/codex/tasks/task_e_68d6960a89948320b858a538aaf8442f