### PR TITLE
Handle empty query metrics in analytics page

### DIFF
--- a/frontend/src/pages/Analytics.metrics.test.tsx
+++ b/frontend/src/pages/Analytics.metrics.test.tsx
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict'
+import { afterEach, beforeEach, describe, it } from 'node:test'
+import { JSDOM } from 'jsdom'
+import React from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { TranslationProvider } from '../i18n'
+import AnalyticsPage, {
+  type AnalyticsServices,
+  type NormalizedQueryMetrics,
+} from './Analytics'
+
+describe('AnalyticsPage query metrics', () => {
+  let dom: JSDOM
+
+  beforeEach(() => {
+    dom = new JSDOM('<!doctype html><html><body></body></html>', {
+      url: 'http://localhost/analytics',
+    })
+    const globalWithDom = globalThis as typeof globalThis & {
+      window: Window & typeof globalThis
+      document: Document
+      navigator: Navigator
+    }
+    globalWithDom.window = dom.window
+    globalWithDom.document = dom.window.document
+    globalWithDom.navigator = dom.window.navigator
+  })
+
+  afterEach(() => {
+    cleanup()
+    dom.window.close()
+    const globalWithDom = globalThis as {
+      window?: Window & typeof globalThis
+      document?: Document
+      navigator?: Navigator
+    }
+    delete globalWithDom.window
+    delete globalWithDom.document
+    delete globalWithDom.navigator
+  })
+
+  it('renders normalized metrics when available', async () => {
+    const services: AnalyticsServices = {
+      fetchQueryMetrics: async () => ({
+        byId: {
+          q1: {
+            id: 'q1',
+            statement: 'SELECT * FROM buildings LIMIT 5',
+            averageDurationMs: 12,
+            executionCount: 3,
+            lastRunAt: '2024-05-01T00:00:00Z',
+          },
+        },
+        allIds: ['q1'],
+      }),
+    }
+
+    render(
+      <TranslationProvider>
+        <AnalyticsPage services={services} />
+      </TranslationProvider>,
+    )
+
+    const list = await screen.findByTestId('query-metrics-list')
+    assert.ok(list)
+    assert.match(list.textContent ?? '', /SELECT \* FROM buildings/i)
+    assert.equal(screen.queryByTestId('query-metrics-empty'), null)
+  })
+
+  it('shows an explicit empty state when no recent queries exist', async () => {
+    const services: AnalyticsServices = {
+      fetchQueryMetrics: async () => ({ byId: {}, allIds: [] }),
+    }
+
+    render(
+      <TranslationProvider>
+        <AnalyticsPage services={services} />
+      </TranslationProvider>,
+    )
+
+    const emptyState = await screen.findByTestId('query-metrics-empty')
+    assert.ok(emptyState)
+    assert.equal(emptyState.textContent?.trim(), 'No recent queries have been recorded yet.')
+    assert.equal(screen.queryByTestId('query-metrics-list'), null)
+  })
+
+  it('retains the empty normalized snapshot from the remote source', async () => {
+    const payload: NormalizedQueryMetrics = { byId: {}, allIds: [] }
+    let callCount = 0
+
+    const services: AnalyticsServices = {
+      fetchQueryMetrics: async () => {
+        callCount += 1
+        return payload
+      },
+    }
+
+    render(
+      <TranslationProvider>
+        <AnalyticsPage services={services} />
+      </TranslationProvider>,
+    )
+
+    const emptyState = await screen.findByTestId('query-metrics-empty')
+    assert.ok(emptyState)
+    assert.equal(emptyState.textContent?.trim(), 'No recent queries have been recorded yet.')
+    assert.equal(callCount, 1)
+  })
+
+  it('surfaces errors without discarding the last snapshot', async () => {
+    const services: AnalyticsServices = {
+      fetchQueryMetrics: async () => {
+        throw new Error('network down')
+      },
+    }
+
+    render(
+      <TranslationProvider>
+        <AnalyticsPage services={services} />
+      </TranslationProvider>,
+    )
+
+    const alert = await screen.findByRole('alert')
+    assert.match(alert.textContent ?? '', /network down/i)
+
+    const emptyState = await screen.findByTestId('query-metrics-empty')
+    assert.ok(emptyState)
+    assert.equal(emptyState.textContent?.trim(), 'No recent queries have been recorded yet.')
+  })
+})

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { AppLayout } from '../App'
+
+export interface QueryMetric {
+  id: string
+  statement: string
+  averageDurationMs: number
+  executionCount: number
+  lastRunAt: string
+}
+
+export interface NormalizedQueryMetrics {
+  byId: Record<string, QueryMetric>
+  allIds: string[]
+}
+
+export type QueryMetricsSource = 'local' | 'remote'
+
+type QueryMetricsStatus = 'idle' | 'loading' | 'ready'
+
+export interface QueryMetricsSnapshot {
+  source: QueryMetricsSource
+  data: NormalizedQueryMetrics
+}
+
+export interface QueryMetricsErrorState {
+  message: string
+}
+
+export interface AnalyticsServices {
+  fetchQueryMetrics: () => Promise<NormalizedQueryMetrics>
+}
+
+const EMPTY_NORMALIZED_METRICS: NormalizedQueryMetrics = {
+  byId: {},
+  allIds: [],
+}
+
+const defaultSnapshot: QueryMetricsSnapshot = {
+  source: 'local',
+  data: EMPTY_NORMALIZED_METRICS,
+}
+
+async function defaultFetchQueryMetrics(): Promise<NormalizedQueryMetrics> {
+  // Placeholder implementation; real implementation should call API service.
+  return EMPTY_NORMALIZED_METRICS
+}
+
+const defaultServices: AnalyticsServices = {
+  fetchQueryMetrics: defaultFetchQueryMetrics,
+}
+
+function renderQueryList(snapshot: QueryMetricsSnapshot) {
+  if (snapshot.data.allIds.length === 0) {
+    return (
+      <p className="analytics__empty" data-testid="query-metrics-empty">
+        No recent queries have been recorded yet.
+      </p>
+    )
+  }
+
+  return (
+    <ul className="analytics__queries" data-testid="query-metrics-list">
+      {snapshot.data.allIds.map((id) => {
+        const metric = snapshot.data.byId[id]
+        return (
+          <li key={id} className="analytics__query">
+            <pre className="analytics__query-sql">{metric.statement}</pre>
+            <dl className="analytics__query-meta">
+              <div>
+                <dt>Average duration</dt>
+                <dd>{metric.averageDurationMs.toLocaleString()} ms</dd>
+              </div>
+              <div>
+                <dt>Execution count</dt>
+                <dd>{metric.executionCount.toLocaleString()}</dd>
+              </div>
+              <div>
+                <dt>Last run</dt>
+                <dd>{metric.lastRunAt}</dd>
+              </div>
+            </dl>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+export interface AnalyticsPageProps {
+  services?: Partial<AnalyticsServices>
+}
+
+export function AnalyticsPage({ services }: AnalyticsPageProps) {
+  const mergedServices = useMemo<AnalyticsServices>(() => {
+    if (!services) {
+      return defaultServices
+    }
+    return {
+      ...defaultServices,
+      ...services,
+    }
+  }, [services])
+
+  const [metrics, setMetrics] = useState<QueryMetricsSnapshot>(defaultSnapshot)
+  const [status, setStatus] = useState<QueryMetricsStatus>('idle')
+  const [error, setError] = useState<QueryMetricsErrorState | null>(null)
+
+  const loadQueryMetrics = useCallback(async () => {
+    setStatus('loading')
+    setError(null)
+    try {
+      const normalized = await mergedServices.fetchQueryMetrics()
+      setMetrics({
+        source: 'remote',
+        data: normalized,
+      })
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Unable to load query metrics'
+      setError({ message })
+    } finally {
+      setStatus('ready')
+    }
+  }, [mergedServices])
+
+  useEffect(() => {
+    loadQueryMetrics().catch(() => {
+      // Errors handled in loadQueryMetrics
+    })
+  }, [loadQueryMetrics])
+
+  return (
+    <AppLayout title="Analytics" subtitle="Query performance overview">
+      <section className="analytics">
+        <header className="analytics__header">
+          <h3>Recent query activity</h3>
+          <button
+            type="button"
+            className="analytics__refresh"
+            onClick={() => {
+              loadQueryMetrics().catch(() => {
+                // Errors handled in loadQueryMetrics
+              })
+            }}
+            disabled={status === 'loading'}
+          >
+            {status === 'loading' ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </header>
+        {error ? (
+          <p role="alert" className="analytics__error">
+            {error.message}
+          </p>
+        ) : null}
+        {renderQueryList(metrics)}
+      </section>
+    </AppLayout>
+  )
+}
+
+export default AnalyticsPage


### PR DESCRIPTION
## Summary
- add an Analytics page that stores remote query metrics snapshots even when empty and tracks load errors separately
- render an explicit "no recent queries" message whenever the normalized metrics collection is empty
- cover the empty-state behaviour and error handling in Analytics.metrics.test.tsx

## Testing
- npm test -- Analytics.metrics *(fails: tsx command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f90416248320abfc7d9f9a967fc1