### PR TITLE
Handle aggregated SG BCA payloads

### DIFF
--- a/jurisdictions/sg_bca/tests/test_parser.py
+++ b/jurisdictions/sg_bca/tests/test_parser.py
@@ -54,6 +54,34 @@ def test_fetcher_and_parser_against_recorded_fixtures(monkeypatch):
     assert second.global_tags == ["fire_safety"]
 
 
+def test_parser_iterates_all_regulations_from_page_payload():
+    payload = _load_fixture("datastore_page_1.json")
+    record = canonical_models.ProvenanceRecord(
+        regulation_external_id="page-1",
+        source_uri="https://data.gov.sg/api/action/datastore_search",
+        fetched_at=datetime(2025, 4, 12, 10, 0, 0, tzinfo=timezone.utc),
+        fetch_parameters={"offset": 0},
+        raw_content=json.dumps(payload),
+    )
+
+    regulations = list(PARSER.parse([record]))
+
+    assert [reg.external_id for reg in regulations] == ["2025-04", "2025-03"]
+
+    first = regulations[0]
+    assert first.title == "Revisions to accessible fire exits"
+    assert first.issued_on == date(2025, 4, 10)
+    assert first.effective_on == date(2025, 5, 1)
+    assert first.version == "Revision 4"
+    assert first.metadata["source_uri"] == "https://www1.bca.gov.sg/circulars/2025-04"
+    assert first.metadata["category"] == "Fire Safety"
+    assert first.global_tags == ["accessibility", "fire_safety"]
+
+    second = regulations[1]
+    assert second.metadata["source_uri"] == "https://www1.bca.gov.sg/circulars/2025-03"
+    assert second.global_tags == ["fire_safety"]
+
+
 def test_fetcher_raises_for_bad_credentials(monkeypatch):
     class UnauthorizedResponse:
         status_code = 401
@@ -127,6 +155,24 @@ def test_fetcher_rejects_malformed_payload(monkeypatch):
         fixture_fetcher.fetch_raw(date(2025, 1, 1))
 
     assert "json object" in str(excinfo.value).lower()
+
+
+def test_parser_reports_missing_external_identifier_from_page_payload():
+    payload = _load_fixture("datastore_page_2.json")
+    record = canonical_models.ProvenanceRecord(
+        regulation_external_id="page-2",
+        source_uri="https://data.gov.sg/api/action/datastore_search",
+        fetched_at=datetime(2025, 4, 12, 10, 5, 0, tzinfo=timezone.utc),
+        fetch_parameters={"offset": 2},
+        raw_content=json.dumps(payload),
+    )
+
+    with pytest.raises(ParserError) as excinfo:
+        list(PARSER.parse([record]))
+
+    message = str(excinfo.value)
+    assert "missing a circular number" in message
+    assert "page-2 result.records[0]" in message
 
 
 def test_fetcher_normalises_timezone_aware_issue_dates(monkeypatch):


### PR DESCRIPTION
## Summary
- update the SG BCA parser to handle page-level payloads, extract upstream metadata, and surface clear validation errors
- normalise upstream categories/keywords into global tags with mapping overrides and richer metadata
- expand parser tests to cover aggregated records and error scenarios

## Testing
- pytest jurisdictions/sg_bca/tests/test_parser.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d699af161c8320820a48516201f7e6