### PR TITLE
Add workspace role policies for export gating

### DIFF
--- a/backend/app/core/auth/__init__.py
+++ b/backend/app/core/auth/__init__.py
@@ -1,0 +1,23 @@
+"""Role-based access helpers for workspace policies."""
+
+from .policy import (
+    WorkspaceRole,
+    PolicyContext,
+    SignoffSnapshot,
+    can_export_permit_ready,
+    can_invite_architect,
+    requires_signoff,
+    watermark_forced,
+    watermark_text,
+)
+
+__all__ = [
+    "WorkspaceRole",
+    "PolicyContext",
+    "SignoffSnapshot",
+    "can_export_permit_ready",
+    "can_invite_architect",
+    "requires_signoff",
+    "watermark_forced",
+    "watermark_text",
+]

--- a/backend/app/core/auth/policy.py
+++ b/backend/app/core/auth/policy.py
@@ -1,0 +1,93 @@
+"""Workspace policy helper utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Literal, Optional
+
+
+class WorkspaceRole(str, Enum):
+    AGENCY = "agency"
+    DEVELOPER = "developer"
+    ARCHITECT = "architect"
+
+
+SignoffStatus = Literal["pending", "approved", "rejected"]
+
+
+@dataclass(frozen=True)
+class SignoffSnapshot:
+    project_id: int
+    overlay_version: str
+    status: SignoffStatus
+    architect_user_id: Optional[int]
+    signed_at: Optional[datetime]
+
+    def is_approved(self) -> bool:
+        return self.status == "approved"
+
+
+@dataclass(frozen=True)
+class PolicyContext:
+    role: WorkspaceRole
+    signoff: Optional[SignoffSnapshot] = None
+
+    @property
+    def has_approved_signoff(self) -> bool:
+        if not self.signoff:
+            return False
+        return self.signoff.is_approved()
+
+
+_WATERMARK_TEXT = "Marketing Feasibility Only – Not for Permit or Construction."
+
+
+def requires_signoff(context: PolicyContext) -> bool:
+    if context.role == WorkspaceRole.DEVELOPER:
+        return True
+    if context.role == WorkspaceRole.AGENCY:
+        return True
+    return False
+
+
+def can_export_permit_ready(context: PolicyContext) -> bool:
+    if context.role == WorkspaceRole.AGENCY:
+        return False
+    if context.role == WorkspaceRole.DEVELOPER:
+        return context.has_approved_signoff
+    if context.role == WorkspaceRole.ARCHITECT:
+        return context.has_approved_signoff
+    return False
+
+
+def can_invite_architect(context: PolicyContext) -> bool:
+    return context.role == WorkspaceRole.DEVELOPER
+
+
+def watermark_forced(context: PolicyContext) -> bool:
+    if context.role == WorkspaceRole.AGENCY:
+        return True
+    if not context.has_approved_signoff:
+        return True
+    return False
+
+
+def watermark_text(context: PolicyContext) -> str:
+    if watermark_forced(context):
+        return _WATERMARK_TEXT
+    return ""
+
+
+__all__ = [
+    "WorkspaceRole",
+    "PolicyContext",
+    "SignoffSnapshot",
+    "SignoffStatus",
+    "requires_signoff",
+    "can_export_permit_ready",
+    "can_invite_architect",
+    "watermark_forced",
+    "watermark_text",
+]

--- a/backend/app/core/export/guard.py
+++ b/backend/app/core/export/guard.py
@@ -1,0 +1,42 @@
+"""Permit-ready export gating helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.core.auth import PolicyContext, WorkspaceRole, can_export_permit_ready
+
+
+@dataclass(frozen=True)
+class ExportRequest:
+    project_id: int
+    overlay_version: str
+    permit_ready: bool
+
+
+@dataclass(frozen=True)
+class ExportDecision:
+    allowed: bool
+    reason: str | None = None
+
+
+def evaluate_export(request: ExportRequest, context: PolicyContext) -> ExportDecision:
+    if not request.permit_ready:
+        return ExportDecision(allowed=True)
+    if can_export_permit_ready(context):
+        return ExportDecision(allowed=True)
+    role = context.role
+    if role == WorkspaceRole.AGENCY:
+        return ExportDecision(allowed=False, reason="Agency exports cannot be permit-ready")
+    if role == WorkspaceRole.DEVELOPER:
+        return ExportDecision(
+            allowed=False,
+            reason="Developer exports require architect sign-off before permit-ready",
+        )
+    return ExportDecision(
+        allowed=False,
+        reason="Permit-ready exports require an approved sign-off",
+    )
+
+
+__all__ = ["ExportRequest", "ExportDecision", "evaluate_export"]

