### PR TITLE
Add CI workflow hygiene guardrails

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -9,10 +9,15 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   auto-format:
     name: Auto-format and commit
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/code-quality-gate.yml
+++ b/.github/workflows/code-quality-gate.yml
@@ -6,10 +6,15 @@ on:
   push:
     branches: [main, develop]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality-check:
     name: Code Quality Verification
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     env:
       # CI runs Python via setup-python (no .venv); override Makefile defaults
       # that point at .venv/bin/python so `make check-coding-rules` resolves.

--- a/.github/workflows/duplicate-scan.yml
+++ b/.github/workflows/duplicate-scan.yml
@@ -11,10 +11,15 @@ on:
 env:
   PYTHON_VERSION: '3.11'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   duplicate-scan:
     name: Scan Repository For Duplicate Files
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,6 +39,7 @@ jobs:
         with:
           name: duplicate-scan
           path: duplicate_scan.json
+          retention-days: 7
 
       - name: Fail if duplicates remain
         run: |

--- a/.github/workflows/infra-tests.yml
+++ b/.github/workflows/infra-tests.yml
@@ -29,11 +29,16 @@ env:
   PYTHON_VERSION: '3.11'
   NODE_VERSION: '20'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Backend infrastructure module tests
   backend-infra-tests:
     name: Backend Infrastructure Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -82,6 +87,7 @@ jobs:
   kubernetes-validation:
     name: Kubernetes Manifest Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -125,6 +131,7 @@ jobs:
   helm-validation:
     name: Helm Chart Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -163,6 +170,7 @@ jobs:
   backup-validation:
     name: Backup Script Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -195,6 +203,7 @@ jobs:
   alerting-validation:
     name: Alerting Rules Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -231,6 +240,7 @@ jobs:
   e2e-setup-validation:
     name: E2E Test Setup Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -256,6 +266,7 @@ jobs:
   load-test-validation:
     name: Load Test Setup Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -281,6 +292,7 @@ jobs:
   infra-tests-summary:
     name: Infrastructure Tests Summary
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs:
       - backend-infra-tests
       - kubernetes-validation

