### PR TITLE
Fix stub routing fallbacks for enhanced upload tests

### DIFF
--- a/backend/starlette/__init__.py
+++ b/backend/starlette/__init__.py
@@ -1,22 +1,57 @@
-"""Expose Starlette via a bundled stub when available, fall back to the real package."""
+"""Expose Starlette by deferring to the installed package or the vendored stub."""
 
 from __future__ import annotations
 
+import importlib
+import pkgutil
+import sys
+from pathlib import Path
 from types import ModuleType
 
-import sys
+from backend._stub_loader import import_runtime_dependency
 
-from backend._stub_loader import load_optional_package
+_SHADOW_PREFIX = "starlette_shadow_"
 
 
-def _load_module() -> ModuleType:
-    return load_optional_package(
-        __name__,
-        "starlette",
-        "Starlette",
+def _load_runtime_distribution() -> ModuleType | None:
+    try:
+        return import_runtime_dependency("starlette", "Starlette")
+    except ModuleNotFoundError:
+        return None
+
+
+def _load_shadow_stub() -> ModuleType:
+    search_root = Path(__file__).resolve().parents[2]
+    candidates = sorted(
+        name
+        for _, name, _ in pkgutil.iter_modules([str(search_root)])
+        if name.startswith(_SHADOW_PREFIX)
     )
+    if not candidates:
+        raise ModuleNotFoundError(
+            "Starlette is not installed and no starlette_shadow_* stub directory was found"
+        )
+    return importlib.import_module(candidates[0])
 
 
-_starlette = _load_module()
-globals().update(_starlette.__dict__)
-sys.modules[__name__] = _starlette
+_module = _load_runtime_distribution() or _load_shadow_stub()
+globals().update(_module.__dict__)
+sys.modules[__name__] = _module
+
+if _module.__name__ != __name__:
+    shadow_prefix = f"{_module.__name__}."
+    canonical_prefix = f"{__name__}."
+    for module_name, module in list(sys.modules.items()):
+        if not module_name.startswith(shadow_prefix):
+            continue
+        canonical_name = canonical_prefix + module_name[len(shadow_prefix) :]
+        sys.modules.setdefault(canonical_name, module)
+
+del ModuleType
+del Path
+del importlib
+del pkgutil
+del _SHADOW_PREFIX
+del _module
+del _load_runtime_distribution
+del _load_shadow_stub

--- a/backend/tests/test_yosai/test_enhanced_upload_router.py
+++ b/backend/tests/test_yosai/test_enhanced_upload_router.py
@@ -1,0 +1,81 @@
+"""Regression tests for the enhanced upload router audit logging."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    "backend.yosai_intel_dashboard.src.adapters.api.routes.enhanced_upload_router"
+)
+
+
+def _reload_router_module() -> None:
+    sys.modules.pop(MODULE_PATH, None)
+    importlib.import_module(MODULE_PATH)
+
+
+def test_router_import_does_not_touch_read_only_filesystem(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Importing the router must not attempt filesystem writes."""
+
+    monkeypatch.delenv("ENHANCED_UPLOAD_AUDIT_DB", raising=False)
+    monkeypatch.delenv("ENHANCED_UPLOAD_AUDIT_DIR", raising=False)
+
+    def _fail_write_bytes(self: Path, data: bytes) -> None:  # pragma: no cover - defensive
+        raise PermissionError("Filesystem is read-only")
+
+    monkeypatch.setattr(Path, "write_bytes", _fail_write_bytes, raising=True)
+
+    def _fail_connect(*_args, **_kwargs) -> sqlite3.Connection:  # pragma: no cover - defensive
+        raise AssertionError("sqlite3.connect should not be invoked during module import")
+
+    monkeypatch.setattr(sqlite3, "connect", _fail_connect)
+
+    _reload_router_module()
+
+
+@pytest.mark.parametrize("env_var", ["ENHANCED_UPLOAD_AUDIT_DB", "ENHANCED_UPLOAD_AUDIT_DIR"])
+def test_audit_records_persist_to_configured_location(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, env_var: str
+) -> None:
+    """Audit records persist to the configured writable location."""
+
+    db_dir = tmp_path / "audit"
+    db_dir.mkdir()
+    db_path = db_dir / "custom.db"
+
+    monkeypatch.setenv(env_var, str(db_path if env_var.endswith("_DB") else db_dir))
+
+    module = importlib.import_module(MODULE_PATH)
+    module.reset_audit_logger_cache()
+
+    logger = module.get_audit_logger()
+    logger.log_upload_event(
+        actor="alice",
+        filename="layout.pdf",
+        status="accepted",
+        payload={"project_id": 42},
+    )
+
+    resolved = module.resolve_audit_db_path()
+    assert resolved.exists()
+    assert resolved == db_path if env_var.endswith("_DB") else db_dir / "enhanced_upload_audit.db"
+
+    with sqlite3.connect(resolved) as connection:
+        connection.row_factory = sqlite3.Row
+        row = connection.execute(
+            "SELECT actor, filename, status, payload FROM enhanced_upload_audit"
+        ).fetchone()
+
+    assert row["actor"] == "alice"
+    assert row["filename"] == "layout.pdf"
+    assert row["status"] == "accepted"
+    assert json.loads(row["payload"]) == {"project_id": 42}
+
+    module.reset_audit_logger_cache()
+

--- a/backend/yosai_intel_dashboard/__init__.py
+++ b/backend/yosai_intel_dashboard/__init__.py
@@ -1,0 +1,5 @@
+"""Yosai Intel Dashboard backend package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.0.0"

--- a/backend/yosai_intel_dashboard/src/__init__.py
+++ b/backend/yosai_intel_dashboard/src/__init__.py
@@ -1,0 +1,1 @@
+"""Source package for the Yosai Intel Dashboard backend."""

--- a/backend/yosai_intel_dashboard/src/adapters/__init__.py
+++ b/backend/yosai_intel_dashboard/src/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Adapters for the Yosai Intel Dashboard API."""

--- a/backend/yosai_intel_dashboard/src/adapters/api/__init__.py
+++ b/backend/yosai_intel_dashboard/src/adapters/api/__init__.py
@@ -1,0 +1,1 @@
+"""API layer for the Yosai Intel Dashboard."""

--- a/backend/yosai_intel_dashboard/src/adapters/api/routes/__init__.py
+++ b/backend/yosai_intel_dashboard/src/adapters/api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""Route registrations for the Yosai Intel Dashboard API."""

--- a/backend/yosai_intel_dashboard/src/adapters/api/routes/enhanced_upload_router.py
+++ b/backend/yosai_intel_dashboard/src/adapters/api/routes/enhanced_upload_router.py
@@ -1,0 +1,175 @@
+"""Enhanced upload router with configurable compliance audit logging."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping
+
+try:  # pragma: no cover - fallback for environments without FastAPI installed
+    from fastapi import APIRouter, Depends
+except ModuleNotFoundError:  # pragma: no cover
+    from backend._stub_loader import load_package_stub
+
+    load_package_stub("fastapi", "fastapi_stub_1758768319", "FastAPI")
+    from fastapi import APIRouter, Depends
+
+try:  # pragma: no cover - fallback for environments without Pydantic installed
+    from pydantic import BaseModel, Field
+except ModuleNotFoundError:  # pragma: no cover
+    from backend._stub_loader import load_package_stub
+
+    load_package_stub("pydantic", "pydantic", "Pydantic")
+    from pydantic import BaseModel, Field
+
+__all__ = [
+    "AUDIT_DB_ENV_VAR",
+    "ComplianceAuditLogger",
+    "EnhancedUploadAuditRecord",
+    "get_audit_logger",
+    "get_audit_logger_dependency",
+    "router",
+]
+
+AUDIT_DB_ENV_VAR = "ENHANCED_UPLOAD_AUDIT_DB"
+AUDIT_DIR_ENV_VAR = "ENHANCED_UPLOAD_AUDIT_DIR"
+_DEFAULT_DB_FILENAME = "enhanced_upload_audit.db"
+
+
+def _resolve_storage_directory() -> Path:
+    """Return the base directory for persisting audit data."""
+
+    override = os.getenv(AUDIT_DIR_ENV_VAR)
+    if override:
+        return Path(override).expanduser()
+
+    xdg_data_home = os.getenv("XDG_DATA_HOME")
+    if xdg_data_home:
+        return Path(xdg_data_home).expanduser() / "yosai_intel_dashboard"
+
+    return Path(tempfile.gettempdir()) / "yosai_intel_dashboard"
+
+
+def resolve_audit_db_path() -> Path:
+    """Return the configured SQLite database path for audit persistence."""
+
+    override = os.getenv(AUDIT_DB_ENV_VAR)
+    if override:
+        return Path(override).expanduser()
+
+    base_dir = _resolve_storage_directory()
+    return base_dir / _DEFAULT_DB_FILENAME
+
+
+@dataclass(slots=True)
+class ComplianceAuditLogger:
+    """Persist compliance audit records for enhanced uploads."""
+
+    db_path: Path
+
+    def __post_init__(self) -> None:
+        self._initialise_database()
+
+    def _initialise_database(self) -> None:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS enhanced_upload_audit (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    created_at TEXT NOT NULL,
+                    actor TEXT,
+                    filename TEXT,
+                    status TEXT,
+                    payload TEXT
+                )
+                """
+            )
+            connection.commit()
+
+    def log_upload_event(
+        self,
+        *,
+        actor: str | None,
+        filename: str | None,
+        status: str,
+        payload: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Persist an audit record for an enhanced upload operation."""
+
+        serialised = json.dumps(payload or {}, default=str)
+        created_at = datetime.now(timezone.utc).isoformat()
+        with sqlite3.connect(self.db_path) as connection:
+            connection.execute(
+                """
+                INSERT INTO enhanced_upload_audit (
+                    created_at,
+                    actor,
+                    filename,
+                    status,
+                    payload
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (created_at, actor, filename, status, serialised),
+            )
+            connection.commit()
+
+
+class EnhancedUploadAuditRecord(BaseModel):
+    """Payload accepted by the audit endpoint."""
+
+    actor: str | None = Field(default=None, description="Identity triggering the upload")
+    filename: str | None = Field(default=None, description="Uploaded file name")
+    status: str = Field(description="Outcome of the upload workflow")
+    payload: MutableMapping[str, Any] | None = Field(
+        default=None, description="Additional metadata captured for the upload"
+    )
+
+
+@lru_cache(maxsize=1)
+def _build_logger(db_path: str) -> ComplianceAuditLogger:
+    return ComplianceAuditLogger(Path(db_path))
+
+
+def reset_audit_logger_cache() -> None:
+    """Clear the cached audit logger instance (useful for tests)."""
+
+    _build_logger.cache_clear()  # type: ignore[attr-defined]
+
+
+def get_audit_logger() -> ComplianceAuditLogger:
+    """Return a cached audit logger backed by the configured database."""
+
+    db_path = resolve_audit_db_path()
+    return _build_logger(str(db_path))
+
+
+def get_audit_logger_dependency() -> ComplianceAuditLogger:
+    """Expose ``ComplianceAuditLogger`` as a FastAPI dependency."""
+
+    return get_audit_logger()
+
+
+router = APIRouter(prefix="/enhanced-upload", tags=["Enhanced Upload"])
+
+
+@router.post("/audit", status_code=201)
+async def record_enhanced_upload_audit(
+    record: EnhancedUploadAuditRecord,
+    audit_logger: ComplianceAuditLogger = Depends(get_audit_logger_dependency),
+) -> dict[str, str]:
+    """Record an enhanced upload audit event and acknowledge receipt."""
+
+    audit_logger.log_upload_event(
+        actor=record.actor,
+        filename=record.filename,
+        status=record.status,
+        payload=dict(record.payload or {}),
+    )
+    return {"detail": "audit record stored"}

--- a/fastapi_shadow_1758771137/__init__.py
+++ b/fastapi_shadow_1758771137/__init__.py
@@ -426,11 +426,29 @@ class APIRouter:
         route = _Route(
             full_path or "/",
             endpoint=endpoint,
-            methods=methods,
+            methods=[method.upper() for method in methods],
             response_model=response_model,
             status_code=status_code,
         )
         self.routes.append(route)
+
+    def api_route(
+        self,
+        path: str,
+        *,
+        methods: Optional[Iterable[str]] = None,
+        response_model: Optional[type] = None,
+        status_code: Optional[int] = None,
+        **kwargs: Any,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        resolved_methods = [method.upper() for method in (methods or ["GET"])]
+        return self._decorator(
+            path,
+            methods=resolved_methods,
+            response_model=response_model,
+            status_code=status_code,
+            **kwargs,
+        )
 
     def get(
         self,
@@ -449,7 +467,7 @@ class APIRouter:
         status_code: Optional[int] = None,
         **kwargs: Any,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-        return self._decorator(
+        return self.api_route(
             path,
             methods=["POST"],
             response_model=response_model,


### PR DESCRIPTION
## Summary
- add api_route support to the vendored FastAPI stub so routers with api_route decorators work
- update the Starlette shim to autodiscover the bundled stub when the real dependency is absent

## Testing
- PYTHONPATH=. pytest backend/tests/test_yosai/test_enhanced_upload_router.py

------
https://chatgpt.com/codex/tasks/task_e_68d69d9af1a08320a3cf30e8d189359b