### PR TITLE
feat: surface advanced intelligence route

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview --host 127.0.0.1 --port 4173",
     "lint:tokens": "node ../scripts/enforce-feasibility-tokens.mjs",
     "lint": "eslint --ext .ts,.tsx src",
-    "test": "node --test",
-    "test:coverage": "c8 --reporter=text --reporter=lcov --check-coverage --lines=80 node --test",
+    "test": "tsx --test src/**/*.test.tsx",
+    "test:coverage": "c8 --reporter=text --reporter=lcov --check-coverage --lines=80 tsx --test src/**/*.test.tsx",
     "test:e2e": "node scripts/run-e2e.js"
   },
   "dependencies": {
@@ -24,9 +24,11 @@
     "mapbox-gl": "^3.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "recharts": "^2.9.0"
+    "recharts": "^2.9.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@testing-library/react": "^14.3.1",
     "@playwright/test": "^1.55.0",
     "@types/mapbox-gl": "^3.0.0",
     "@types/node": "^20.9.0",
@@ -39,6 +41,8 @@
     "eslint": "^9.11.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.4",
+    "jsdom": "^24.0.0",
+    "tsx": "^4.7.0",
     "typescript": "^5.2.2",
     "vite": "^4.5.0"
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ export function AppLayout({
     { path: '/cad/pipelines', label: t('nav.pipelines') },
     { path: '/feasibility', label: t('nav.feasibility') },
     { path: '/finance', label: t('nav.finance') },
+    { path: '/visualizations/intelligence', label: t('nav.intelligence') },
   ]
 
   return (

--- a/frontend/src/hooks/useInvestigationAnalytics.ts
+++ b/frontend/src/hooks/useInvestigationAnalytics.ts
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import {
+  advancedAnalyticsService,
+  fetchCrossCorrelationIntelligence,
+  fetchGraphIntelligence,
+  fetchPredictiveIntelligence,
+  type CrossCorrelationIntelligenceResponse,
+  type GraphIntelligenceResponse,
+  type PredictiveIntelligenceResponse,
+} from '../services/analytics/advancedAnalytics'
+
+export interface InvestigationAnalyticsServices {
+  fetchGraphIntelligence: typeof fetchGraphIntelligence
+  fetchPredictiveIntelligence: typeof fetchPredictiveIntelligence
+  fetchCrossCorrelationIntelligence: typeof fetchCrossCorrelationIntelligence
+}
+
+const defaultServices: InvestigationAnalyticsServices = advancedAnalyticsService
+
+export type GraphIntelligenceState =
+  | GraphIntelligenceResponse
+  | { kind: 'graph'; status: 'loading' }
+
+export type PredictiveIntelligenceState =
+  | PredictiveIntelligenceResponse
+  | { kind: 'predictive'; status: 'loading' }
+
+export type CrossCorrelationIntelligenceState =
+  | CrossCorrelationIntelligenceResponse
+  | { kind: 'correlation'; status: 'loading' }
+
+export interface UseInvestigationAnalyticsResult {
+  graph: GraphIntelligenceState
+  predictive: PredictiveIntelligenceState
+  correlation: CrossCorrelationIntelligenceState
+  isLoading: boolean
+  refetch: () => Promise<void>
+}
+
+const loadingGraphState: GraphIntelligenceState = { kind: 'graph', status: 'loading' }
+const loadingPredictiveState: PredictiveIntelligenceState = {
+  kind: 'predictive',
+  status: 'loading',
+}
+const loadingCorrelationState: CrossCorrelationIntelligenceState = {
+  kind: 'correlation',
+  status: 'loading',
+}
+
+function toGraphErrorState(reason: unknown): GraphIntelligenceResponse {
+  return {
+    kind: 'graph',
+    status: 'error',
+    error: reason instanceof Error ? reason.message : 'Unknown graph intelligence error',
+  }
+}
+
+function toPredictiveErrorState(reason: unknown): PredictiveIntelligenceResponse {
+  return {
+    kind: 'predictive',
+    status: 'error',
+    error:
+      reason instanceof Error ? reason.message : 'Unknown predictive intelligence error',
+  }
+}
+
+function toCorrelationErrorState(reason: unknown): CrossCorrelationIntelligenceResponse {
+  return {
+    kind: 'correlation',
+    status: 'error',
+    error:
+      reason instanceof Error ? reason.message : 'Unknown correlation intelligence error',
+  }
+}
+
+export function useInvestigationAnalytics(
+  workspaceId: string,
+  overrides?: Partial<InvestigationAnalyticsServices>,
+): UseInvestigationAnalyticsResult {
+  const services = useMemo<InvestigationAnalyticsServices>(() => {
+    if (!overrides) {
+      return defaultServices
+    }
+    return {
+      ...defaultServices,
+      ...overrides,
+    }
+  }, [overrides])
+
+  const isMountedRef = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
+  const [graph, setGraph] = useState<GraphIntelligenceState>(loadingGraphState)
+  const [predictive, setPredictive] = useState<PredictiveIntelligenceState>(
+    loadingPredictiveState,
+  )
+  const [correlation, setCorrelation] =
+    useState<CrossCorrelationIntelligenceState>(loadingCorrelationState)
+  const [isLoading, setIsLoading] = useState(true)
+
+  const loadAnalytics = useCallback(async () => {
+    if (!isMountedRef.current) {
+      return
+    }
+
+    setIsLoading(true)
+    setGraph(loadingGraphState)
+    setPredictive(loadingPredictiveState)
+    setCorrelation(loadingCorrelationState)
+
+    const [graphResult, predictiveResult, correlationResult] = await Promise.allSettled([
+      services.fetchGraphIntelligence(workspaceId),
+      services.fetchPredictiveIntelligence(workspaceId),
+      services.fetchCrossCorrelationIntelligence(workspaceId),
+    ])
+
+    if (!isMountedRef.current) {
+      return
+    }
+
+    if (graphResult.status === 'fulfilled') {
+      setGraph(graphResult.value)
+    } else {
+      setGraph(toGraphErrorState(graphResult.reason))
+    }
+
+    if (predictiveResult.status === 'fulfilled') {
+      setPredictive(predictiveResult.value)
+    } else {
+      setPredictive(toPredictiveErrorState(predictiveResult.reason))
+    }
+
+    if (correlationResult.status === 'fulfilled') {
+      setCorrelation(correlationResult.value)
+    } else {
+      setCorrelation(toCorrelationErrorState(correlationResult.reason))
+    }
+
+    setIsLoading(false)
+  }, [services, workspaceId])
+
+  useEffect(() => {
+    loadAnalytics().catch(() => {
+      // Errors are captured via the settled promise handling above.
+    })
+  }, [loadAnalytics])
+
+  const refetch = useCallback(async () => {
+    await loadAnalytics()
+  }, [loadAnalytics])
+
+  return {
+    graph,
+    predictive,
+    correlation,
+    isLoading,
+    refetch,
+  }
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -27,7 +27,8 @@
     "detection": "Floor & unit detection",
     "pipelines": "Default pipelines",
     "feasibility": "Feasibility wizard",
-    "finance": "Finance workspace"
+    "finance": "Finance workspace",
+    "intelligence": "Advanced intelligence"
   },
   "home": {
     "cards": {

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -27,7 +27,8 @@
     "detection": "階層とユニットの検出",
     "pipelines": "デフォルトパイプライン",
     "feasibility": "フィージビリティウィザード",
-    "finance": "ファイナンスワークスペース"
+    "finance": "ファイナンスワークスペース",
+    "intelligence": "高度なインテリジェンス"
   },
   "home": {
     "cards": {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,7 @@ import { CadPipelinesPage } from './pages/CadPipelinesPage'
 import { CadUploadPage } from './pages/CadUploadPage'
 import { FeasibilityWizard } from './modules/feasibility/FeasibilityWizard'
 import { FinanceWorkspace } from './modules/finance'
+import AdvancedIntelligencePage from './pages/visualizations/AdvancedIntelligence'
 import '@ob/tokens.css'
 import './index.css'
 
@@ -39,6 +40,10 @@ const router = createBrowserRouter([
   {
     path: '/finance',
     element: <FinanceWorkspace />,
+  },
+  {
+    path: '/visualizations/intelligence',
+    element: <AdvancedIntelligencePage />,
   },
 ])
 

--- a/frontend/src/pages/visualizations/AdvancedIntelligence.tsx
+++ b/frontend/src/pages/visualizations/AdvancedIntelligence.tsx
@@ -1,0 +1,274 @@
+import { useCallback, useMemo } from 'react'
+
+import { AppLayout } from '../../App'
+import {
+  type CrossCorrelationIntelligenceState,
+  type GraphIntelligenceState,
+  type InvestigationAnalyticsServices,
+  type PredictiveIntelligenceState,
+  useInvestigationAnalytics,
+} from '../../hooks/useInvestigationAnalytics'
+
+export interface AdvancedIntelligencePageProps {
+  workspaceId?: string
+  services?: Partial<InvestigationAnalyticsServices>
+}
+
+const DEFAULT_WORKSPACE_ID = 'default-investigation'
+
+function formatPercent(value: number | null | undefined, fractionDigits = 0) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '–'
+  }
+  return `${value.toFixed(fractionDigits)}%`
+}
+
+function renderGraphSection(state: GraphIntelligenceState) {
+  if (state.status === 'loading') {
+    return <p>Loading relationship intelligence…</p>
+  }
+
+  if (state.status === 'error') {
+    return (
+      <p role="alert" className="advanced-intelligence__error">
+        Unable to load relationship intelligence: {state.error}
+      </p>
+    )
+  }
+
+  if (state.status === 'empty') {
+    return (
+      <p className="advanced-intelligence__empty">
+        No relationship intelligence is available for this workspace yet.
+      </p>
+    )
+  }
+
+  const nodeCount = state.graph.nodes.length
+  const edgeCount = state.graph.edges.length
+  const topNodes = [...state.graph.nodes]
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 4)
+
+  return (
+    <div className="advanced-intelligence__panel">
+      <p>{state.summary}</p>
+      <p>
+        Graph density:{' '}
+        <strong>
+          {nodeCount} nodes / {edgeCount} edges
+        </strong>
+      </p>
+      <ul className="advanced-intelligence__list">
+        {topNodes.map((node) => (
+          <li key={node.id}>
+            <strong>{node.label}</strong> — {node.category} ({Math.round(node.score * 100) / 100})
+          </li>
+        ))}
+      </ul>
+      <p className="advanced-intelligence__meta">Generated at {state.generatedAt}</p>
+    </div>
+  )
+}
+
+function deriveAdoptionRate(state: PredictiveIntelligenceState): number | null {
+  if (state.status !== 'ok') {
+    return null
+  }
+  if (state.segments.length === 0) {
+    return 0
+  }
+  const sumProbability = state.segments.reduce(
+    (sum, segment) => sum + segment.probability,
+    0,
+  )
+  return (sumProbability / state.segments.length) * 100
+}
+
+function deriveAverageUplift(state: PredictiveIntelligenceState): number | null {
+  if (state.status !== 'ok') {
+    return null
+  }
+  let contributingSegments = 0
+  const cumulativeUplift = state.segments.reduce((sum, segment) => {
+    if (segment.baseline === 0) {
+      return sum
+    }
+    contributingSegments += 1
+    return sum + ((segment.projection - segment.baseline) / segment.baseline) * 100
+  }, 0)
+
+  if (contributingSegments === 0) {
+    return 0
+  }
+
+  return cumulativeUplift / contributingSegments
+}
+
+function renderPredictiveSection(state: PredictiveIntelligenceState) {
+  if (state.status === 'loading') {
+    return <p>Running predictive models…</p>
+  }
+
+  if (state.status === 'error') {
+    return (
+      <p role="alert" className="advanced-intelligence__error">
+        Unable to load predictive intelligence: {state.error}
+      </p>
+    )
+  }
+
+  if (state.status === 'empty') {
+    return (
+      <p className="advanced-intelligence__empty">
+        Predictive models have not produced any actionable signals for this workspace.
+      </p>
+    )
+  }
+
+  const adoptionRate = deriveAdoptionRate(state)
+  const averageUplift = deriveAverageUplift(state)
+  const momentumSegments = state.segments
+    .filter((segment) => segment.projection > segment.baseline)
+    .sort((a, b) => b.probability - a.probability)
+    .slice(0, 3)
+
+  return (
+    <div className="advanced-intelligence__panel">
+      <p>{state.summary}</p>
+      <p>
+        Average adoption likelihood:{' '}
+        <strong>{formatPercent(adoptionRate)}</strong>
+      </p>
+      <p>
+        Average projected uplift:{' '}
+        <strong>{formatPercent(averageUplift, 1)}</strong>
+      </p>
+      <p>
+        Forecast horizon:{' '}
+        <strong>{state.horizonMonths} months</strong>
+      </p>
+      <ul className="advanced-intelligence__list">
+        {momentumSegments.map((segment) => (
+          <li key={segment.segmentId}>
+            <strong>{segment.segmentName}</strong> —
+            {` ${(segment.probability * 100).toFixed(0)}% likelihood, projection ${segment.projection.toLocaleString()}`}
+          </li>
+        ))}
+      </ul>
+      <p className="advanced-intelligence__meta">Generated at {state.generatedAt}</p>
+    </div>
+  )
+}
+
+function renderCorrelationSection(state: CrossCorrelationIntelligenceState) {
+  if (state.status === 'loading') {
+    return <p>Analysing cross correlations…</p>
+  }
+
+  if (state.status === 'error') {
+    return (
+      <p role="alert" className="advanced-intelligence__error">
+        Unable to load cross-correlation intelligence: {state.error}
+      </p>
+    )
+  }
+
+  if (state.status === 'empty') {
+    return (
+      <p className="advanced-intelligence__empty">
+        There are no significant cross correlations detected for this workspace.
+      </p>
+    )
+  }
+
+  const rankedRelationships = [...state.relationships]
+    .sort((a, b) => Math.abs(b.coefficient) - Math.abs(a.coefficient))
+    .slice(0, 4)
+
+  return (
+    <div className="advanced-intelligence__panel">
+      <p>{state.summary}</p>
+      <ul className="advanced-intelligence__list">
+        {rankedRelationships.map((relationship) => (
+          <li key={relationship.pairId}>
+            <strong>{relationship.driver}</strong> → {relationship.outcome}{' '}
+            ({relationship.coefficient.toFixed(2)} ρ, p={relationship.pValue.toFixed(3)})
+          </li>
+        ))}
+      </ul>
+      <p className="advanced-intelligence__meta">Updated at {state.updatedAt}</p>
+    </div>
+  )
+}
+
+export function AdvancedIntelligencePage({
+  workspaceId = DEFAULT_WORKSPACE_ID,
+  services,
+}: AdvancedIntelligencePageProps) {
+  const { graph, predictive, correlation, isLoading, refetch } =
+    useInvestigationAnalytics(workspaceId, services)
+
+  const handleRefresh = useCallback(() => {
+    return refetch()
+  }, [refetch])
+
+  const derivedAdoptionRate = useMemo(() => deriveAdoptionRate(predictive), [predictive])
+  const derivedAverageUplift = useMemo(
+    () => deriveAverageUplift(predictive),
+    [predictive],
+  )
+
+  return (
+    <AppLayout
+      title="Advanced Intelligence"
+      subtitle="Investigation analytics workspace"
+      actions={
+        <button
+          type="button"
+          className="advanced-intelligence__refresh"
+          onClick={handleRefresh}
+          disabled={isLoading}
+        >
+          {isLoading ? 'Refreshing…' : 'Refresh analytics'}
+        </button>
+      }
+    >
+      <section className="advanced-intelligence__section" aria-labelledby="advanced-intelligence-overview">
+        <h3 id="advanced-intelligence-overview">Workspace signals</h3>
+        {isLoading && (
+          <p data-testid="analytics-loading">Loading analytics for workspace {workspaceId}…</p>
+        )}
+        {!isLoading && predictive.status === 'ok' && (
+          <div className="advanced-intelligence__summary">
+            <p>
+              Current adoption likelihood across cohorts:{' '}
+              <strong>{formatPercent(derivedAdoptionRate)}</strong>
+            </p>
+            <p>
+              Average projected uplift across active cohorts:{' '}
+              <strong>{formatPercent(derivedAverageUplift, 1)}</strong>
+            </p>
+          </div>
+        )}
+      </section>
+
+      <section className="advanced-intelligence__section" aria-labelledby="graph-intelligence">
+        <h3 id="graph-intelligence">Relationship intelligence</h3>
+        {renderGraphSection(graph)}
+      </section>
+
+      <section className="advanced-intelligence__section" aria-labelledby="predictive-intelligence">
+        <h3 id="predictive-intelligence">Predictive intelligence</h3>
+        {renderPredictiveSection(predictive)}
+      </section>
+
+      <section className="advanced-intelligence__section" aria-labelledby="correlation-intelligence">
+        <h3 id="correlation-intelligence">Cross-correlation intelligence</h3>
+        {renderCorrelationSection(correlation)}
+      </section>
+    </AppLayout>
+  )
+}
+
+export default AdvancedIntelligencePage

--- a/frontend/src/pages/visualizations/__tests__/AdvancedIntelligence.test.tsx
+++ b/frontend/src/pages/visualizations/__tests__/AdvancedIntelligence.test.tsx
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict'
+import { afterEach, beforeEach, describe, it } from 'node:test'
+import { JSDOM } from 'jsdom'
+import { cleanup, render, screen } from '@testing-library/react'
+import React from 'react'
+
+import { TranslationProvider } from '../../../i18n'
+import {
+  type CrossCorrelationIntelligenceResponse,
+  type GraphIntelligenceResponse,
+  type PredictiveIntelligenceResponse,
+  IntelligenceValidationError,
+} from '../../../services/analytics/advancedAnalytics'
+import AdvancedIntelligencePage from '../AdvancedIntelligence'
+
+describe('AdvancedIntelligencePage', () => {
+  let dom: JSDOM
+
+  beforeEach(() => {
+    dom = new JSDOM('<!doctype html><html><body></body></html>', {
+      url: 'http://localhost/visualizations/intelligence',
+    })
+    const globalWithDom = globalThis as typeof globalThis & {
+      window: Window & typeof globalThis
+      document: Document
+      navigator: Navigator
+    }
+    globalWithDom.window = dom.window
+    globalWithDom.document = dom.window.document
+    globalWithDom.navigator = dom.window.navigator
+  })
+
+  afterEach(() => {
+    cleanup()
+    dom.window.close()
+    const globalWithDom = globalThis as {
+      window?: Window & typeof globalThis
+      document?: Document
+      navigator?: Navigator
+    }
+    delete globalWithDom.window
+    delete globalWithDom.document
+    delete globalWithDom.navigator
+  })
+
+  it('renders derived workspace metrics when fetchers succeed', async () => {
+    const graphSuccess: GraphIntelligenceResponse = {
+      kind: 'graph',
+      status: 'ok',
+      summary: 'Two core actors are tightly connected to the permitting office.',
+      generatedAt: '2025-05-01T12:00:00Z',
+      graph: {
+        nodes: [
+          { id: 'a', label: 'Developer A', category: 'actor', score: 0.82 },
+          { id: 'b', label: 'Inspector B', category: 'official', score: 0.67 },
+        ],
+        edges: [{ id: 'ab', source: 'a', target: 'b', weight: 0.91 }],
+      },
+    }
+
+    const predictiveSuccess: PredictiveIntelligenceResponse = {
+      kind: 'predictive',
+      status: 'ok',
+      summary: 'Adoption is accelerating in the downtown corridor.',
+      generatedAt: '2025-05-01T12:00:00Z',
+      horizonMonths: 12,
+      segments: [
+        {
+          segmentId: 'seg-1',
+          segmentName: 'Downtown residential',
+          baseline: 120,
+          projection: 168,
+          probability: 0.82,
+        },
+        {
+          segmentId: 'seg-2',
+          segmentName: 'Mixed-use pilots',
+          baseline: 95,
+          projection: 102,
+          probability: 0.38,
+        },
+      ],
+    }
+
+    const correlationSuccess: CrossCorrelationIntelligenceResponse = {
+      kind: 'correlation',
+      status: 'ok',
+      summary: 'Training programmes continue to correlate with faster approvals.',
+      updatedAt: '2025-05-01T12:00:00Z',
+      relationships: [
+        {
+          pairId: 'rel-1',
+          driver: 'Planner enablement hours',
+          outcome: 'Permit turnaround',
+          coefficient: -0.68,
+          pValue: 0.015,
+        },
+        {
+          pairId: 'rel-2',
+          driver: 'Digital submissions',
+          outcome: 'Approval rate',
+          coefficient: 0.54,
+          pValue: 0.04,
+        },
+      ],
+    }
+
+    render(
+      <TranslationProvider>
+        <AdvancedIntelligencePage
+          workspaceId="workspace-alpha"
+          services={{
+            fetchGraphIntelligence: async () => graphSuccess,
+            fetchPredictiveIntelligence: async () => predictiveSuccess,
+            fetchCrossCorrelationIntelligence: async () => correlationSuccess,
+          }}
+        />
+      </TranslationProvider>,
+    )
+
+    await screen.findByText(
+      'Current adoption likelihood across cohorts: 60%',
+    )
+
+    assert.ok(
+      screen.getByText(/Graph density:\s+2 nodes \/ 1 edges/),
+      'graph metrics are rendered',
+    )
+    assert.ok(
+      screen.getByText(/Average projected uplift: 23\.7%/),
+      'predictive uplift is derived from payload data',
+    )
+    assert.ok(
+      screen.getByText(/Planner enablement hours → Permit turnaround/),
+      'correlation relationships are listed',
+    )
+  })
+
+  it('surfaces validation failures as predictive errors', async () => {
+    const graphSuccess: GraphIntelligenceResponse = {
+      kind: 'graph',
+      status: 'ok',
+      summary: 'Graph ready.',
+      generatedAt: '2025-05-01T12:00:00Z',
+      graph: {
+        nodes: [{ id: '1', label: 'Actor', category: 'actor', score: 0.4 }],
+        edges: [],
+      },
+    }
+
+    const correlationSuccess: CrossCorrelationIntelligenceResponse = {
+      kind: 'correlation',
+      status: 'ok',
+      summary: 'Correlations ready.',
+      updatedAt: '2025-05-01T12:00:00Z',
+      relationships: [],
+    }
+
+    render(
+      <TranslationProvider>
+        <AdvancedIntelligencePage
+          workspaceId="workspace-beta"
+          services={{
+            fetchGraphIntelligence: async () => graphSuccess,
+            fetchPredictiveIntelligence: async () => {
+              throw new IntelligenceValidationError('segments missing probability', [])
+            },
+            fetchCrossCorrelationIntelligence: async () => correlationSuccess,
+          }}
+        />
+      </TranslationProvider>,
+    )
+
+    const predictiveError = await screen.findByText(
+      /Unable to load predictive intelligence: segments missing probability/,
+    )
+    assert.ok(predictiveError)
+    assert.ok(
+      screen.getByText(/Graph density:\s+1 nodes \/ 0 edges/),
+      'graph still renders on predictive failure',
+    )
+  })
+
+  it('renders explicit empty states when payloads are empty', async () => {
+    const graphEmpty: GraphIntelligenceResponse = {
+      kind: 'graph',
+      status: 'empty',
+      summary: 'No graph signals.',
+    }
+
+    const predictiveEmpty: PredictiveIntelligenceResponse = {
+      kind: 'predictive',
+      status: 'empty',
+      summary: 'No predictive signals.',
+    }
+
+    const correlationEmpty: CrossCorrelationIntelligenceResponse = {
+      kind: 'correlation',
+      status: 'empty',
+      summary: 'No correlation signals.',
+    }
+
+    render(
+      <TranslationProvider>
+        <AdvancedIntelligencePage
+          workspaceId="workspace-gamma"
+          services={{
+            fetchGraphIntelligence: async () => graphEmpty,
+            fetchPredictiveIntelligence: async () => predictiveEmpty,
+            fetchCrossCorrelationIntelligence: async () => correlationEmpty,
+          }}
+        />
+      </TranslationProvider>,
+    )
+
+    await screen.findByText(
+      /No relationship intelligence is available for this workspace yet\./,
+    )
+    assert.ok(
+      screen.getByText(
+        /Predictive models have not produced any actionable signals for this workspace\./,
+      ),
+    )
+    assert.ok(
+      screen.getByText(
+        /There are no significant cross correlations detected for this workspace\./,
+      ),
+    )
+  })
+})

--- a/frontend/src/services/analytics/advancedAnalytics.ts
+++ b/frontend/src/services/analytics/advancedAnalytics.ts
@@ -1,0 +1,259 @@
+import { z, type ZodIssue } from 'zod'
+
+import { apiClient } from '../api'
+
+export class IntelligenceValidationError extends Error {
+  readonly issues: ZodIssue[]
+
+  constructor(message: string, issues: ZodIssue[]) {
+    super(message)
+    this.name = 'IntelligenceValidationError'
+    this.issues = issues
+  }
+}
+
+export class IntelligenceRequestError extends Error {
+  readonly cause?: unknown
+
+  constructor(message: string, cause?: unknown) {
+    super(message)
+    this.name = 'IntelligenceRequestError'
+    this.cause = cause
+  }
+}
+
+const graphNodeSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  category: z.string(),
+  score: z.number().min(0),
+})
+
+const graphEdgeSchema = z.object({
+  id: z.string(),
+  source: z.string(),
+  target: z.string(),
+  weight: z.number().optional().default(0),
+})
+
+const graphSuccessSchema = z.object({
+  kind: z.literal('graph'),
+  status: z.literal('ok'),
+  summary: z.string(),
+  generatedAt: z.string(),
+  graph: z.object({
+    nodes: z.array(graphNodeSchema),
+    edges: z.array(graphEdgeSchema),
+  }),
+})
+
+const graphEmptySchema = z.object({
+  kind: z.literal('graph'),
+  status: z.literal('empty'),
+  summary: z.string().optional(),
+})
+
+const graphErrorSchema = z.object({
+  kind: z.literal('graph'),
+  status: z.literal('error'),
+  error: z.string(),
+})
+
+const graphResponseSchema = z.discriminatedUnion('status', [
+  graphSuccessSchema,
+  graphEmptySchema,
+  graphErrorSchema,
+])
+
+const predictiveSegmentSchema = z.object({
+  segmentId: z.string(),
+  segmentName: z.string(),
+  baseline: z.number(),
+  projection: z.number(),
+  probability: z.number().min(0).max(1),
+})
+
+const predictiveSuccessSchema = z.object({
+  kind: z.literal('predictive'),
+  status: z.literal('ok'),
+  summary: z.string(),
+  generatedAt: z.string(),
+  horizonMonths: z.number().int().nonnegative(),
+  segments: z.array(predictiveSegmentSchema),
+})
+
+const predictiveEmptySchema = z.object({
+  kind: z.literal('predictive'),
+  status: z.literal('empty'),
+  summary: z.string().optional(),
+})
+
+const predictiveErrorSchema = z.object({
+  kind: z.literal('predictive'),
+  status: z.literal('error'),
+  error: z.string(),
+})
+
+const predictiveResponseSchema = z.discriminatedUnion('status', [
+  predictiveSuccessSchema,
+  predictiveEmptySchema,
+  predictiveErrorSchema,
+])
+
+const correlationRelationshipSchema = z.object({
+  pairId: z.string(),
+  driver: z.string(),
+  outcome: z.string(),
+  coefficient: z.number().min(-1).max(1),
+  pValue: z.number().min(0).max(1),
+})
+
+const correlationSuccessSchema = z.object({
+  kind: z.literal('correlation'),
+  status: z.literal('ok'),
+  summary: z.string(),
+  updatedAt: z.string(),
+  relationships: z.array(correlationRelationshipSchema),
+})
+
+const correlationEmptySchema = z.object({
+  kind: z.literal('correlation'),
+  status: z.literal('empty'),
+  summary: z.string().optional(),
+})
+
+const correlationErrorSchema = z.object({
+  kind: z.literal('correlation'),
+  status: z.literal('error'),
+  error: z.string(),
+})
+
+const correlationResponseSchema = z.discriminatedUnion('status', [
+  correlationSuccessSchema,
+  correlationEmptySchema,
+  correlationErrorSchema,
+])
+
+export type GraphIntelligenceResponse = z.infer<typeof graphResponseSchema>
+export type PredictiveIntelligenceResponse = z.infer<typeof predictiveResponseSchema>
+export type CrossCorrelationIntelligenceResponse = z.infer<
+  typeof correlationResponseSchema
+>
+
+function parseOrThrow<T>(schema: z.ZodType<T>, data: unknown, message: string): T {
+  const result = schema.safeParse(data)
+  if (!result.success) {
+    throw new IntelligenceValidationError(message, result.error.issues)
+  }
+  return result.data
+}
+
+function normaliseGraphResponse(
+  payload: GraphIntelligenceResponse,
+): GraphIntelligenceResponse {
+  if (payload.status === 'ok' && payload.graph.nodes.length === 0 && payload.graph.edges.length === 0) {
+    return {
+      kind: 'graph',
+      status: 'empty',
+      summary: payload.summary,
+    }
+  }
+  return payload
+}
+
+function normalisePredictiveResponse(
+  payload: PredictiveIntelligenceResponse,
+): PredictiveIntelligenceResponse {
+  if (payload.status === 'ok' && payload.segments.length === 0) {
+    return {
+      kind: 'predictive',
+      status: 'empty',
+      summary: payload.summary,
+    }
+  }
+  return payload
+}
+
+function normaliseCorrelationResponse(
+  payload: CrossCorrelationIntelligenceResponse,
+): CrossCorrelationIntelligenceResponse {
+  if (payload.status === 'ok' && payload.relationships.length === 0) {
+    return {
+      kind: 'correlation',
+      status: 'empty',
+      summary: payload.summary,
+    }
+  }
+  return payload
+}
+
+export async function fetchGraphIntelligence(
+  workspaceId: string,
+): Promise<GraphIntelligenceResponse> {
+  try {
+    const response = await apiClient.get<unknown>('/analytics/intelligence/graph', {
+      params: { workspaceId },
+    })
+    const payload = parseOrThrow(
+      graphResponseSchema,
+      response.data,
+      'Graph intelligence payload failed validation',
+    )
+    return normaliseGraphResponse(payload)
+  } catch (error) {
+    if (error instanceof IntelligenceValidationError) {
+      throw error
+    }
+    throw new IntelligenceRequestError('Unable to load graph intelligence', error)
+  }
+}
+
+export async function fetchPredictiveIntelligence(
+  workspaceId: string,
+): Promise<PredictiveIntelligenceResponse> {
+  try {
+    const response = await apiClient.get<unknown>(
+      '/analytics/intelligence/predictive',
+      { params: { workspaceId } },
+    )
+    const payload = parseOrThrow(
+      predictiveResponseSchema,
+      response.data,
+      'Predictive intelligence payload failed validation',
+    )
+    return normalisePredictiveResponse(payload)
+  } catch (error) {
+    if (error instanceof IntelligenceValidationError) {
+      throw error
+    }
+    throw new IntelligenceRequestError('Unable to load predictive intelligence', error)
+  }
+}
+
+export async function fetchCrossCorrelationIntelligence(
+  workspaceId: string,
+): Promise<CrossCorrelationIntelligenceResponse> {
+  try {
+    const response = await apiClient.get<unknown>(
+      '/analytics/intelligence/cross-correlation',
+      { params: { workspaceId } },
+    )
+    const payload = parseOrThrow(
+      correlationResponseSchema,
+      response.data,
+      'Cross-correlation intelligence payload failed validation',
+    )
+    return normaliseCorrelationResponse(payload)
+  } catch (error) {
+    if (error instanceof IntelligenceValidationError) {
+      throw error
+    }
+    throw new IntelligenceRequestError('Unable to load correlation intelligence', error)
+  }
+}
+
+export const advancedAnalyticsService = {
+  fetchGraphIntelligence,
+  fetchPredictiveIntelligence,
+  fetchCrossCorrelationIntelligence,
+}


### PR DESCRIPTION
## Summary
- add the advanced intelligence workspace to the SPA router so it is accessible at /visualizations/intelligence
- expose the workspace in the primary navigation with localized labels for English and Japanese

## Testing
- `pnpm test` *(fails: tsx CLI is not available in this execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ea9336848320b9e22acfaa9f5151