--- a/.github/workflows/lint-prod.yml
+++ b/.github/workflows/lint-prod.yml
@@ -5,9 +5,14 @@ on:
   push:
     branches: [ main, master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-prod:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,14 @@ on:
   push:
     branches: [ main, master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/migration-validation.yaml
+++ b/.github/workflows/migration-validation.yaml
@@ -16,10 +16,15 @@ on:
       - 'alembic.ini'
       - '.github/workflows/migration-validation.yaml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-migrations:
     name: Validate Migration Patterns and Schema
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     services:
       postgres:
@@ -83,6 +88,7 @@ jobs:
   smoke-tests:
     name: Run Smoke Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: validate-migrations
 
     services:
@@ -155,6 +161,7 @@ jobs:
   migration-summary:
     name: Migration Validation Summary
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [validate-migrations, smoke-tests]
     if: always()
 

--- a/.github/workflows/migrations-audit.yml
+++ b/.github/workflows/migrations-audit.yml
@@ -3,9 +3,15 @@ on:
   pull_request:
   push:
     branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/production-readiness-gate.yml
+++ b/.github/workflows/production-readiness-gate.yml
@@ -27,6 +27,10 @@ on:
       - "backend/.env.production"
       - "backend/.env.production.template"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   readiness-gate:
     name: Production Security Validation

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,16 +8,27 @@ on:
   schedule:
     # Run weekly on Sundays at midnight UTC
     - cron: '0 0 * * 0'
+  workflow_dispatch:
+    inputs:
+      run_dast:
+        description: Run dynamic application security testing
+        required: false
+        default: 'false'
 
 env:
   PYTHON_VERSION: '3.11'
   NODE_VERSION: '20'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Static Application Security Testing (SAST)
   sast:
     name: SAST - Static Analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -67,6 +78,7 @@ jobs:
           name: bandit-report
           path: bandit-report.json
           if-no-files-found: ignore
+          retention-days: 7
 
       - name: Upload Safety Report
         uses: actions/upload-artifact@v4
@@ -74,11 +86,13 @@ jobs:
           name: safety-report
           path: safety-report.json
           if-no-files-found: ignore
+          retention-days: 7
 
   # Dependency Audit
   dependency-audit:
     name: Dependency Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -123,6 +137,7 @@ jobs:
           name: pip-audit-report
           path: security/reports/pip-audit-report.json
           if-no-files-found: ignore
+          retention-days: 7
 
       - name: Upload npm audit Report
         uses: actions/upload-artifact@v4
@@ -130,11 +145,13 @@ jobs:
           name: npm-audit-report
           path: npm-audit-report.json
           if-no-files-found: ignore
+          retention-days: 7
 
   # Secret Scanning
   secret-scan:
     name: Secret Scanning
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -160,6 +177,7 @@ jobs:
   container-scan:
     name: Container Security
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.event_name == 'push' || github.event_name == 'schedule'
     steps:
       - name: Checkout repository
@@ -215,6 +233,7 @@ jobs:
   iac-scan:
     name: IaC Security Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -239,6 +258,7 @@ jobs:
   dast:
     name: DAST - Dynamic Testing
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.event_name == 'schedule' || github.event.inputs.run_dast == 'true'
     services:
       postgres:
@@ -316,11 +336,13 @@ jobs:
           name: zap-report
           path: report_html.html
           if-no-files-found: ignore
+          retention-days: 7
 
   # Summary job
   security-summary:
     name: Security Summary
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [sast, dependency-audit, secret-scan, iac-scan]
     if: always()
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -316,11 +316,15 @@ docs/_build/
 
 # Frontend test artifacts
 frontend/.tmp-e2e-*/
+frontend/playwright-report/
+frontend/test-results/
 
-# Playwright offline browsers (tracked cache)
+# Playwright offline browser metadata is tracked; downloaded browsers are not.
+.playwright-browsers/*
 !.playwright-browsers/
-!.playwright-browsers/**
-!.playwright-browsers.tar.gz
+!.playwright-browsers/README.md
+!.playwright-browsers/browsers.json
+.playwright-browsers.tar.gz
 
 # Generated preview assets
 backend/static/dev-previews/

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+
+def _load_workflow(path: Path) -> dict:
+    workflow = yaml.safe_load(path.read_text()) or {}
+    # PyYAML follows YAML 1.1 and treats the GitHub Actions `on` key as a
+    # boolean. Normalize it so the assertions read like the workflow files.
+    if True in workflow and "on" not in workflow:
+        workflow["on"] = workflow.pop(True)
+    return workflow
+
+
+def _workflow_files() -> list[Path]:
+    return sorted(
+        path for path in WORKFLOW_DIR.iterdir() if path.suffix in {".yml", ".yaml"}
+    )
+
+
+def test_workflows_cancel_stale_runs() -> None:
+    for path in _workflow_files():
+        workflow = _load_workflow(path)
+        concurrency = workflow.get("concurrency")
+
+        assert isinstance(concurrency, dict), f"{path.name} must define concurrency"
+        assert (
+            concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}"
+        ), f"{path.name} must group concurrency by workflow and ref"
+        assert (
+            concurrency.get("cancel-in-progress") is True
+        ), f"{path.name} must cancel stale in-progress runs"
+
+
+def test_all_workflow_jobs_have_timeouts() -> None:
+    for path in _workflow_files():
+        workflow = _load_workflow(path)
+        for job_name, job in workflow.get("jobs", {}).items():
+            timeout = job.get("timeout-minutes")
+            assert isinstance(timeout, int), f"{path.name}:{job_name} needs a timeout"
+            assert 1 <= timeout <= 60, f"{path.name}:{job_name} timeout is too high"
+
+
+def test_artifact_uploads_have_short_retention() -> None:
+    for path in _workflow_files():
+        workflow = _load_workflow(path)
+        for job_name, job in workflow.get("jobs", {}).items():
+            for step in job.get("steps", []):
+                if step.get("uses") != "actions/upload-artifact@v4":
+                    continue
+
+                with_config = step.get("with", {})
+                retention_days = with_config.get("retention-days")
+                assert isinstance(
+                    retention_days, int
+                ), f"{path.name}:{job_name}:{step.get('name')} must set retention-days"
+                assert (
+                    retention_days <= 7
+                ), f"{path.name}:{job_name}:{step.get('name')} keeps artifacts too long"
+
+
+def test_lint_workflow_keeps_unit_tests_on_pull_requests() -> None:
+    workflow = _load_workflow(WORKFLOW_DIR / "lint.yml")
+    lint_job = workflow["jobs"]["lint-tests"]
+
+    pytest_commands = [
+        step.get("run", "").strip()
+        for step in lint_job["steps"]
+        if "pytest" in step.get("run", "")
+    ]
+
+    assert "pytest -q" in pytest_commands
+
+
+def test_main_ci_static_gates_are_not_serialized() -> None:
+    workflow = _load_workflow(WORKFLOW_DIR / "ci.yml")
+    jobs = workflow["jobs"]
+
+    assert jobs["typecheck"]["needs"] == "changes"
+    assert jobs["build"]["needs"] == "changes"
+    assert "lint" not in jobs["tests"]["needs"]
+    assert "typecheck" not in jobs["tests"]["needs"]
+
+
+def test_frontend_e2e_does_not_start_duplicate_backend() -> None:
+    workflow = _load_workflow(WORKFLOW_DIR / "ci.yml")
+    test_steps = workflow["jobs"]["tests"]["steps"]
+    step_names = {step.get("name") for step in test_steps}
+
+    assert "Launch backend API for E2E tests" not in step_names
+    assert "Wait for backend readiness (E2E)" not in step_names
+
+
+def test_playwright_generated_artifacts_are_ignored() -> None:
+    gitignore = (REPO_ROOT / ".gitignore").read_text().splitlines()
+
+    for pattern in (
+        "frontend/playwright-report/",
+        "frontend/test-results/",
+        ".playwright-browsers/*",
+        "!.playwright-browsers/",
+        "!.playwright-browsers/README.md",
+        "!.playwright-browsers/browsers.json",
+    ):
+        assert pattern in gitignore


### PR DESCRIPTION
Summary:
- add concurrency cancellation and job timeouts across auxiliary workflows
- shorten artifact retention for uploaded CI reports
- keep full PR safety gates: lint.yml still runs pytest -q, and SAST/dependency/IaC scans still run on PRs
- ignore generated Playwright browser cache, reports, and test-results while keeping tracked metadata
- add workflow-policy regression tests for these guardrails

Validation:
- .venv/bin/pytest -q tests/test_ci_workflows.py