--- a/backend/app/core/export/watermark.py
+++ b/backend/app/core/export/watermark.py
@@ -1,0 +1,25 @@
+"""Watermark helper utilities for exports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.core.auth import PolicyContext, watermark_text
+
+
+@dataclass(frozen=True)
+class ExportPayload:
+    content: bytes
+    watermark: str | None = None
+
+
+def apply_watermark(payload: ExportPayload, context: PolicyContext) -> ExportPayload:
+    text = watermark_text(context)
+    if not text:
+        return payload
+    if payload.watermark == text:
+        return payload
+    return ExportPayload(content=payload.content, watermark=text)
+
+
+__all__ = ["ExportPayload", "apply_watermark"]

--- a/backend/tests/test_core/test_auth_policy.py
+++ b/backend/tests/test_core/test_auth_policy.py
@@ -1,0 +1,89 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from app.core.auth import (
+    PolicyContext,
+    SignoffSnapshot,
+    WorkspaceRole,
+    can_export_permit_ready,
+    can_invite_architect,
+    requires_signoff,
+    watermark_forced,
+    watermark_text,
+)
+
+
+@pytest.fixture
+def approved_signoff() -> SignoffSnapshot:
+    return SignoffSnapshot(
+        project_id=10,
+        overlay_version="v1",
+        status="approved",
+        architect_user_id=42,
+        signed_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+@pytest.fixture
+def pending_signoff() -> SignoffSnapshot:
+    return SignoffSnapshot(
+        project_id=10,
+        overlay_version="v1",
+        status="pending",
+        architect_user_id=None,
+        signed_at=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "role,expected",
+    [
+        (WorkspaceRole.AGENCY, True),
+        (WorkspaceRole.DEVELOPER, True),
+        (WorkspaceRole.ARCHITECT, False),
+    ],
+)
+def test_requires_signoff(role, expected, approved_signoff):
+    context = PolicyContext(role=role, signoff=approved_signoff)
+    assert requires_signoff(context) is expected
+
+
+@pytest.mark.parametrize(
+    "role,signoff,expected",
+    [
+        (WorkspaceRole.AGENCY, None, False),
+        (WorkspaceRole.DEVELOPER, None, False),
+        (WorkspaceRole.DEVELOPER, "approved", True),
+        (WorkspaceRole.ARCHITECT, "approved", True),
+    ],
+)
+def test_can_export_permit_ready(role, signoff, expected, approved_signoff, pending_signoff):
+    snapshot = approved_signoff if signoff == "approved" else pending_signoff if signoff else None
+    context = PolicyContext(role=role, signoff=snapshot)
+    assert can_export_permit_ready(context) is expected
+
+
+@pytest.mark.parametrize(
+    "role,signoff,forced",
+    [
+        (WorkspaceRole.AGENCY, None, True),
+        (WorkspaceRole.DEVELOPER, None, True),
+        (WorkspaceRole.DEVELOPER, "approved", False),
+        (WorkspaceRole.ARCHITECT, "approved", False),
+    ],
+)
+def test_watermark_policies(role, signoff, forced, approved_signoff, pending_signoff):
+    snapshot = approved_signoff if signoff == "approved" else pending_signoff if signoff else None
+    context = PolicyContext(role=role, signoff=snapshot)
+    assert watermark_forced(context) is forced
+    if forced:
+        assert watermark_text(context)
+    else:
+        assert watermark_text(context) == ""
+
+
+def test_can_invite_architect_only_developer(approved_signoff):
+    assert can_invite_architect(PolicyContext(role=WorkspaceRole.DEVELOPER, signoff=approved_signoff))
+    assert not can_invite_architect(PolicyContext(role=WorkspaceRole.AGENCY))
+    assert not can_invite_architect(PolicyContext(role=WorkspaceRole.ARCHITECT))

--- a/backend/tests/test_core/test_export_guard.py
+++ b/backend/tests/test_core/test_export_guard.py
@@ -1,0 +1,45 @@
+from app.core.auth import PolicyContext, SignoffSnapshot, WorkspaceRole
+from app.core.export.guard import ExportDecision, ExportRequest, evaluate_export
+
+
+def build_signoff(status: str | None) -> SignoffSnapshot | None:
+    if not status:
+        return None
+    return SignoffSnapshot(
+        project_id=7,
+        overlay_version="v2",
+        status=status,  # type: ignore[arg-type]
+        architect_user_id=88,
+        signed_at=None,
+    )
+
+
+def test_non_permit_ready_requests_always_allowed():
+    context = PolicyContext(role=WorkspaceRole.AGENCY)
+    request = ExportRequest(project_id=1, overlay_version="v1", permit_ready=False)
+    decision = evaluate_export(request, context)
+    assert decision == ExportDecision(allowed=True, reason=None)
+
+
+def test_developer_requires_signoff_for_permit_ready():
+    context = PolicyContext(role=WorkspaceRole.DEVELOPER, signoff=build_signoff("pending"))
+    request = ExportRequest(project_id=1, overlay_version="v1", permit_ready=True)
+    decision = evaluate_export(request, context)
+    assert not decision.allowed
+    assert "sign-off" in (decision.reason or "")
+
+
+def test_architect_with_signoff_is_allowed():
+    signoff = build_signoff("approved")
+    context = PolicyContext(role=WorkspaceRole.ARCHITECT, signoff=signoff)
+    request = ExportRequest(project_id=1, overlay_version="v1", permit_ready=True)
+    decision = evaluate_export(request, context)
+    assert decision.allowed
+
+
+def test_agency_never_permit_ready():
+    context = PolicyContext(role=WorkspaceRole.AGENCY, signoff=build_signoff("approved"))
+    request = ExportRequest(project_id=1, overlay_version="v1", permit_ready=True)
+    decision = evaluate_export(request, context)
+    assert not decision.allowed
+    assert decision.reason == "Agency exports cannot be permit-ready"

--- a/backend/tests/test_core/test_export_watermark.py
+++ b/backend/tests/test_core/test_export_watermark.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timezone
+
+from app.core.auth import PolicyContext, SignoffSnapshot, WorkspaceRole
+from app.core.export.watermark import ExportPayload, apply_watermark
+
+
+def approved_signoff() -> SignoffSnapshot:
+    return SignoffSnapshot(
+        project_id=2,
+        overlay_version="v1",
+        status="approved",
+        architect_user_id=3,
+        signed_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_watermark_applied_for_agency():
+    context = PolicyContext(role=WorkspaceRole.AGENCY)
+    payload = ExportPayload(content=b"data")
+    result = apply_watermark(payload, context)
+    assert result.watermark
+    assert result.content == payload.content
+
+
+def test_watermark_retained_if_already_applied():
+    context = PolicyContext(role=WorkspaceRole.AGENCY)
+    payload = ExportPayload(
+        content=b"data",
+        watermark="Marketing Feasibility Only – Not for Permit or Construction.",
+    )
+    result = apply_watermark(payload, context)
+    assert result is payload
+
+
+def test_no_watermark_for_architect_with_signoff():
+    context = PolicyContext(role=WorkspaceRole.ARCHITECT, signoff=approved_signoff())
+    payload = ExportPayload(content=b"data")
+    result = apply_watermark(payload, context)
+    assert result.watermark is None


### PR DESCRIPTION
## Summary
- add workspace role policy helpers to describe agency, developer, and architect capabilities
- introduce export guard and watermark utilities driven by the shared policy context
- cover policy, guard, and watermark behaviours with new unit tests

## Testing
- pytest backend/tests/test_core/test_auth_policy.py backend/tests/test_core/test_export_guard.py backend/tests/test_core/test_export_watermark.py

------
https://chatgpt.com/codex/tasks/task_e_68d7331b90e08320b8786b53965aa694