### PR TITLE
Document reference deployment infrastructure footprint

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,3 +41,18 @@ UI/API → Core (jurisdiction-agnostic)
        ├─ Compliance/AI reasoners
        └─ Analytics (diffs/overlap)
 ```
+
+## Reference deployment footprint
+
+The current reference deployment bundles a fairly heavy backing stack:
+
+- **PostgreSQL** stores the regulation corpus and feeds downstream analytics.
+- **Neo4j** powers the graph-relations service that materialises regulation
+  relationships for the UI and automated checks.
+- **Kafka** acts as the event backbone that streams regulation changes to graph
+  processors and other consumers.
+- **Graph-relations service** depends on both Kafka and Neo4j to build the
+  real-time relationship views exposed to clients.
+
+Teams evaluating the platform should plan for this footprint, especially if
+they do not already operate managed graph or streaming infrastructure.


### PR DESCRIPTION
## Summary
- note the services included in the reference deployment stack in the architecture overview
- call out that PostgreSQL, Neo4j, Kafka, and the graph-relations service drive the current infrastructure footprint

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d9616727808320b90e12d958fef303