### PR TITLE
Add fixture-backed SG BCA fetcher tests

### DIFF
--- a/jurisdictions/sg_bca/tests/fixtures/datastore_malformed_records.json
+++ b/jurisdictions/sg_bca/tests/fixtures/datastore_malformed_records.json
@@ -1,0 +1,11 @@
+{
+  "help": "https://data.gov.sg/api/3/action/help_show?name=datastore_search",
+  "success": true,
+  "result": {
+    "resource_id": "realistic-resource-id",
+    "records": "This should have been a list of records",
+    "total": 1,
+    "offset": 0,
+    "limit": 100
+  }
+}

--- a/jurisdictions/sg_bca/tests/fixtures/datastore_unauthorized.json
+++ b/jurisdictions/sg_bca/tests/fixtures/datastore_unauthorized.json
@@ -1,0 +1,9 @@
+{
+  "help": "https://data.gov.sg/api/3/action/help_show?name=datastore_search",
+  "success": false,
+  "error": {
+    "__type": "Authorization Error",
+    "message": "Invalid API key provided",
+    "info": "You do not have access to this resource."
+  }
+}


### PR DESCRIPTION
## Summary
- add recorded datastore fixtures for unauthorized and malformed responses
- update SG BCA fetcher error handling tests to use the new fixtures
- strengthen ingestion deduplication assertions to verify regulation and provenance counts

## Testing
- pytest jurisdictions/sg_bca/tests/test_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68d699b0efb0832092c7b21001b78c3a