### PR TITLE
Add Prettier and ESLint pre-commit hooks for frontend linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,27 @@ repos:
     - id: flake8
       additional_dependencies: [flake8-bugbear==24.8.19]
       files: ^(backend/tests|tests)/
+
+- repo: https://github.com/pre-commit/mirrors-prettier
+  rev: v3.4.2
+  hooks:
+    - id: prettier
+      files: ^(frontend|ui-admin)/.*\.(?:[cm]?jsx?|tsx?|json|ya?ml|css|scss|less|mdx?|html?)$
+      exclude: ^(frontend|ui-admin)/(?:node_modules|dist)/|(?:pnpm-lock|package-lock)\.ya?ml$
+
+- repo: https://github.com/pre-commit/mirrors-eslint
+  rev: v9.11.1
+  hooks:
+    - id: eslint
+      files: ^frontend/(?!node_modules/).+\.(?:[cm]?jsx?|tsx?)$
+      args:
+        - --config
+        - frontend/eslint.config.cjs
+      additional_dependencies:
+        - '@eslint/js@9.11.1'
+        - '@typescript-eslint/eslint-plugin@8.44.1'
+        - '@typescript-eslint/parser@8.44.1'
+        - eslint-plugin-react-hooks@4.6.0
+        - eslint-plugin-react-refresh@0.4.4
+        - globals@13.24.0
+        - typescript@5.2.2


### PR DESCRIPTION
## Summary
- add Prettier and ESLint hooks to run against the frontend (and ui-admin) directories
- configure the ESLint hook to use the frontend flat config and required plugins

## Testing
- pre-commit run --all-files *(fails: `pre-commit` is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d86ffce4e48320b5a122376dd5ea44