### PR TITLE
[codex] Scope Advanced Intelligence to projects

### DIFF
--- a/backend/app/api/v1/advanced_intelligence.py
+++ b/backend/app/api/v1/advanced_intelligence.py
@@ -13,21 +13,30 @@ from app.schemas.advanced_intelligence import (
     GraphIntelligenceResponse,
     PredictiveIntelligenceResponse,
 )
-from app.services.analytics import WorkspaceAnalyticsSnapshotService
+from app.services.analytics import (
+    WorkspaceAnalyticsSnapshotService,
+    resolve_analytics_scope,
+)
 
 router = APIRouter(prefix="/analytics/intelligence", tags=["advanced-intelligence"])
 
 
 @router.get("/graph", response_model=GraphIntelligenceResponse)
 async def graph_intelligence(
-    workspace_id: str = Query(..., alias="workspaceId"),
+    project_id: str | None = Query(None, alias="projectId"),
+    workspace_id: str | None = Query(None, alias="workspaceId"),
     _: RequestIdentity = Depends(require_viewer),
     db: AsyncSession = Depends(get_db),
 ) -> GraphIntelligenceResponse:
     """Return relationship intelligence for the requested workspace."""
 
+    scope = await resolve_analytics_scope(
+        db,
+        project_id=project_id,
+        workspace_id=workspace_id,
+    )
     service = WorkspaceAnalyticsSnapshotService(db)
-    payload = await service.get_graph_snapshot(workspace_id)
+    payload = await service.get_graph_snapshot(scope.scope_id)
     return cast(GraphIntelligenceResponse, payload)
 
 
