### PR TITLE
Update CI frontend path detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,29 @@ env:
   NODE_VERSION: '20'
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            frontend:
+              - 'frontend/**'
+
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest
+    needs: changes
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,10 +52,46 @@ jobs:
       - name: Run pre-commit hooks
         run: pre-commit run --all-files --show-diff-on-failure
 
+      - name: Set up Node.js
+        if: needs.changes.outputs.frontend == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Enable Corepack
+        if: needs.changes.outputs.frontend == 'true'
+        run: corepack enable
+
+      - name: Resolve pnpm store path
+        if: needs.changes.outputs.frontend == 'true'
+        id: lint-pnpm-store
+        run: echo "store-path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        if: needs.changes.outputs.frontend == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.lint-pnpm-store.outputs.store-path }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('frontend/pnpm-lock.yaml', 'frontend/package.json') }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-
+
+      - name: Install frontend dependencies
+        if: needs.changes.outputs.frontend == 'true'
+        run: pnpm -C frontend install --frozen-lockfile
+
+      - name: Run frontend lint
+        if: needs.changes.outputs.frontend == 'true'
+        run: pnpm -C frontend lint
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest
-    needs: lint
+    needs:
+      - lint
+      - changes
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -55,6 +111,7 @@ jobs:
         run: mypy backend
 
       - name: Set up Node.js
+        if: needs.changes.outputs.frontend == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -62,13 +119,16 @@ jobs:
           cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Enable Corepack
+        if: needs.changes.outputs.frontend == 'true'
         run: corepack enable
 
       - name: Resolve pnpm store path
+        if: needs.changes.outputs.frontend == 'true'
         id: typecheck-pnpm-store
         run: echo "store-path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pnpm store
+        if: needs.changes.outputs.frontend == 'true'
         uses: actions/cache@v4
         with:
           path: ${{ steps.typecheck-pnpm-store.outputs.store-path }}
@@ -77,15 +137,19 @@ jobs:
             pnpm-${{ runner.os }}-
 
       - name: Install frontend dependencies
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm -C frontend install --frozen-lockfile
 
       - name: Run frontend type checks
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm -C frontend exec tsc --noEmit
 
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: typecheck
+    needs:
+      - typecheck
+      - changes
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -105,6 +169,7 @@ jobs:
         run: python -m compileall backend
 
       - name: Set up Node.js
+        if: needs.changes.outputs.frontend == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -112,13 +177,16 @@ jobs:
           cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Enable Corepack
+        if: needs.changes.outputs.frontend == 'true'
         run: corepack enable
 
       - name: Resolve pnpm store path
+        if: needs.changes.outputs.frontend == 'true'
         id: build-pnpm-store
         run: echo "store-path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pnpm store
+        if: needs.changes.outputs.frontend == 'true'
         uses: actions/cache@v4
         with:
           path: ${{ steps.build-pnpm-store.outputs.store-path }}
@@ -127,15 +195,19 @@ jobs:
             pnpm-${{ runner.os }}-
 
       - name: Install frontend dependencies
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm -C frontend install --frozen-lockfile
 
       - name: Build frontend application
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm -C frontend build
 
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - build
+      - changes
     env:
       POSTGRES_SERVER: 127.0.0.1
       POSTGRES_DB: building_compliance
@@ -172,6 +244,7 @@ jobs:
           pip install -r backend/requirements-dev.txt
 
       - name: Set up Node.js
+        if: needs.changes.outputs.frontend == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -179,13 +252,16 @@ jobs:
           cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Enable Corepack
+        if: needs.changes.outputs.frontend == 'true'
         run: corepack enable
 
       - name: Resolve pnpm store path
+        if: needs.changes.outputs.frontend == 'true'
         id: tests-pnpm-store
         run: echo "store-path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pnpm store
+        if: needs.changes.outputs.frontend == 'true'
         uses: actions/cache@v4
         with:
           path: ${{ steps.tests-pnpm-store.outputs.store-path }}
@@ -194,9 +270,11 @@ jobs:
             pnpm-${{ runner.os }}-
 
       - name: Install frontend dependencies
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm -C frontend install --frozen-lockfile
 
       - name: Cache Playwright browsers
+        if: needs.changes.outputs.frontend == 'true'
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
@@ -205,6 +283,7 @@ jobs:
             playwright-${{ runner.os }}-
 
       - name: Install Playwright browsers
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm -C frontend exec playwright install --with-deps
 
       - name: Start backing services
@@ -380,9 +459,11 @@ jobs:
           fi
 
       - name: Run frontend unit tests
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm -C frontend test
 
       - name: Launch backend API for E2E tests
+        if: needs.changes.outputs.frontend == 'true'
         run: |
           python -m uvicorn app.main:app \
             --host 0.0.0.0 \
@@ -392,6 +473,7 @@ jobs:
         working-directory: backend
 
       - name: Wait for backend readiness (E2E)
+        if: needs.changes.outputs.frontend == 'true'
         run: |
           set -euo pipefail
           for attempt in $(seq 1 40); do
@@ -406,10 +488,11 @@ jobs:
       - name: Run frontend end-to-end tests
         env:
           PLAYWRIGHT_SKIP_BROWSER_INSTALL: '1'
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm -C frontend test:e2e
 
       - name: Stop backend API (E2E)
-        if: always()
+        if: always() && needs.changes.outputs.frontend == 'true'
         run: |
           if [ -f "$RUNNER_TEMP/backend-e2e.pid" ]; then
             PID=$(cat "$RUNNER_TEMP/backend-e2e.pid")
@@ -442,7 +525,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload Playwright artifacts
-        if: always()
+        if: always() && needs.changes.outputs.frontend == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: frontend-playwright


### PR DESCRIPTION
## Summary
- add a changes detection job that marks when files under `frontend/` have been modified
- conditionally install dependencies and run lint/build/test steps for the frontend using pnpm when frontend code changes
- ensure frontend linting uses the package.json script so the correct commands execute during CI

## Testing
- not run (CI only)

------
https://chatgpt.com/codex/tasks/task_e_68d87cbddaf88320a0a880a0143dac14