### PR TITLE
Add ESLint plugins to pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,15 @@ repos:
     - id: flake8
       additional_dependencies: [flake8-bugbear==24.8.19]
       files: ^(backend/tests|tests)/
+
+- repo: https://github.com/pre-commit/mirrors-eslint
+  rev: v9.11.1
+  hooks:
+    - id: eslint
+      files: ^frontend/
+      additional_dependencies:
+        - eslint@9.11.1
+        - '@typescript-eslint/eslint-plugin@8.44.1'
+        - '@typescript-eslint/parser@8.44.1'
+        - eslint-plugin-react-hooks@4.6.0
+        - eslint-plugin-react-refresh@0.4.4


### PR DESCRIPTION
## Summary
- add an ESLint pre-commit hook scoped to the frontend sources
- include the TypeScript and React-specific ESLint plugins as additional dependencies

## Testing
- pre-commit run eslint --all-files *(fails: `pre-commit` command not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d86ffecb308320a228683b3063e6be