### PR TITLE
Configure mypy hook dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,26 @@ repos:
     - id: flake8
       additional_dependencies: [flake8-bugbear==24.8.19]
       files: ^(backend/tests|tests)/
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.7.1
+  hooks:
+    - id: mypy
+      name: mypy-backend
+      files: ^backend/
+      args: [--config-file=backend/pyproject.toml]
+      additional_dependencies:
+        - fastapi==0.104.1
+        - uvicorn[standard]==0.24.0
+        - pydantic[email]==2.5.0
+        - sqlalchemy[asyncio]==2.0.23
+        - asyncpg==0.29.0
+        - alembic==1.13.0
+        - python-multipart==0.0.6
+        - python-jose[cryptography]==3.3.0
+        - passlib[bcrypt]==1.7.4
+        - httpx==0.25.2
+        - python-dateutil==2.8.2
+        - prefect==2.14.10
+        - structlog==23.2.0
+        - prometheus-client==0.19.0


### PR DESCRIPTION
## Summary
- add a mypy pre-commit hook configured to read the backend settings
- include the backend runtime packages in the hook's additional dependencies so mypy can import them

## Testing
- pre-commit run --all-files *(fails: `pre-commit` unavailable in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d86ffdcd7483209de076e881a5c90e