@@ -51,7 +60,8 @@ async def ingest_knowledge(
 
 @router.get("/predictive")
 async def predictive_intelligence(
-    workspace_id: str = Query(..., alias="workspaceId"),
+    project_id: str | None = Query(None, alias="projectId"),
+    workspace_id: str | None = Query(None, alias="workspaceId"),
     query: str | None = Query(None, description="Optional natural language query"),
     _: RequestIdentity = Depends(require_viewer),
     db: AsyncSession = Depends(get_db),
@@ -73,8 +83,13 @@ async def predictive_intelligence(
             "segments": [],
         }
 
+    scope = await resolve_analytics_scope(
+        db,
+        project_id=project_id,
+        workspace_id=workspace_id,
+    )
     service = WorkspaceAnalyticsSnapshotService(db)
-    payload = await service.get_predictive_snapshot(workspace_id)
+    payload = await service.get_predictive_snapshot(scope.scope_id)
     return cast(PredictiveIntelligenceResponse, payload)
 
 
@@ -83,12 +98,18 @@ async def predictive_intelligence(
     response_model=CrossCorrelationIntelligenceResponse,
 )
 async def cross_correlation_intelligence(
-    workspace_id: str = Query(..., alias="workspaceId"),
+    project_id: str | None = Query(None, alias="projectId"),
+    workspace_id: str | None = Query(None, alias="workspaceId"),
     _: RequestIdentity = Depends(require_viewer),
     db: AsyncSession = Depends(get_db),
 ) -> CrossCorrelationIntelligenceResponse:
     """Return cross-correlation analytics for the requested workspace."""
 
+    scope = await resolve_analytics_scope(
+        db,
+        project_id=project_id,
+        workspace_id=workspace_id,
+    )
     service = WorkspaceAnalyticsSnapshotService(db)
-    payload = await service.get_correlation_snapshot(workspace_id)
+    payload = await service.get_correlation_snapshot(scope.scope_id)
     return cast(CrossCorrelationIntelligenceResponse, payload)

--- a/backend/app/services/analytics/__init__.py
+++ b/backend/app/services/analytics/__init__.py
@@ -1,5 +1,10 @@
 """Services for persisted Advanced Intelligence analytics."""
 
+from .scope import AnalyticsScope, resolve_analytics_scope
 from .workspace_snapshots import WorkspaceAnalyticsSnapshotService
 
-__all__ = ["WorkspaceAnalyticsSnapshotService"]
+__all__ = [
+    "AnalyticsScope",
+    "WorkspaceAnalyticsSnapshotService",
+    "resolve_analytics_scope",
+]

--- a/backend/app/services/analytics/scope.py
+++ b/backend/app/services/analytics/scope.py
@@ -1,0 +1,52 @@
+"""Helpers for resolving Advanced Intelligence request scope."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.projects import Project
+
+
+@dataclass(frozen=True, slots=True)
+class AnalyticsScope:
+    """Resolved analytics scope for snapshot-backed routes."""
+
+    scope_id: str
+    project_id: str | None = None
+
+
+async def resolve_analytics_scope(
+    session: AsyncSession,
+    *,
+    project_id: str | None,
+    workspace_id: str | None,
+) -> AnalyticsScope:
+    """Resolve a durable analytics scope key from route query params."""
+
+    normalized_project_id = (project_id or "").strip()
+    if normalized_project_id:
+        project = await session.get(Project, normalized_project_id)
+        if project is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Project '{normalized_project_id}' was not found",
+            )
+        return AnalyticsScope(
+            scope_id=f"project:{normalized_project_id}",
+            project_id=normalized_project_id,
+        )
+
+    normalized_workspace_id = (workspace_id or "").strip()
+    if normalized_workspace_id:
+        return AnalyticsScope(scope_id=normalized_workspace_id)
+
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        detail="projectId or workspaceId is required",
+    )
+
+
+__all__ = ["AnalyticsScope", "resolve_analytics_scope"]

--- a/backend/tests/test_api/test_advanced_intelligence.py
+++ b/backend/tests/test_api/test_advanced_intelligence.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import uuid
+
 import pytest
 from sqlalchemy import select
 
@@ -8,26 +10,43 @@ from app.models.advanced_intelligence import (
     WorkspaceGraphSnapshot,
     WorkspacePredictiveSnapshot,
 )
+from app.models.projects import Project, ProjectPhase, ProjectType
 from app.services.intelligence import intelligence_service
 from app.services.analytics import WorkspaceAnalyticsSnapshotService
 
 
+async def _create_project(db_session) -> str:
+    project_id = str(uuid.uuid4())
+    project = Project(
+        id=project_id,
+        project_name="Analytics Project",
+        project_code=f"AN-{project_id[:8]}",
+        project_type=ProjectType.NEW_DEVELOPMENT,
+        current_phase=ProjectPhase.CONCEPT,
+    )
+    db_session.add(project)
+    await db_session.commit()
+    return project_id
+
+
 @pytest.mark.asyncio
 async def test_graph_intelligence_persists_empty_snapshot(client, db_session):
+    project_id = await _create_project(db_session)
+
     response = await client.get(
         "/api/v1/analytics/intelligence/graph",
-        params={"workspaceId": "ws-123"},
+        params={"projectId": project_id},
     )
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["kind"] == "graph"
     assert payload["status"] == "empty"
-    assert "ws-123" in payload["summary"]
+    assert "project:" in payload["summary"]
 
     snapshot = await db_session.scalar(
         select(WorkspaceGraphSnapshot).where(
-            WorkspaceGraphSnapshot.workspace_id == "ws-123"
+            WorkspaceGraphSnapshot.workspace_id == f"project:{project_id}"
         )
     )
     assert snapshot is not None
@@ -38,9 +57,10 @@ async def test_graph_intelligence_persists_empty_snapshot(client, db_session):
 
 @pytest.mark.asyncio
 async def test_graph_intelligence_returns_persisted_snapshot(client, db_session):
+    project_id = await _create_project(db_session)
     service = WorkspaceAnalyticsSnapshotService(db_session)
     await service.save_graph_snapshot(
-        "ws-graph-ok",
+        f"project:{project_id}",
         payload={
             "kind": "graph",
             "status": "ok",
@@ -70,7 +90,7 @@ async def test_graph_intelligence_returns_persisted_snapshot(client, db_session)
 
     response = await client.get(
         "/api/v1/analytics/intelligence/graph",
-        params={"workspaceId": "ws-graph-ok"},
+        params={"projectId": project_id},
     )
 
     assert response.status_code == 200
@@ -83,20 +103,21 @@ async def test_graph_intelligence_returns_persisted_snapshot(client, db_session)
 async def test_predictive_intelligence_persists_empty_snapshot_without_query(
     client, db_session
 ):
+    project_id = await _create_project(db_session)
     response = await client.get(
         "/api/v1/analytics/intelligence/predictive",
-        params={"workspaceId": "ws-789"},
+        params={"projectId": project_id},
     )
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["kind"] == "predictive"
     assert payload["status"] == "empty"
-    assert "ws-789" in payload["summary"]
+    assert "project:" in payload["summary"]
 
     snapshot = await db_session.scalar(
         select(WorkspacePredictiveSnapshot).where(
-            WorkspacePredictiveSnapshot.workspace_id == "ws-789"
+            WorkspacePredictiveSnapshot.workspace_id == f"project:{project_id}"
         )
     )
     assert snapshot is not None
@@ -106,9 +127,10 @@ async def test_predictive_intelligence_persists_empty_snapshot_without_query(
 
 @pytest.mark.asyncio
 async def test_predictive_intelligence_returns_persisted_snapshot(client, db_session):
+    project_id = await _create_project(db_session)
     service = WorkspaceAnalyticsSnapshotService(db_session)
     await service.save_predictive_snapshot(
-        "ws-predictive-ok",
+        f"project:{project_id}",
         payload={
             "kind": "predictive",
             "status": "ok",
@@ -130,7 +152,7 @@ async def test_predictive_intelligence_returns_persisted_snapshot(client, db_ses
 
     response = await client.get(
         "/api/v1/analytics/intelligence/predictive",
-        params={"workspaceId": "ws-predictive-ok"},
+        params={"projectId": project_id},
     )
 
     assert response.status_code == 200
@@ -165,20 +187,21 @@ async def test_predictive_intelligence_query_path_still_returns_agent_payload(
 async def test_cross_correlation_intelligence_persists_empty_snapshot(
     client, db_session
 ):
+    project_id = await _create_project(db_session)
     response = await client.get(
         "/api/v1/analytics/intelligence/cross-correlation",
-        params={"workspaceId": "ws-456"},
+        params={"projectId": project_id},
     )
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["kind"] == "correlation"
     assert payload["status"] == "empty"
-    assert "ws-456" in payload["summary"]
+    assert "project:" in payload["summary"]
 
     snapshot = await db_session.scalar(
         select(WorkspaceCorrelationSnapshot).where(
-            WorkspaceCorrelationSnapshot.workspace_id == "ws-456"
+            WorkspaceCorrelationSnapshot.workspace_id == f"project:{project_id}"
         )
     )
     assert snapshot is not None
@@ -190,9 +213,10 @@ async def test_cross_correlation_intelligence_persists_empty_snapshot(
 async def test_cross_correlation_intelligence_returns_persisted_snapshot(
     client, db_session
 ):
+    project_id = await _create_project(db_session)
     service = WorkspaceAnalyticsSnapshotService(db_session)
     await service.save_correlation_snapshot(
-        "ws-correlation-ok",
+        f"project:{project_id}",
         payload={
             "kind": "correlation",
             "status": "ok",
@@ -213,10 +237,20 @@ async def test_cross_correlation_intelligence_returns_persisted_snapshot(
 
     response = await client.get(
         "/api/v1/analytics/intelligence/cross-correlation",
-        params={"workspaceId": "ws-correlation-ok"},
+        params={"projectId": project_id},
     )
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["status"] == "ok"
     assert payload["relationships"][0]["pairId"] == "finance_speed"
+
+
+@pytest.mark.asyncio
+async def test_graph_intelligence_rejects_unknown_project(client):
+    response = await client.get(
+        "/api/v1/analytics/intelligence/graph",
+        params={"projectId": str(uuid.uuid4())},
+    )
+
+    assert response.status_code == 404

--- a/frontend/src/pages/visualizations/AdvancedIntelligence.tsx
+++ b/frontend/src/pages/visualizations/AdvancedIntelligence.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useMemo } from 'react'
+import { ReactNode, useCallback, useContext, useMemo } from 'react'
 import { Box, Grid, Typography, useTheme } from '@mui/material'
 import {
   AccountTreeOutlined,
@@ -9,6 +9,8 @@ import {
 
 import { AppLayout } from '../../App'
 import { EmptyState, Skeleton, SkeletonText } from '../../components/canonical'
+import { ProjectContext } from '../../contexts/projectContextDef'
+import { useRouterParams } from '../../router'
 import {
   type CrossCorrelationIntelligenceState,
   type GraphIntelligenceState,
@@ -22,11 +24,9 @@ import { ConfidenceGauge } from './components/ConfidenceGauge'
 import { CorrelationHeatmap } from './components/CorrelationHeatmap'
 
 export interface AdvancedIntelligencePageProps {
-  workspaceId?: string
+  projectId?: string
   services?: Partial<InvestigationAnalyticsServices>
 }
-
-const DEFAULT_WORKSPACE_ID = 'default-investigation'
 
 interface IntelligenceStatusPanelProps {
   status: 'loading' | 'empty' | 'error'
@@ -204,12 +204,17 @@ function isCorrelationError(
   return correlation.status === 'error'
 }
 
-export function AdvancedIntelligencePage({
-  workspaceId = DEFAULT_WORKSPACE_ID,
+interface AdvancedIntelligenceContentProps {
+  projectId: string
+  services?: Partial<InvestigationAnalyticsServices>
+}
+
+function AdvancedIntelligenceContent({
+  projectId,
   services,
-}: AdvancedIntelligencePageProps) {
+}: AdvancedIntelligenceContentProps) {
   const { graph, predictive, correlation, isLoading, refetch } =
-    useInvestigationAnalytics(workspaceId, services)
+    useInvestigationAnalytics(projectId, services)
   const theme = useTheme()
 
   const handleRefresh = useCallback(() => {
@@ -291,7 +296,7 @@ export function AdvancedIntelligencePage({
             fontSize: 'var(--ob-font-size-sm)',
           }}
         >
-          {isLoading ? 'SYNCING...' : 'SYNC WORKSPACE'}
+          {isLoading ? 'SYNCING...' : 'SYNC PROJECT'}
         </button>
       }
     >
@@ -301,7 +306,7 @@ export function AdvancedIntelligencePage({
           pb: 'var(--ob-space-400)',
         }}
       >
-        {/* 1. Hero Section: Workspace Signals - Depth 1 (Glass Card with cyan edge) */}
+        {/* 1. Hero Section: Project Signals - Depth 1 (Glass Card with cyan edge) */}
         <Box className="ob-card-module ob-section-gap">
           <Typography
             variant="subtitle2"
@@ -312,7 +317,7 @@ export function AdvancedIntelligencePage({
               letterSpacing: '0.05em',
             }}
           >
-            Workspace Signals
+            Project Signals
           </Typography>
           <Grid container spacing="var(--ob-space-150)">
             <Grid item xs={12} md={3}>
@@ -456,7 +461,7 @@ export function AdvancedIntelligencePage({
                     )
                   }
                   loadingLabel="Running predictive models..."
-                  emptyTitle="No predictive signals available for this workspace yet"
+                  emptyTitle="No predictive signals available for this project yet"
                   emptyDescription={predictiveEmptySummary}
                   errorTitle="Unable to load predictive forecast"
                   errorMessage={predictiveErrorMessage}
@@ -514,6 +519,204 @@ export function AdvancedIntelligencePage({
         </Grid>
       </Box>
     </AppLayout>
+  )
+}
+
+export function AdvancedIntelligencePage({
+  projectId,
+  services,
+}: AdvancedIntelligencePageProps) {
+  const params = useRouterParams()
+  const projectContext = useContext(ProjectContext)
+  const theme = useTheme()
+  const effectiveProjectId =
+    projectId?.trim() ||
+    params.projectId?.trim() ||
+    projectContext?.currentProject?.id ||
+    ''
+
+  if (!effectiveProjectId) {
+    return (
+      <AppLayout
+        title="Advanced Intelligence"
+        subtitle="Predictive analytics and relationship insights"
+        actions={
+          <button
+            type="button"
+            className="advanced-intelligence__refresh"
+            disabled={true}
+            style={{
+              background: 'transparent',
+              border: `1px solid ${theme.palette.primary.main}`,
+              color: theme.palette.primary.main,
+              padding: '6px 12px',
+              borderRadius: '2px',
+              cursor: 'not-allowed',
+              opacity: 0.5,
+              fontSize: 'var(--ob-font-size-sm)',
+            }}
+          >
+            SELECT PROJECT
+          </button>
+        }
+      >
+        <Box
+          sx={{
+            width: '100%',
+            pb: 'var(--ob-space-400)',
+          }}
+        >
+          <Box className="ob-card-module ob-section-gap">
+            <Typography
+              variant="subtitle2"
+              sx={{
+                color: 'text.secondary',
+                mb: 'var(--ob-space-200)',
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+              }}
+            >
+              Project Signals
+            </Typography>
+            <Grid container spacing="var(--ob-space-150)">
+              <Grid item xs={12} md={3}>
+                <KPITickerCard
+                  label="Adoption Likelihood"
+                  value="N/A"
+                  trend={null}
+                  data={null}
+                  active={true}
+                />
+              </Grid>
+              <Grid item xs={12} md={3}>
+                <KPITickerCard
+                  label="Projected Uplift"
+                  value="N/A"
+                  trend={null}
+                  data={null}
+                />
+              </Grid>
+              <Grid item xs={12} md={3}>
+                <KPITickerCard
+                  label="Active Experiments"
+                  value="N/A"
+                  trend={null}
+                  data={null}
+                />
+              </Grid>
+              <Grid item xs={12} md={3}>
+                <KPITickerCard
+                  label="Intelligence Score"
+                  value="N/A"
+                  trend={null}
+                  data={null}
+                />
+              </Grid>
+            </Grid>
+          </Box>
+
+          <Grid container spacing="var(--ob-space-300)">
+            <Grid item xs={12} lg={8}>
+              <Box
+                className="ob-card-module"
+                sx={{ height: '100%', minHeight: 500 }}
+              >
+                <Typography
+                  variant="subtitle2"
+                  sx={{
+                    color: 'text.secondary',
+                    mb: 'var(--ob-space-200)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                  }}
+                >
+                  Relationship Intelligence
+                </Typography>
+                <IntelligenceStatusPanel
+                  status="empty"
+                  icon={
+                    <HubOutlined
+                      sx={{ color: 'var(--ob-color-brand-primary)' }}
+                    />
+                  }
+                  loadingLabel="Mapping organization network..."
+                  emptyTitle="Select a project to load intelligence graph"
+                  emptyDescription="Advanced Intelligence now runs against a real project scope. Pick a project from the selector or open a project route first."
+                  errorTitle="Unable to load intelligence graph"
+                  minHeight={600}
+                />
+              </Box>
+            </Grid>
+
+            <Grid item xs={12} lg={4}>
+              <Box
+                className="ob-card-module"
+                sx={{ mb: 'var(--ob-space-300)' }}
+              >
+                <Typography
+                  variant="subtitle2"
+                  sx={{
+                    color: 'text.secondary',
+                    mb: 'var(--ob-space-200)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                  }}
+                >
+                  Predictive Forecast
+                </Typography>
+                <IntelligenceStatusPanel
+                  status="empty"
+                  icon={
+                    <AutoGraph
+                      sx={{ color: 'var(--ob-color-brand-primary)' }}
+                    />
+                  }
+                  loadingLabel="Running predictive models..."
+                  emptyTitle="Select a project to load predictive signals"
+                  emptyDescription="Choose a project to evaluate workflow, finance, and delivery signals."
+                  errorTitle="Unable to load predictive forecast"
+                  minHeight={280}
+                />
+              </Box>
+
+              <Box className="ob-card-module">
+                <Typography
+                  variant="subtitle2"
+                  sx={{
+                    color: 'text.secondary',
+                    mb: 'var(--ob-space-200)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                  }}
+                >
+                  Cross-Correlation
+                </Typography>
+                <IntelligenceStatusPanel
+                  status="empty"
+                  icon={
+                    <AccountTreeOutlined
+                      sx={{ color: 'var(--ob-color-brand-primary)' }}
+                    />
+                  }
+                  loadingLabel="Analyzing correlations..."
+                  emptyTitle="Select a project to analyze correlations"
+                  emptyDescription="Correlation analysis needs a concrete project scope before it can inspect approvals, workflow activity, and finance history."
+                  errorTitle="Unable to load correlation analysis"
+                  minHeight={280}
+                />
+              </Box>
+            </Grid>
+          </Grid>
+        </Box>
+      </AppLayout>
+    )
+  }
+
+  return (
+    <AdvancedIntelligenceContent
+      projectId={effectiveProjectId}
+      services={services}
+    />
   )
 }
 

--- a/frontend/src/pages/visualizations/__tests__/AdvancedIntelligence.test.tsx
+++ b/frontend/src/pages/visualizations/__tests__/AdvancedIntelligence.test.tsx
@@ -11,7 +11,22 @@ import type {
 } from '../../../services/analytics/advancedAnalytics'
 
 vi.mock('../../../App', () => ({
-  AppLayout: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AppLayout: ({
+    children,
+    actions,
+  }: {
+    children: ReactNode
+    actions?: ReactNode
+  }) => (
+    <div>
+      {actions}
+      {children}
+    </div>
+  ),
+}))
+
+vi.mock('../../../router', () => ({
+  useRouterParams: () => ({}),
 }))
 
 vi.mock('../components/KPITickerCard', () => ({
@@ -44,10 +59,7 @@ function renderPage(services: {
   fetchCrossCorrelationIntelligence: () => Promise<CrossCorrelationIntelligenceResponse>
 }) {
   return render(
-    <AdvancedIntelligencePage
-      workspaceId="workspace-test"
-      services={services}
-    />,
+    <AdvancedIntelligencePage projectId="project-test" services={services} />,
   )
 }
 
@@ -94,9 +106,7 @@ describe('AdvancedIntelligencePage', () => {
     ).toBeInTheDocument()
     expect(screen.getByText('No graph signals.')).toBeInTheDocument()
     expect(
-      screen.getByText(
-        'No predictive signals available for this workspace yet',
-      ),
+      screen.getByText('No predictive signals available for this project yet'),
     ).toBeInTheDocument()
     expect(screen.getByText('No predictive signals.')).toBeInTheDocument()
     expect(
@@ -131,12 +141,24 @@ describe('AdvancedIntelligencePage', () => {
     ).toBeInTheDocument()
     expect(screen.getByText('graph service unavailable')).toBeInTheDocument()
     expect(
-      screen.getByText(
-        'No predictive signals available for this workspace yet',
-      ),
+      screen.getByText('No predictive signals available for this project yet'),
     ).toBeInTheDocument()
     expect(
       screen.getByText('No significant cross-correlations detected yet'),
     ).toBeInTheDocument()
+  })
+
+  it('renders a strict select-project empty state when no project is scoped', () => {
+    render(<AdvancedIntelligencePage services={undefined} />)
+
+    expect(
+      screen.getByText('Select a project to load intelligence graph'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Advanced Intelligence now runs against a real project scope. Pick a project from the selector or open a project route first.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getByText('SELECT PROJECT')).toBeInTheDocument()
   })
 })

--- a/frontend/src/services/analytics/advancedAnalytics.ts
+++ b/frontend/src/services/analytics/advancedAnalytics.ts
@@ -255,17 +255,14 @@ function normaliseCorrelationResponse(
 }
 
 export async function fetchGraphIntelligence(
-  workspaceId: string,
+  projectId: string,
 ): Promise<GraphIntelligenceResponse> {
-  debugLog(
-    '[fetchGraphIntelligence] Calling API with workspaceId:',
-    workspaceId,
-  )
+  debugLog('[fetchGraphIntelligence] Calling API with projectId:', projectId)
   try {
     const response = await requestWithTimeout(
       (signal) =>
         apiClient.get<unknown>('/api/v1/analytics/intelligence/graph', {
-          params: { workspaceId },
+          params: { projectId },
           signal,
         }),
       'Graph intelligence request timed out',
@@ -294,17 +291,14 @@ export async function fetchGraphIntelligence(
 }
 
 export async function fetchPredictiveIntelligence(
-  workspaceId: string,
+  projectId: string,
 ): Promise<PredictiveIntelligenceResponse> {
-  debugLog(
-    '[fetchPredictiveIntelligence] Calling API for workspace:',
-    workspaceId,
-  )
+  debugLog('[fetchPredictiveIntelligence] Calling API for project:', projectId)
   try {
     const response = await requestWithTimeout(
       (signal) =>
         apiClient.get<unknown>('/api/v1/analytics/intelligence/predictive', {
-          params: { workspaceId },
+          params: { projectId },
           signal,
         }),
       'Predictive intelligence request timed out',
@@ -330,11 +324,11 @@ export async function fetchPredictiveIntelligence(
 }
 
 export async function fetchCrossCorrelationIntelligence(
-  workspaceId: string,
+  projectId: string,
 ): Promise<CrossCorrelationIntelligenceResponse> {
   debugLog(
-    '[fetchCrossCorrelationIntelligence] Calling API for workspace:',
-    workspaceId,
+    '[fetchCrossCorrelationIntelligence] Calling API for project:',
+    projectId,
   )
   try {
     const response = await requestWithTimeout(
@@ -342,7 +336,7 @@ export async function fetchCrossCorrelationIntelligence(
         apiClient.get<unknown>(
           '/api/v1/analytics/intelligence/cross-correlation',
           {
-            params: { workspaceId },
+            params: { projectId },
             signal,
           },
         ),


### PR DESCRIPTION
## Summary
- resolve Advanced Intelligence requests against a real project scope instead of a fake workspace identifier
- make the frontend use the selected or routed project and show a strict select-project empty state when none is available
- preserve workspaceId as a backend compatibility fallback while adding project-scoped API coverage

## Testing
- /Users/tb/Projects/optimal_build/.venv/bin/pytest backend/tests/test_api/test_advanced_intelligence.py -q
- cd frontend && /Users/tb/Projects/optimal_build/frontend/node_modules/.bin/vitest run src/pages/visualizations/__tests__/AdvancedIntelligence.test.tsx
