### PR TITLE
[codex] Persist Advanced Intelligence snapshots

### DIFF
--- a/backend/app/api/v1/advanced_intelligence.py
+++ b/backend/app/api/v1/advanced_intelligence.py
@@ -2,49 +2,33 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import require_viewer
+from app.api.deps import RequestIdentity, get_db, require_viewer
+from app.schemas.advanced_intelligence import (
+    CrossCorrelationIntelligenceResponse,
+    GraphIntelligenceResponse,
+    PredictiveIntelligenceResponse,
+)
+from app.services.analytics import WorkspaceAnalyticsSnapshotService
 
 router = APIRouter(prefix="/analytics/intelligence", tags=["advanced-intelligence"])
 
 
-def _empty_graph_payload(_: str) -> dict[str, Any]:
-    return {
-        "kind": "graph",
-        "status": "empty",
-        "summary": ("No investigation graph is available for this workspace yet."),
-    }
-
-
-def _empty_predictive_payload(_: str) -> dict[str, Any]:
-    return {
-        "kind": "predictive",
-        "status": "empty",
-        "summary": ("No predictive analytics are available for this workspace yet."),
-    }
-
-
-def _empty_correlation_payload(_: str) -> dict[str, Any]:
-    return {
-        "kind": "correlation",
-        "status": "empty",
-        "summary": (
-            "No cross-correlation signals are available for this workspace yet."
-        ),
-    }
-
-
-@router.get("/graph")
+@router.get("/graph", response_model=GraphIntelligenceResponse)
 async def graph_intelligence(
     workspace_id: str = Query(..., alias="workspaceId"),
-    _: str = Depends(require_viewer),
-) -> dict[str, Any]:
+    _: RequestIdentity = Depends(require_viewer),
+    db: AsyncSession = Depends(get_db),
+) -> GraphIntelligenceResponse:
     """Return relationship intelligence for the requested workspace."""
 
-    return _empty_graph_payload(workspace_id)
+    service = WorkspaceAnalyticsSnapshotService(db)
+    payload = await service.get_graph_snapshot(workspace_id)
+    return cast(GraphIntelligenceResponse, payload)
 
 
 @router.post("/ingest")
@@ -68,9 +52,10 @@ async def ingest_knowledge(
 @router.get("/predictive")
 async def predictive_intelligence(
     workspace_id: str = Query(..., alias="workspaceId"),
-    query: str = Query(None, description="Optional natural language query"),
-    _: str = Depends(require_viewer),
-) -> dict[str, Any]:
+    query: str | None = Query(None, description="Optional natural language query"),
+    _: RequestIdentity = Depends(require_viewer),
+    db: AsyncSession = Depends(get_db),
+) -> PredictiveIntelligenceResponse | dict[str, object]:
     """Return predictive analytics. If 'query' is provided, uses RAG agent."""
 
     if query:
@@ -88,14 +73,22 @@ async def predictive_intelligence(
             "segments": [],
         }
 
-    return _empty_predictive_payload(workspace_id)
+    service = WorkspaceAnalyticsSnapshotService(db)
+    payload = await service.get_predictive_snapshot(workspace_id)
+    return cast(PredictiveIntelligenceResponse, payload)
 
 
-@router.get("/cross-correlation")
+@router.get(
+    "/cross-correlation",
+    response_model=CrossCorrelationIntelligenceResponse,
+)
 async def cross_correlation_intelligence(
     workspace_id: str = Query(..., alias="workspaceId"),
-    _: str = Depends(require_viewer),
-) -> dict[str, Any]:
+    _: RequestIdentity = Depends(require_viewer),
+    db: AsyncSession = Depends(get_db),
+) -> CrossCorrelationIntelligenceResponse:
     """Return cross-correlation analytics for the requested workspace."""
 
-    return _empty_correlation_payload(workspace_id)
+    service = WorkspaceAnalyticsSnapshotService(db)
+    payload = await service.get_correlation_snapshot(workspace_id)
+    return cast(CrossCorrelationIntelligenceResponse, payload)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -32,6 +32,7 @@ def _register_alias(module_name: str, module: ModuleType) -> None:
 
 
 _MODEL_MODULES: Final[tuple[str, ...]] = (
+    "advanced_intelligence",
     "agent_advisory",
     "ai_agents",
     "ai_config",

--- a/backend/app/models/advanced_intelligence.py
+++ b/backend/app/models/advanced_intelligence.py
@@ -1,0 +1,94 @@
+"""Persisted snapshot models for Advanced Intelligence analytics."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import ClassVar
+from uuid import uuid4
+
+from app.models.base import UUID, BaseModel
+from app.models.types import FlexibleJSONB
+from sqlalchemy import DateTime, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, declared_attr, mapped_column
+from sqlalchemy.sql import func
+
+JSONType = FlexibleJSONB
+
+
+class _WorkspaceSnapshotBase(BaseModel):
+    """Shared fields for persisted workspace analytics snapshots."""
+
+    __abstract__ = True
+
+    id: Mapped[str] = mapped_column(
+        UUID(), primary_key=True, default=lambda: str(uuid4())
+    )
+    workspace_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    sample_size: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="empty")
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    payload_json: Mapped[dict] = mapped_column("payload_json", JSONType, nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    computed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    _unique_name: ClassVar[str]
+    _workspace_index_name: ClassVar[str]
+
+    @declared_attr.directive
+    def __table_args__(cls) -> tuple[object, ...]:
+        return (
+            UniqueConstraint("workspace_id", name=cls._unique_name),
+            Index(cls._workspace_index_name, "workspace_id"),
+            {"extend_existing": True},
+        )
+
+
+class WorkspaceGraphSnapshot(_WorkspaceSnapshotBase):
+    """Stored relationship intelligence payload for a workspace."""
+
+    __tablename__ = "workspace_graph_snapshots"
+    _unique_name = "uq_workspace_graph_snapshots_workspace_id"
+    _workspace_index_name = "ix_workspace_graph_snapshots_workspace_id"
+
+
+class WorkspacePredictiveSnapshot(_WorkspaceSnapshotBase):
+    """Stored predictive intelligence payload for a workspace."""
+
+    __tablename__ = "workspace_predictive_snapshots"
+    _unique_name = "uq_workspace_predictive_snapshots_workspace_id"
+    _workspace_index_name = "ix_workspace_predictive_snapshots_workspace_id"
+
+
+class WorkspaceCorrelationSnapshot(_WorkspaceSnapshotBase):
+    """Stored cross-correlation payload for a workspace."""
+
+    __tablename__ = "workspace_correlation_snapshots"
+    _unique_name = "uq_workspace_correlation_snapshots_workspace_id"
+    _workspace_index_name = "ix_workspace_correlation_snapshots_workspace_id"
+
+
+class WorkspaceSignalSnapshot(_WorkspaceSnapshotBase):
+    """Stored KPI and trend payload for a workspace."""
+
+    __tablename__ = "workspace_signal_snapshots"
+    _unique_name = "uq_workspace_signal_snapshots_workspace_id"
+    _workspace_index_name = "ix_workspace_signal_snapshots_workspace_id"
+
+
+__all__ = [
+    "WorkspaceGraphSnapshot",
+    "WorkspacePredictiveSnapshot",
+    "WorkspaceCorrelationSnapshot",
+    "WorkspaceSignalSnapshot",
+]

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -29,6 +29,7 @@ def _register_alias(module_name: str, module: ModuleType) -> None:
 
 
 _SCHEMA_MODULES: Final[tuple[str, ...]] = (
+    "advanced_intelligence",
     "ai",
     "ai_config",
     "buildable",

--- a/backend/app/schemas/advanced_intelligence.py
+++ b/backend/app/schemas/advanced_intelligence.py
@@ -1,0 +1,207 @@
+"""Typed response schemas for Advanced Intelligence routes."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal, TypeAlias, cast
+
+from pydantic import BaseModel, Field, TypeAdapter
+
+
+class GraphNode(BaseModel):
+    id: str
+    label: str
+    category: str
+    score: float = Field(ge=0)
+
+
+class GraphEdge(BaseModel):
+    id: str
+    source: str
+    target: str
+    weight: float | None = None
+
+
+class GraphSuccessResponse(BaseModel):
+    kind: Literal["graph"]
+    status: Literal["ok"]
+    summary: str
+    generatedAt: str
+    graph: dict[str, list[GraphNode] | list[GraphEdge]]
+
+
+class GraphEmptyResponse(BaseModel):
+    kind: Literal["graph"]
+    status: Literal["empty"]
+    summary: str
+
+
+class GraphErrorResponse(BaseModel):
+    kind: Literal["graph"]
+    status: Literal["error"]
+    error: str
+
+
+GraphIntelligenceResponse: TypeAlias = Annotated[
+    GraphSuccessResponse | GraphEmptyResponse | GraphErrorResponse,
+    Field(discriminator="status"),
+]
+
+
+class PredictiveSegment(BaseModel):
+    segmentId: str
+    segmentName: str
+    baseline: float
+    projection: float
+    probability: float = Field(ge=0, le=1)
+
+
+class PredictiveSuccessResponse(BaseModel):
+    kind: Literal["predictive"]
+    status: Literal["ok"]
+    summary: str
+    generatedAt: str
+    horizonMonths: int = Field(ge=0)
+    segments: list[PredictiveSegment]
+
+
+class PredictiveEmptyResponse(BaseModel):
+    kind: Literal["predictive"]
+    status: Literal["empty"]
+    summary: str
+
+
+class PredictiveErrorResponse(BaseModel):
+    kind: Literal["predictive"]
+    status: Literal["error"]
+    error: str
+
+
+PredictiveIntelligenceResponse: TypeAlias = Annotated[
+    PredictiveSuccessResponse | PredictiveEmptyResponse | PredictiveErrorResponse,
+    Field(discriminator="status"),
+]
+
+
+class CorrelationRelationship(BaseModel):
+    pairId: str
+    driver: str
+    outcome: str
+    coefficient: float = Field(ge=-1, le=1)
+    pValue: float = Field(ge=0, le=1)
+
+
+class CorrelationSuccessResponse(BaseModel):
+    kind: Literal["correlation"]
+    status: Literal["ok"]
+    summary: str
+    updatedAt: str
+    relationships: list[CorrelationRelationship]
+
+
+class CorrelationEmptyResponse(BaseModel):
+    kind: Literal["correlation"]
+    status: Literal["empty"]
+    summary: str
+
+
+class CorrelationErrorResponse(BaseModel):
+    kind: Literal["correlation"]
+    status: Literal["error"]
+    error: str
+
+
+CrossCorrelationIntelligenceResponse: TypeAlias = Annotated[
+    CorrelationSuccessResponse | CorrelationEmptyResponse | CorrelationErrorResponse,
+    Field(discriminator="status"),
+]
+
+
+class SignalHistoryPoint(BaseModel):
+    timestamp: str
+    value: float
+
+
+class WorkspaceSignal(BaseModel):
+    signalId: str
+    label: str
+    value: float | None = None
+    unit: str | None = None
+    trend: list[SignalHistoryPoint] = Field(default_factory=list)
+
+
+class SignalSuccessResponse(BaseModel):
+    kind: Literal["signals"]
+    status: Literal["ok"]
+    summary: str
+    generatedAt: str
+    signals: list[WorkspaceSignal]
+
+
+class SignalEmptyResponse(BaseModel):
+    kind: Literal["signals"]
+    status: Literal["empty"]
+    summary: str
+
+
+class SignalErrorResponse(BaseModel):
+    kind: Literal["signals"]
+    status: Literal["error"]
+    error: str
+
+
+WorkspaceSignalsResponse: TypeAlias = Annotated[
+    SignalSuccessResponse | SignalEmptyResponse | SignalErrorResponse,
+    Field(discriminator="status"),
+]
+
+_graph_adapter: TypeAdapter[GraphIntelligenceResponse] = TypeAdapter(
+    GraphIntelligenceResponse
+)
+_predictive_adapter: TypeAdapter[PredictiveIntelligenceResponse] = TypeAdapter(
+    PredictiveIntelligenceResponse
+)
+_correlation_adapter: TypeAdapter[CrossCorrelationIntelligenceResponse] = TypeAdapter(
+    CrossCorrelationIntelligenceResponse
+)
+_signals_adapter: TypeAdapter[WorkspaceSignalsResponse] = TypeAdapter(
+    WorkspaceSignalsResponse
+)
+
+
+def parse_graph_response(payload: Any) -> GraphIntelligenceResponse:
+    return cast(GraphIntelligenceResponse, _graph_adapter.validate_python(payload))
+
+
+def parse_predictive_response(payload: Any) -> PredictiveIntelligenceResponse:
+    return cast(
+        PredictiveIntelligenceResponse,
+        _predictive_adapter.validate_python(payload),
+    )
+
+
+def parse_correlation_response(payload: Any) -> CrossCorrelationIntelligenceResponse:
+    return cast(
+        CrossCorrelationIntelligenceResponse,
+        _correlation_adapter.validate_python(payload),
+    )
+
+
+def parse_signals_response(payload: Any) -> WorkspaceSignalsResponse:
+    return cast(WorkspaceSignalsResponse, _signals_adapter.validate_python(payload))
+
+
+__all__ = [
+    "CorrelationRelationship",
+    "CrossCorrelationIntelligenceResponse",
+    "GraphEdge",
+    "GraphIntelligenceResponse",
+    "GraphNode",
+    "PredictiveIntelligenceResponse",
+    "PredictiveSegment",
+    "WorkspaceSignal",
+    "WorkspaceSignalsResponse",
+    "parse_correlation_response",
+    "parse_graph_response",
+    "parse_predictive_response",
+    "parse_signals_response",
+]

--- a/backend/app/services/analytics/__init__.py
+++ b/backend/app/services/analytics/__init__.py
@@ -1,0 +1,5 @@
+"""Services for persisted Advanced Intelligence analytics."""
+
+from .workspace_snapshots import WorkspaceAnalyticsSnapshotService
+
+__all__ = ["WorkspaceAnalyticsSnapshotService"]

--- a/backend/app/services/analytics/workspace_snapshots.py
+++ b/backend/app/services/analytics/workspace_snapshots.py
@@ -1,0 +1,249 @@
+"""Persistence helpers for Advanced Intelligence snapshots."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, TypeVar
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.advanced_intelligence import (
+    WorkspaceCorrelationSnapshot,
+    WorkspaceGraphSnapshot,
+    WorkspacePredictiveSnapshot,
+    WorkspaceSignalSnapshot,
+)
+from app.schemas.advanced_intelligence import (
+    CrossCorrelationIntelligenceResponse,
+    GraphIntelligenceResponse,
+    PredictiveIntelligenceResponse,
+    WorkspaceSignalsResponse,
+    parse_correlation_response,
+    parse_graph_response,
+    parse_predictive_response,
+    parse_signals_response,
+)
+
+SnapshotModel = TypeVar(
+    "SnapshotModel",
+    WorkspaceGraphSnapshot,
+    WorkspacePredictiveSnapshot,
+    WorkspaceCorrelationSnapshot,
+    WorkspaceSignalSnapshot,
+)
+
+
+def _empty_graph_payload(workspace_id: str) -> dict[str, Any]:
+    return {
+        "kind": "graph",
+        "status": "empty",
+        "summary": (
+            f"No investigation graph is available for workspace '{workspace_id}' yet."
+        ),
+    }
+
+
+def _empty_predictive_payload(workspace_id: str) -> dict[str, Any]:
+    return {
+        "kind": "predictive",
+        "status": "empty",
+        "summary": (
+            "No predictive analytics are available for "
+            f"workspace '{workspace_id}' yet."
+        ),
+    }
+
+
+def _empty_correlation_payload(workspace_id: str) -> dict[str, Any]:
+    return {
+        "kind": "correlation",
+        "status": "empty",
+        "summary": (
+            "No cross-correlation signals are available for "
+            f"workspace '{workspace_id}' yet."
+        ),
+    }
+
+
+def _empty_signals_payload(workspace_id: str) -> dict[str, Any]:
+    return {
+        "kind": "signals",
+        "status": "empty",
+        "summary": f"No workspace signal snapshots are available for '{workspace_id}' yet.",
+    }
+
+
+class WorkspaceAnalyticsSnapshotService:
+    """Read and write persisted analytics snapshots for a workspace."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_graph_snapshot(self, workspace_id: str) -> GraphIntelligenceResponse:
+        snapshot = await self._get_or_create_snapshot(
+            WorkspaceGraphSnapshot,
+            workspace_id,
+            payload_factory=_empty_graph_payload,
+        )
+        return parse_graph_response(snapshot.payload_json)
+
+    async def get_predictive_snapshot(
+        self, workspace_id: str
+    ) -> PredictiveIntelligenceResponse:
+        snapshot = await self._get_or_create_snapshot(
+            WorkspacePredictiveSnapshot,
+            workspace_id,
+            payload_factory=_empty_predictive_payload,
+        )
+        return parse_predictive_response(snapshot.payload_json)
+
+    async def get_correlation_snapshot(
+        self, workspace_id: str
+    ) -> CrossCorrelationIntelligenceResponse:
+        snapshot = await self._get_or_create_snapshot(
+            WorkspaceCorrelationSnapshot,
+            workspace_id,
+            payload_factory=_empty_correlation_payload,
+        )
+        return parse_correlation_response(snapshot.payload_json)
+
+    async def get_signal_snapshot(self, workspace_id: str) -> WorkspaceSignalsResponse:
+        snapshot = await self._get_or_create_snapshot(
+            WorkspaceSignalSnapshot,
+            workspace_id,
+            payload_factory=_empty_signals_payload,
+        )
+        return parse_signals_response(snapshot.payload_json)
+
+    async def save_graph_snapshot(
+        self,
+        workspace_id: str,
+        *,
+        payload: dict[str, Any],
+        sample_size: int,
+        version: int = 1,
+    ) -> WorkspaceGraphSnapshot:
+        return await self._save_snapshot(
+            WorkspaceGraphSnapshot,
+            workspace_id,
+            payload=payload,
+            sample_size=sample_size,
+            version=version,
+        )
+
+    async def save_predictive_snapshot(
+        self,
+        workspace_id: str,
+        *,
+        payload: dict[str, Any],
+        sample_size: int,
+        version: int = 1,
+    ) -> WorkspacePredictiveSnapshot:
+        return await self._save_snapshot(
+            WorkspacePredictiveSnapshot,
+            workspace_id,
+            payload=payload,
+            sample_size=sample_size,
+            version=version,
+        )
+
+    async def save_correlation_snapshot(
+        self,
+        workspace_id: str,
+        *,
+        payload: dict[str, Any],
+        sample_size: int,
+        version: int = 1,
+    ) -> WorkspaceCorrelationSnapshot:
+        return await self._save_snapshot(
+            WorkspaceCorrelationSnapshot,
+            workspace_id,
+            payload=payload,
+            sample_size=sample_size,
+            version=version,
+        )
+
+    async def save_signal_snapshot(
+        self,
+        workspace_id: str,
+        *,
+        payload: dict[str, Any],
+        sample_size: int,
+        version: int = 1,
+    ) -> WorkspaceSignalSnapshot:
+        return await self._save_snapshot(
+            WorkspaceSignalSnapshot,
+            workspace_id,
+            payload=payload,
+            sample_size=sample_size,
+            version=version,
+        )
+
+    async def _get_or_create_snapshot(
+        self,
+        model: type[SnapshotModel],
+        workspace_id: str,
+        *,
+        payload_factory: Callable[[str], dict[str, Any]],
+    ) -> SnapshotModel:
+        snapshot = await self._get_snapshot(model, workspace_id)
+        if snapshot is not None:
+            return snapshot
+
+        payload = payload_factory(workspace_id)
+        snapshot = model(
+            workspace_id=workspace_id,
+            sample_size=0,
+            status=payload["status"],
+            summary=payload.get("summary", ""),
+            payload_json=payload,
+            version=1,
+        )
+        self._session.add(snapshot)
+        await self._session.commit()
+        await self._session.refresh(snapshot)
+        return snapshot
+
+    async def _save_snapshot(
+        self,
+        model: type[SnapshotModel],
+        workspace_id: str,
+        *,
+        payload: dict[str, Any],
+        sample_size: int,
+        version: int,
+    ) -> SnapshotModel:
+        snapshot = await self._get_snapshot(model, workspace_id)
+        if snapshot is None:
+            snapshot = model(
+                workspace_id=workspace_id,
+                sample_size=sample_size,
+                status=payload["status"],
+                summary=payload.get("summary", ""),
+                payload_json=payload,
+                version=version,
+            )
+            self._session.add(snapshot)
+        else:
+            snapshot.sample_size = sample_size
+            snapshot.status = payload["status"]
+            snapshot.summary = payload.get("summary", "")
+            snapshot.payload_json = payload
+            snapshot.version = version
+
+        await self._session.commit()
+        await self._session.refresh(snapshot)
+        return snapshot
+
+    async def _get_snapshot(
+        self,
+        model: type[SnapshotModel],
+        workspace_id: str,
+    ) -> SnapshotModel | None:
+        result = await self._session.execute(
+            select(model).where(model.workspace_id == workspace_id)
+        )
+        return result.scalar_one_or_none()
+
+
+__all__ = ["WorkspaceAnalyticsSnapshotService"]

--- a/backend/migrations/versions/20260406_000041_add_advanced_intelligence_snapshot_tables.py
+++ b/backend/migrations/versions/20260406_000041_add_advanced_intelligence_snapshot_tables.py
@@ -1,0 +1,113 @@
+"""add_advanced_intelligence_snapshot_tables
+
+Revision ID: 20260406_000041
+Revises: 20260117_000040
+Create Date: 2026-04-06 11:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "20260406_000041"
+down_revision: Union[str, None] = "20260117_000040"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _create_snapshot_table(table_name: str, unique_name: str, index_name: str) -> None:
+    op.create_table(
+        table_name,
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("workspace_id", sa.String(length=255), nullable=False),
+        sa.Column(
+            "sample_size",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            nullable=False,
+            server_default=sa.text("'empty'"),
+        ),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("payload_json", sa.JSON(), nullable=False),
+        sa.Column(
+            "version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column(
+            "computed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("workspace_id", name=unique_name),
+    )
+    op.create_index(index_name, table_name, ["workspace_id"], unique=False)
+
+
+def upgrade() -> None:
+    _create_snapshot_table(
+        "workspace_graph_snapshots",
+        "uq_workspace_graph_snapshots_workspace_id",
+        "ix_workspace_graph_snapshots_workspace_id",
+    )
+    _create_snapshot_table(
+        "workspace_predictive_snapshots",
+        "uq_workspace_predictive_snapshots_workspace_id",
+        "ix_workspace_predictive_snapshots_workspace_id",
+    )
+    _create_snapshot_table(
+        "workspace_correlation_snapshots",
+        "uq_workspace_correlation_snapshots_workspace_id",
+        "ix_workspace_correlation_snapshots_workspace_id",
+    )
+    _create_snapshot_table(
+        "workspace_signal_snapshots",
+        "uq_workspace_signal_snapshots_workspace_id",
+        "ix_workspace_signal_snapshots_workspace_id",
+    )
+
+
+def downgrade() -> None:
+    for table_name, index_name in (
+        (
+            "workspace_signal_snapshots",
+            "ix_workspace_signal_snapshots_workspace_id",
+        ),
+        (
+            "workspace_correlation_snapshots",
+            "ix_workspace_correlation_snapshots_workspace_id",
+        ),
+        (
+            "workspace_predictive_snapshots",
+            "ix_workspace_predictive_snapshots_workspace_id",
+        ),
+        (
+            "workspace_graph_snapshots",
+            "ix_workspace_graph_snapshots_workspace_id",
+        ),
+    ):
+        op.execute(f'DROP INDEX IF EXISTS "{index_name}"')
+        op.execute(f"DROP TABLE IF EXISTS {table_name}")

--- a/backend/tests/test_api/test_advanced_intelligence.py
+++ b/backend/tests/test_api/test_advanced_intelligence.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
 import pytest
+from sqlalchemy import select
+
+from app.models.advanced_intelligence import (
+    WorkspaceCorrelationSnapshot,
+    WorkspaceGraphSnapshot,
+    WorkspacePredictiveSnapshot,
+)
+from app.services.intelligence import intelligence_service
+from app.services.analytics import WorkspaceAnalyticsSnapshotService
 
 
 @pytest.mark.asyncio
-async def test_graph_intelligence_returns_empty_state(client):
+async def test_graph_intelligence_persists_empty_snapshot(client, db_session):
     response = await client.get(
         "/api/v1/analytics/intelligence/graph",
         params={"workspaceId": "ws-123"},
@@ -14,11 +23,66 @@ async def test_graph_intelligence_returns_empty_state(client):
     payload = response.json()
     assert payload["kind"] == "graph"
     assert payload["status"] == "empty"
-    assert "available" in payload["summary"]
+    assert "ws-123" in payload["summary"]
+
+    snapshot = await db_session.scalar(
+        select(WorkspaceGraphSnapshot).where(
+            WorkspaceGraphSnapshot.workspace_id == "ws-123"
+        )
+    )
+    assert snapshot is not None
+    assert snapshot.status == "empty"
+    assert snapshot.sample_size == 0
+    assert snapshot.payload_json["kind"] == "graph"
 
 
 @pytest.mark.asyncio
-async def test_predictive_intelligence_returns_empty_state_without_query(client):
+async def test_graph_intelligence_returns_persisted_snapshot(client, db_session):
+    service = WorkspaceAnalyticsSnapshotService(db_session)
+    await service.save_graph_snapshot(
+        "ws-graph-ok",
+        payload={
+            "kind": "graph",
+            "status": "ok",
+            "summary": "Persisted relationship graph",
+            "generatedAt": "2026-04-06T00:00:00Z",
+            "graph": {
+                "nodes": [
+                    {
+                        "id": "user-1",
+                        "label": "Analyst",
+                        "category": "team",
+                        "score": 0.8,
+                    }
+                ],
+                "edges": [
+                    {
+                        "id": "edge-1",
+                        "source": "user-1",
+                        "target": "workflow-1",
+                        "weight": 0.4,
+                    }
+                ],
+            },
+        },
+        sample_size=5,
+    )
+
+    response = await client.get(
+        "/api/v1/analytics/intelligence/graph",
+        params={"workspaceId": "ws-graph-ok"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["graph"]["nodes"][0]["label"] == "Analyst"
+
+
+@pytest.mark.asyncio
+async def test_predictive_intelligence_persists_empty_snapshot_without_query(
+    client, db_session
+):
     response = await client.get(
         "/api/v1/analytics/intelligence/predictive",
         params={"workspaceId": "ws-789"},
@@ -28,11 +92,79 @@ async def test_predictive_intelligence_returns_empty_state_without_query(client)
     payload = response.json()
     assert payload["kind"] == "predictive"
     assert payload["status"] == "empty"
-    assert "available" in payload["summary"]
+    assert "ws-789" in payload["summary"]
+
+    snapshot = await db_session.scalar(
+        select(WorkspacePredictiveSnapshot).where(
+            WorkspacePredictiveSnapshot.workspace_id == "ws-789"
+        )
+    )
+    assert snapshot is not None
+    assert snapshot.status == "empty"
+    assert snapshot.sample_size == 0
 
 
 @pytest.mark.asyncio
-async def test_cross_correlation_intelligence_returns_empty_state(client):
+async def test_predictive_intelligence_returns_persisted_snapshot(client, db_session):
+    service = WorkspaceAnalyticsSnapshotService(db_session)
+    await service.save_predictive_snapshot(
+        "ws-predictive-ok",
+        payload={
+            "kind": "predictive",
+            "status": "ok",
+            "summary": "Persisted predictive snapshot",
+            "generatedAt": "2026-04-06T00:00:00Z",
+            "horizonMonths": 6,
+            "segments": [
+                {
+                    "segmentId": "seg-1",
+                    "segmentName": "High fit",
+                    "baseline": 10,
+                    "projection": 14,
+                    "probability": 0.7,
+                }
+            ],
+        },
+        sample_size=8,
+    )
+
+    response = await client.get(
+        "/api/v1/analytics/intelligence/predictive",
+        params={"workspaceId": "ws-predictive-ok"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["segments"][0]["segmentName"] == "High fit"
+
+
+@pytest.mark.asyncio
+async def test_predictive_intelligence_query_path_still_returns_agent_payload(
+    client, monkeypatch
+):
+    monkeypatch.setattr(
+        intelligence_service,
+        "query_agent",
+        lambda query: f"Agent answer for {query}",
+    )
+
+    response = await client.get(
+        "/api/v1/analytics/intelligence/predictive",
+        params={"workspaceId": "ws-agent", "query": "status"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["kind"] == "predictive_agent"
+    assert payload["status"] == "ok"
+    assert payload["summary"] == "Agent answer for status"
+
+
+@pytest.mark.asyncio
+async def test_cross_correlation_intelligence_persists_empty_snapshot(
+    client, db_session
+):
     response = await client.get(
         "/api/v1/analytics/intelligence/cross-correlation",
         params={"workspaceId": "ws-456"},
@@ -42,4 +174,49 @@ async def test_cross_correlation_intelligence_returns_empty_state(client):
     payload = response.json()
     assert payload["kind"] == "correlation"
     assert payload["status"] == "empty"
-    assert "available" in payload["summary"]
+    assert "ws-456" in payload["summary"]
+
+    snapshot = await db_session.scalar(
+        select(WorkspaceCorrelationSnapshot).where(
+            WorkspaceCorrelationSnapshot.workspace_id == "ws-456"
+        )
+    )
+    assert snapshot is not None
+    assert snapshot.status == "empty"
+    assert snapshot.sample_size == 0
+
+
+@pytest.mark.asyncio
+async def test_cross_correlation_intelligence_returns_persisted_snapshot(
+    client, db_session
+):
+    service = WorkspaceAnalyticsSnapshotService(db_session)
+    await service.save_correlation_snapshot(
+        "ws-correlation-ok",
+        payload={
+            "kind": "correlation",
+            "status": "ok",
+            "summary": "Persisted cross-correlation snapshot",
+            "updatedAt": "2026-04-06T00:00:00Z",
+            "relationships": [
+                {
+                    "pairId": "finance_speed",
+                    "driver": "Finance readiness",
+                    "outcome": "Approval speed",
+                    "coefficient": 0.62,
+                    "pValue": 0.03,
+                }
+            ],
+        },
+        sample_size=12,
+    )
+
+    response = await client.get(
+        "/api/v1/analytics/intelligence/cross-correlation",
+        params={"workspaceId": "ws-correlation-ok"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["relationships"][0]["pairId"] == "finance_speed"


### PR DESCRIPTION
## Summary
- add persisted workspace snapshot tables for graph, predictive, correlation, and signal analytics
- move Advanced Intelligence route payload retrieval into a snapshot-backed service that lazily creates explicit empty snapshots
- add typed response schemas and API tests covering persisted snapshots plus the existing predictive-agent query path

## Testing
- /Users/tb/Projects/optimal_build/.venv/bin/pytest backend/tests/test_api/test_advanced_intelligence.py -q
