### PR TITLE
Improve Singapore Capture geocoding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,16 @@ TORONTO_SODA_APP_TOKEN=public
 VITE_MAPBOX_ACCESS_TOKEN=
 GOOGLE_MAPS_API_KEY=
 
+# Singapore OneMap address search
+# Required for authoritative SG address-to-coordinate lookup before parcel zoning.
+# Preferred production setup: configure server-side account credentials so the
+# backend can mint and cache short-lived OneMap tokens.
+ONEMAP_EMAIL=
+ONEMAP_PASSWORD=
+# Optional override for local debugging or shell-only runs.
+# For local development, put real values in ignored .env.local.
+ONEMAP_ACCESS_TOKEN=
+
 # Singapore URA Data Service
 # Required for live URA approved-use, transaction, rental, and pipeline smoke checks.
 # Keep this in local/deployment secrets only; do not commit real keys.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,6 +332,7 @@ jobs:
           python -m backend.flows.watch_fetch \
             --once \
             --offline \
+            --seed-offline-sources \
             --storage-path "$REFERENCE_STORAGE" \
             --summary-path "$CI_ARTIFACTS/watch_fetch_summary.json"
 

--- a/.github/workflows/infra-tests.yml
+++ b/.github/workflows/infra-tests.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Run Helm chart structure tests
         run: |
-          python -m pytest tests/infra/test_helm_chart.py -v --tb=short -k "not helm_"
+          python -m pytest tests/infra/test_helm_chart.py -v --tb=short -k "not TestHelmLint"
 
       - name: Set up Helm
         uses: azure/setup-helm@v3
@@ -166,7 +166,7 @@ jobs:
 
       - name: Run Helm CLI tests
         run: |
-          python -m pytest tests/infra/test_helm_chart.py -v --tb=short -k "helm_"
+          python -m pytest tests/infra/test_helm_chart.py -v --tb=short -k "TestHelmLint"
 
   # Backup script validation
   backup-validation:

--- a/.github/workflows/infra-tests.yml
+++ b/.github/workflows/infra-tests.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip install pytest pyyaml
+          pip install pytest pytest-asyncio pyyaml
 
       - name: Run Kubernetes manifest tests
         run: |
@@ -143,7 +143,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip install pytest pyyaml
+          pip install pytest pytest-asyncio pyyaml
 
       - name: Run Helm chart structure tests
         run: |
@@ -182,7 +182,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip install pytest pyyaml
+          pip install pytest pytest-asyncio pyyaml
 
       - name: Run backup script tests
         run: |

--- a/.github/workflows/infra-tests.yml
+++ b/.github/workflows/infra-tests.yml
@@ -99,6 +99,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
+          pip install -r backend/requirements.txt
           pip install pytest pytest-asyncio pyyaml
 
       - name: Run Kubernetes manifest tests
@@ -143,6 +144,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
+          pip install -r backend/requirements.txt
           pip install pytest pytest-asyncio pyyaml
 
       - name: Run Helm chart structure tests
@@ -182,6 +184,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
+          pip install -r backend/requirements.txt
           pip install pytest pytest-asyncio pyyaml
 
       - name: Run backup script tests

--- a/Makefile
+++ b/Makefile
@@ -664,7 +664,7 @@ _dev-services: ## Internal target to start backend, frontend, and admin UI
 			: > $(DEV_BACKEND_LOG); \
 			rm -f $(DEV_BACKEND_PID); \
 			( \
-				set -a; [ -f .env ] && . ./.env; set +a; \
+				set -a; [ -f .env ] && . ./.env; [ -f .env.local ] && . ./.env.local; set +a; \
 				EFFECTIVE_DB_URL=$${DATABASE_URL:-$(DEV_SQLITE_URL)}; \
 				SECRET_KEY=$${SECRET_KEY:-dev-secret-key-do-not-use-in-production} \
 				DEV_SQLITE_URL="$(DEV_SQLITE_URL)" SQLALCHEMY_DATABASE_URI="$$EFFECTIVE_DB_URL" DATABASE_URL="$$EFFECTIVE_DB_URL" \

--- a/backend/app/api/v1/developers_gps.py
+++ b/backend/app/api/v1/developers_gps.py
@@ -3043,7 +3043,10 @@ async def _resolve_submitted_sg_address_lookup(
 
     try:
         lookup = await asyncio.wait_for(
-            _developer_geocoding.instance.geocode_lookup(request.submitted_address),
+            _developer_geocoding.instance.geocode_lookup(
+                request.submitted_address,
+                jurisdiction_code=request.jurisdiction_code or "SG",
+            ),
             timeout=CAPTURE_ADDRESS_LOOKUP_TIMEOUT_SECONDS,
         )
     except Exception as exc:  # pragma: no cover - non-critical enrichment

--- a/backend/app/api/v1/geocoding.py
+++ b/backend/app/api/v1/geocoding.py
@@ -26,11 +26,15 @@ class GeocodeResponse(BaseModel):
 @router.get("/forward", response_model=GeocodeResponse)
 async def forward_geocode(
     address: str = Query(..., min_length=3),
+    jurisdiction_code: str | None = Query(default=None, alias="jurisdictionCode"),
 ) -> GeocodeResponse:
     """Translate a free-form address into coordinates."""
 
     try:
-        result = await geocoding_service.geocode_lookup(address)
+        result = await geocoding_service.geocode_lookup(
+            address,
+            jurisdiction_code=jurisdiction_code,
+        )
     except RuntimeError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -26,6 +26,45 @@ _TEST_RATE_LIMIT = "1000/minute"
 _GEOMETRY_DETAIL_LEVELS = {"simple", "medium"}
 
 
+def _load_dotenv_file(path: str, *, override: bool) -> None:
+    """Load a minimal dotenv file without shell-expanding secret values."""
+
+    if not os.path.exists(path):
+        return
+
+    try:
+        with open(path, encoding="utf-8") as env_file:
+            lines = env_file.readlines()
+    except OSError:
+        return
+
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if not key or not key.replace("_", "").isalnum() or key[0].isdigit():
+            continue
+        if not override and key in os.environ:
+            continue
+
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        os.environ[key] = value
+
+
+def _load_local_dotenv_files() -> None:
+    """Load local development env files before Settings snapshots os.environ."""
+
+    if _load_bool("OPTIMAL_BUILD_SKIP_DOTENV", False):
+        return
+    _load_dotenv_file(".env", override=False)
+    _load_dotenv_file(".env.local", override=True)
+
+
 def _load_bool(name: str, default: bool) -> bool:
     """Return a boolean configuration flag from the environment."""
 
@@ -216,6 +255,9 @@ class Settings:
     SEATTLE_SODA_APP_TOKEN: str
     TORONTO_SODA_APP_TOKEN: str
     GOOGLE_MAPS_API_KEY: str
+    ONEMAP_ACCESS_TOKEN: str
+    ONEMAP_EMAIL: str
+    ONEMAP_PASSWORD: str
     URA_ACCESS_KEY: str
 
     BUILDABLE_TYP_FLOOR_TO_FLOOR_M: float
@@ -319,6 +361,12 @@ class Settings:
         self.SEATTLE_SODA_APP_TOKEN = os.getenv("SEATTLE_SODA_APP_TOKEN", "public")
         self.TORONTO_SODA_APP_TOKEN = os.getenv("TORONTO_SODA_APP_TOKEN", "public")
         self.GOOGLE_MAPS_API_KEY = os.getenv("GOOGLE_MAPS_API_KEY", "")
+        self.ONEMAP_ACCESS_TOKEN = os.getenv(
+            "ONEMAP_ACCESS_TOKEN",
+            os.getenv("ONEMAP_TOKEN", ""),
+        )
+        self.ONEMAP_EMAIL = os.getenv("ONEMAP_EMAIL", "")
+        self.ONEMAP_PASSWORD = os.getenv("ONEMAP_PASSWORD", "")
         self.URA_ACCESS_KEY = os.getenv("URA_ACCESS_KEY", "")
 
         self.BUILDABLE_TYP_FLOOR_TO_FLOOR_M = _load_positive_float(
@@ -359,4 +407,5 @@ class Settings:
         return self.SECRET_KEY
 
 
+_load_local_dotenv_files()
 settings = Settings()

--- a/backend/app/services/geocoding.py
+++ b/backend/app/services/geocoding.py
@@ -1,6 +1,7 @@
 """Geocoding service for address lookup and reverse geocoding."""
 
 import re
+import time
 from typing import Any, Dict, Optional, Tuple
 
 import structlog
@@ -36,8 +37,12 @@ class GeocodeLookupResult(BaseModel):
     source: ExternalSourceMetadata
 
 
+class OneMapAuthError(RuntimeError):
+    """Raised when OneMap authentication fails before address search can run."""
+
+
 class GeocodingService(AsyncClientService):
-    """Service for geocoding and reverse geocoding using Google Maps."""
+    """Service for jurisdiction-aware geocoding and reverse geocoding."""
 
     def __init__(self) -> None:
         self.onemap_base_url = "https://www.onemap.gov.sg/api"
@@ -46,6 +51,11 @@ class GeocodingService(AsyncClientService):
             "https://maps.googleapis.com/maps/api/place/details/json"
         )
         self.google_maps_api_key = settings.GOOGLE_MAPS_API_KEY
+        self.onemap_access_token = settings.ONEMAP_ACCESS_TOKEN
+        self.onemap_email = settings.ONEMAP_EMAIL
+        self.onemap_password = settings.ONEMAP_PASSWORD
+        self._onemap_access_token_cache: str | None = None
+        self._onemap_access_token_expires_at = 0.0
         self.offline_mode = settings.OFFLINE_MODE
         if self.offline_mode:
             logger.info(
@@ -140,11 +150,37 @@ class GeocodingService(AsyncClientService):
                 synthetic=False,
                 reason="Geocoding client unavailable",
             )
+        if not self._has_onemap_auth_configured():
+            return ExternalSourceMetadata(
+                provider="onemap_address_search",
+                state=ExternalSourceState.UNAVAILABLE,
+                configured=False,
+                synthetic=False,
+                reason=(
+                    "ONEMAP_ACCESS_TOKEN or ONEMAP_EMAIL/ONEMAP_PASSWORD not "
+                    "configured"
+                ),
+            )
         return ExternalSourceMetadata(
             provider="onemap_address_search",
             state=ExternalSourceState.LIVE,
             configured=True,
             synthetic=False,
+        )
+
+    def get_onemap_street_interpolation_metadata(self) -> ExternalSourceMetadata:
+        """Describe derived coordinates from neighboring OneMap address points."""
+
+        base = self.get_onemap_address_metadata()
+        return ExternalSourceMetadata(
+            provider="onemap_street_interpolation",
+            state=base.state,
+            configured=base.configured,
+            synthetic=True,
+            reason=(
+                "Exact address was not returned by OneMap; approximate coordinates are "
+                "interpolated from bracketing OneMap address points on the same street"
+            ),
         )
 
     @staticmethod
@@ -240,22 +276,43 @@ class GeocodingService(AsyncClientService):
             )
         return address
 
-    async def geocode(self, address: str) -> Optional[Tuple[float, float]]:
-        """Convert address to coordinates using Google Maps."""
-        result = await self.geocode_lookup(address)
+    async def geocode(
+        self,
+        address: str,
+        *,
+        jurisdiction_code: str | None = None,
+    ) -> Optional[Tuple[float, float]]:
+        """Convert an address to coordinates using the jurisdiction resolver."""
+        result = await self.geocode_lookup(
+            address,
+            jurisdiction_code=jurisdiction_code,
+        )
         if result is None:
             logger.warning("geocode_no_results", address=address)
             return None
         return (result.latitude, result.longitude)
 
-    async def geocode_details(self, address: str) -> Optional[Tuple[float, float, str]]:
+    async def geocode_details(
+        self,
+        address: str,
+        *,
+        jurisdiction_code: str | None = None,
+    ) -> Optional[Tuple[float, float, str]]:
         """Return coordinates plus a formatted address for the input."""
-        result = await self.geocode_lookup(address)
+        result = await self.geocode_lookup(
+            address,
+            jurisdiction_code=jurisdiction_code,
+        )
         if result is None:
             return None
         return (result.latitude, result.longitude, result.formatted_address)
 
-    async def geocode_lookup(self, address: str) -> Optional[GeocodeLookupResult]:
+    async def geocode_lookup(
+        self,
+        address: str,
+        *,
+        jurisdiction_code: str | None = None,
+    ) -> Optional[GeocodeLookupResult]:
         """Return coordinates, formatted address, structured address, and source."""
 
         if self.offline_mode:
@@ -275,17 +332,40 @@ class GeocodingService(AsyncClientService):
                 source=self.get_google_geocoding_metadata(),
             )
 
-        if self._looks_like_singapore_address(address):
-            try:
-                onemap_result = await self._onemap_geocode(address)
-                if onemap_result is not None:
-                    return onemap_result
-            except Exception as exc:
-                logger.warning(
-                    "onemap_address_geocode_failed",
-                    error=str(exc),
-                    address=address,
+        should_use_onemap = self._should_use_onemap(address, jurisdiction_code)
+        if should_use_onemap:
+            onemap_metadata = self.get_onemap_address_metadata()
+            if onemap_metadata.state != ExternalSourceState.LIVE:
+                raise RuntimeError(
+                    onemap_metadata.reason
+                    or "OneMap address search is unavailable for Singapore geocoding"
                 )
+            for search_value in self._onemap_search_values(
+                address,
+                jurisdiction_code=jurisdiction_code,
+            ):
+                try:
+                    onemap_result = await self._onemap_geocode(
+                        search_value,
+                        submitted_address=address,
+                    )
+                    if onemap_result is not None:
+                        return onemap_result
+                except OneMapAuthError:
+                    raise
+                except Exception as exc:
+                    logger.warning(
+                        "onemap_address_geocode_failed",
+                        error=str(exc),
+                        address=address,
+                        search_value=search_value,
+                    )
+            interpolated_result = await self._onemap_interpolate_street_address(
+                address,
+            )
+            if interpolated_result is not None:
+                return interpolated_result
+            return None
 
         if not self.google_maps_api_key:
             logger.warning("geocode_details_mock_fallback", address=address)
@@ -557,11 +637,19 @@ class GeocodingService(AsyncClientService):
             country="Singapore" if postal_code else "Unknown",
         )
 
-    async def _onemap_geocode(self, address: str) -> Optional[GeocodeLookupResult]:
+    async def _onemap_geocode(
+        self,
+        address: str,
+        *,
+        submitted_address: str | None = None,
+    ) -> Optional[GeocodeLookupResult]:
         if self.client is None:
             return None
 
+        score_address = submitted_address or address
         client = self.client
+        access_token = await self._get_onemap_access_token()
+        headers = {"Authorization": f"Bearer {access_token}"}
         response = await client.get(
             f"{self.onemap_base_url}/common/elastic/search",
             params={
@@ -570,6 +658,7 @@ class GeocodingService(AsyncClientService):
                 "getAddrDetails": "Y",
                 "pageNum": 1,
             },
+            headers=headers,
         )
         if response.status_code != 200:
             logger.warning(
@@ -580,6 +669,9 @@ class GeocodingService(AsyncClientService):
             return None
 
         payload = response.json()
+        error = payload.get("error")
+        if isinstance(error, str) and "token" in error.lower():
+            raise OneMapAuthError(error)
         raw_results = payload.get("results")
         if not isinstance(raw_results, list) or not raw_results:
             return None
@@ -596,14 +688,14 @@ class GeocodingService(AsyncClientService):
 
         best = max(
             candidates,
-            key=lambda entry: self._score_onemap_candidate(address, entry),
+            key=lambda entry: self._score_onemap_candidate(score_address, entry),
         )
         latitude = self._coerce_coordinate(best.get("LATITUDE"))
         longitude = self._coerce_coordinate(best.get("LONGITUDE"))
         if latitude is None or longitude is None:
             return None
 
-        address_payload = self._parse_onemap_address(best, fallback=address)
+        address_payload = self._parse_onemap_address(best, fallback=score_address)
         return GeocodeLookupResult(
             latitude=latitude,
             longitude=longitude,
@@ -611,6 +703,229 @@ class GeocodingService(AsyncClientService):
             address=address_payload,
             source=self.get_onemap_address_metadata(),
         )
+
+    async def _onemap_interpolate_street_address(
+        self,
+        address: str,
+    ) -> Optional[GeocodeLookupResult]:
+        """Interpolate missing Singapore street numbers from bracketing OneMap hits."""
+
+        target_block = self._leading_block_number(address)
+        if not target_block or not target_block.isdigit():
+            return None
+
+        street_name = self._extract_singapore_street_query(address)
+        if not street_name:
+            return None
+
+        target_number = int(target_block)
+        lower: tuple[int, GeocodeLookupResult] | None = None
+        upper: tuple[int, GeocodeLookupResult] | None = None
+
+        for offset in range(1, 9):
+            if lower is None and target_number - offset > 0:
+                candidate = await self._lookup_onemap_neighbor(
+                    target_number - offset,
+                    street_name,
+                )
+                if candidate is not None:
+                    lower = candidate
+
+            if upper is None:
+                candidate = await self._lookup_onemap_neighbor(
+                    target_number + offset,
+                    street_name,
+                )
+                if candidate is not None:
+                    upper = candidate
+
+            if lower is not None and upper is not None:
+                break
+
+        if lower is None or upper is None:
+            logger.info(
+                "onemap_street_interpolation_skipped",
+                address=address,
+                street_name=street_name,
+                reason="bracketing_address_points_not_found",
+            )
+            return None
+
+        lower_number, lower_result = lower
+        upper_number, upper_result = upper
+        span = upper_number - lower_number
+        if span <= 0:
+            return None
+
+        ratio = (target_number - lower_number) / span
+        latitude = lower_result.latitude + ratio * (
+            upper_result.latitude - lower_result.latitude
+        )
+        longitude = lower_result.longitude + ratio * (
+            upper_result.longitude - lower_result.longitude
+        )
+        formatted_street = street_name.upper()
+        postal_code = self._extract_singapore_postal(address)
+        formatted_address = f"{target_number} {formatted_street} SINGAPORE"
+        if postal_code:
+            formatted_address = f"{formatted_address} {postal_code}"
+
+        logger.info(
+            "onemap_street_interpolation_used",
+            address=address,
+            target_number=target_number,
+            lower_number=lower_number,
+            upper_number=upper_number,
+            street_name=street_name,
+        )
+        return GeocodeLookupResult(
+            latitude=latitude,
+            longitude=longitude,
+            formatted_address=formatted_address,
+            address=Address(
+                full_address=formatted_address,
+                street_name=formatted_street,
+                block_number=str(target_number),
+                postal_code=postal_code,
+                district=self._get_district_from_postal(postal_code or ""),
+                country="Singapore",
+            ),
+            source=self.get_onemap_street_interpolation_metadata(),
+        )
+
+    async def _lookup_onemap_neighbor(
+        self,
+        block_number: int,
+        street_name: str,
+    ) -> tuple[int, GeocodeLookupResult] | None:
+        query = f"{block_number} {street_name} Singapore"
+        result = await self._onemap_geocode(query, submitted_address=query)
+        if result is None:
+            return None
+
+        result_block = self._numeric_block_number(result.address.block_number)
+        if result_block is None or not result_block.isdigit():
+            return None
+        if int(result_block) != block_number:
+            return None
+        if self._normalise_street_for_match(
+            result.address.street_name,
+        ) != self._normalise_street_for_match(street_name):
+            return None
+
+        return (block_number, result)
+
+    def _has_onemap_auth_configured(self) -> bool:
+        if self.onemap_access_token:
+            return True
+        return bool(self.onemap_email and self.onemap_password)
+
+    async def _get_onemap_access_token(self) -> str:
+        if self.onemap_access_token:
+            return self.onemap_access_token
+
+        now = time.time()
+        if (
+            self._onemap_access_token_cache
+            and self._onemap_access_token_expires_at - 60 > now
+        ):
+            return self._onemap_access_token_cache
+
+        if not self.onemap_email or not self.onemap_password:
+            raise RuntimeError(
+                "ONEMAP_ACCESS_TOKEN or ONEMAP_EMAIL/ONEMAP_PASSWORD not configured"
+            )
+        if self.client is None:
+            raise RuntimeError("Geocoding client unavailable")
+
+        response = await self.client.post(
+            f"{self.onemap_base_url}/auth/post/getToken",
+            json={
+                "email": self.onemap_email,
+                "password": self.onemap_password,
+            },
+        )
+        if response.status_code != 200:
+            logger.warning(
+                "onemap_token_request_status",
+                status_code=response.status_code,
+            )
+            reason = self._extract_onemap_error_message(response)
+            detail = f": {reason}" if reason else ""
+            raise OneMapAuthError(
+                f"OneMap token request failed ({response.status_code}){detail}"
+            )
+
+        payload = response.json()
+        token = self._extract_onemap_token(payload)
+        if not token:
+            raise OneMapAuthError(
+                "OneMap token response did not include an access token"
+            )
+
+        self._onemap_access_token_cache = token
+        self._onemap_access_token_expires_at = self._extract_onemap_token_expiry(
+            payload,
+            fallback=now + 25 * 60,
+        )
+        return token
+
+    @staticmethod
+    def _extract_onemap_error_message(response: Any) -> str | None:
+        try:
+            payload = response.json()
+        except Exception:
+            return None
+
+        if not isinstance(payload, dict):
+            return None
+        for key in ("error", "message", "error_description"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    @staticmethod
+    def _extract_onemap_token(payload: dict[str, Any]) -> str | None:
+        candidates: list[Any] = [
+            payload.get("access_token"),
+            payload.get("token"),
+        ]
+        result = payload.get("result")
+        if isinstance(result, dict):
+            candidates.extend([result.get("access_token"), result.get("token")])
+
+        for candidate in candidates:
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate.strip()
+        return None
+
+    @staticmethod
+    def _extract_onemap_token_expiry(
+        payload: dict[str, Any],
+        *,
+        fallback: float,
+    ) -> float:
+        for key in ("expiry_timestamp", "expires_at"):
+            value = payload.get(key)
+            try:
+                if isinstance(value, (int, float)):
+                    return float(value)
+                if isinstance(value, str) and value.strip().isdigit():
+                    return float(value.strip())
+            except (TypeError, ValueError):
+                continue
+
+        expires_in = payload.get("expires_in")
+        try:
+            if isinstance(expires_in, (int, float)):
+                return time.time() + float(expires_in)
+            if isinstance(expires_in, str) and expires_in.strip().isdigit():
+                return time.time() + float(expires_in.strip())
+        except (TypeError, ValueError):
+            return fallback
+
+        return fallback
 
     def _parse_onemap_address(
         self,
@@ -707,11 +1022,111 @@ class GeocodingService(AsyncClientService):
         match = re.match(r"^\s*(\d+[a-zA-Z]?)(?=\s)", value)
         return match.group(1).lower() if match else None
 
+    @staticmethod
+    def _numeric_block_number(value: str | None) -> str | None:
+        if not value:
+            return None
+        match = re.match(r"^\s*(\d+)\s*$", value)
+        return match.group(1) if match else None
+
+    def _extract_singapore_street_query(self, address: str) -> str | None:
+        value = re.sub(r"\b\d{6}\b", " ", address)
+        value = re.sub(r"\bsingapore\b", " ", value, flags=re.IGNORECASE)
+        value = re.sub(r"[,]+", " ", value)
+        value = re.sub(r"^\s*\d+[a-zA-Z]?\s+", " ", value)
+        value = self._expand_singapore_road_abbreviations(value)
+        value = re.sub(r"\s+", " ", value).strip()
+        return value or None
+
+    def _normalise_street_for_match(self, value: str | None) -> str:
+        if not value:
+            return ""
+        expanded = self._expand_singapore_road_abbreviations(value)
+        return " ".join(re.findall(r"[a-z0-9]+", expanded.lower()))
+
+    @staticmethod
+    def _normalise_jurisdiction_code(jurisdiction_code: str | None) -> str | None:
+        if not jurisdiction_code:
+            return None
+        value = jurisdiction_code.strip().upper()
+        return value or None
+
     def _looks_like_singapore_address(self, address: str) -> bool:
         lower = address.lower()
         return (
             "singapore" in lower or self._extract_singapore_postal(address) is not None
         )
+
+    def _should_use_onemap(
+        self,
+        address: str,
+        jurisdiction_code: str | None,
+    ) -> bool:
+        return self._normalise_jurisdiction_code(
+            jurisdiction_code,
+        ) == "SG" or self._looks_like_singapore_address(address)
+
+    def _onemap_search_values(
+        self,
+        address: str,
+        *,
+        jurisdiction_code: str | None,
+    ) -> list[str]:
+        base = re.sub(r"\s+", " ", address).strip()
+        if not base:
+            return []
+
+        is_sg_context = self._normalise_jurisdiction_code(
+            jurisdiction_code,
+        ) == "SG" or self._looks_like_singapore_address(base)
+        expanded = self._expand_singapore_road_abbreviations(base)
+        values: list[str] = []
+        for candidate in (expanded, base):
+            normalised_candidate = self._normalise_onemap_search_query(candidate)
+            values.append(normalised_candidate)
+            if is_sg_context and "singapore" not in normalised_candidate.lower():
+                values.append(f"{normalised_candidate} Singapore")
+
+        deduped: list[str] = []
+        seen: set[str] = set()
+        for value in values:
+            key = value.lower()
+            if key not in seen:
+                seen.add(key)
+                deduped.append(value)
+        return deduped
+
+    @staticmethod
+    def _normalise_onemap_search_query(address: str) -> str:
+        without_country_comma = re.sub(
+            r",\s*(Singapore\b)",
+            r" \1",
+            address,
+            flags=re.IGNORECASE,
+        )
+        return re.sub(r"\s+", " ", without_country_comma).strip()
+
+    @staticmethod
+    def _expand_singapore_road_abbreviations(address: str) -> str:
+        replacements = {
+            "ave": "Avenue",
+            "blvd": "Boulevard",
+            "dr": "Drive",
+            "jln": "Jalan",
+            "ln": "Lane",
+            "pk": "Park",
+            "rd": "Road",
+            "st": "Street",
+        }
+
+        def replace(match: re.Match[str]) -> str:
+            return replacements[match.group(1).lower()]
+
+        pattern = re.compile(
+            r"\b(" + "|".join(re.escape(key) for key in replacements) + r")\.?\b",
+            re.IGNORECASE,
+        )
+        return pattern.sub(replace, address)
 
     def _require_google_client(self) -> httpx.AsyncClient:
         if not self.google_maps_api_key:

--- a/backend/flows/watch_fetch.py
+++ b/backend/flows/watch_fetch.py
@@ -39,6 +39,45 @@ from ._prefect_utils import resolve_flow_callable
 
 SUPPORTED_FETCH_KINDS = {"pdf", "html", "sitemap"}
 
+_OFFLINE_SOURCE_FIXTURES: Sequence[dict[str, str]] = (
+    {
+        "jurisdiction": "SG",
+        "authority": "URA",
+        "topic": "zoning",
+        "doc_title": "URA Master Plan Planning Parameters",
+        "landing_url": "https://www.ura.gov.sg/Corporate/Planning/Master-Plan",
+        "fetch_kind": "html",
+        "update_freq_hint": "biennial",
+    },
+    {
+        "jurisdiction": "SG",
+        "authority": "BCA",
+        "topic": "building",
+        "doc_title": "BCA Building Control Regulations",
+        "landing_url": "https://www1.bca.gov.sg/buildsg/bca-codes/building-control-act",
+        "fetch_kind": "pdf",
+        "update_freq_hint": "annual",
+    },
+    {
+        "jurisdiction": "SG",
+        "authority": "SCDF",
+        "topic": "fire",
+        "doc_title": "SCDF Fire Code 2018",
+        "landing_url": "https://www.scdf.gov.sg/home/fire-safety/fire-code",
+        "fetch_kind": "pdf",
+        "update_freq_hint": "biennial",
+    },
+    {
+        "jurisdiction": "SG",
+        "authority": "PUB",
+        "topic": "drainage",
+        "doc_title": "PUB Code of Practice on Surface Water Drainage",
+        "landing_url": "https://www.pub.gov.sg/Documents/COP_SurfaceWaterDrainage.pdf",
+        "fetch_kind": "pdf",
+        "update_freq_hint": "annual",
+    },
+)
+
 
 @flow(name="watch-reference-sources")
 async def watch_reference_sources(
@@ -342,6 +381,14 @@ def _build_cli_parser() -> argparse.ArgumentParser:
         default=1,
         help="Fail the run if fewer than this number of documents exist after execution.",
     )
+    parser.add_argument(
+        "--seed-offline-sources",
+        action="store_true",
+        help=(
+            "When running with --offline, upsert deterministic reference sources "
+            "before ingestion. Intended for CI smoke runs."
+        ),
+    )
     return parser
 
 
@@ -391,13 +438,51 @@ async def _run_flow(
     *,
     storage: ReferenceStorage,
     fetcher: ReferenceSourceFetcher | None,
+    seed_offline_sources: bool = False,
 ) -> dict[str, Any]:
     """Execute the ingestion flow and derive a summary in one event loop."""
 
     load_model_modules()
     await _ensure_database_schema(AsyncSessionLocal)
+    if seed_offline_sources:
+        await _seed_offline_reference_sources(AsyncSessionLocal)
     results = await _run_once(storage=storage, fetcher=fetcher)
     return await _summarise_ingestion(results)
+
+
+async def _seed_offline_reference_sources(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Upsert reference sources needed by deterministic offline smoke runs."""
+
+    async with session_factory() as session:
+        existing_rows = (
+            (
+                await session.execute(
+                    select(RefSource).where(RefSource.jurisdiction == "SG")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        by_authority = {
+            (source.authority or "").upper(): source for source in existing_rows
+        }
+
+        for record in _OFFLINE_SOURCE_FIXTURES:
+            authority = record["authority"].upper()
+            source = by_authority.get(authority)
+            if source is None:
+                session.add(RefSource(**record, is_active=True))
+                continue
+            source.topic = record["topic"]
+            source.doc_title = record["doc_title"]
+            source.landing_url = record["landing_url"]
+            source.fetch_kind = record["fetch_kind"]
+            source.update_freq_hint = record["update_freq_hint"]
+            source.is_active = True
+
+        await session.commit()
 
 
 async def _ensure_database_schema(
@@ -440,7 +525,13 @@ def main(argv: Sequence[str] | None = None) -> dict[str, Any]:
     else:
         fetcher = ReferenceSourceFetcher()
 
-    summary = asyncio.run(_run_flow(storage=storage, fetcher=fetcher))
+    summary = asyncio.run(
+        _run_flow(
+            storage=storage,
+            fetcher=fetcher,
+            seed_offline_sources=args.seed_offline_sources,
+        )
+    )
 
     if summary["document_count"] < args.min_documents:
         raise SystemExit(

--- a/backend/tests/services/test_geocoding_service.py
+++ b/backend/tests/services/test_geocoding_service.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from app.schemas.external_sources import ExternalSourceState
-from app.services.geocoding import GeocodingService
+from app.services.geocoding import GeocodingService, OneMapAuthError
 
 
 class _FakeResponse:
@@ -23,16 +23,30 @@ class _DummyClient:
     def __init__(self, responder):
         self._responder = responder
 
+    def _call(self, method: str, url: str, payload: dict[str, Any]) -> _FakeResponse:
+        try:
+            return self._responder(method, url, payload)
+        except TypeError:
+            return self._responder(url, payload)
+
     async def get(
-        self, url: str, params: dict[str, Any]
+        self, url: str, params: dict[str, Any], **_: Any
     ):  # pragma: no cover - simple forwarder
-        return self._responder(url, params)
+        return self._call("GET", url, params)
+
+    async def post(
+        self, url: str, json: dict[str, Any], **_: Any
+    ):  # pragma: no cover - simple forwarder
+        return self._call("POST", url, json)
 
 
 def _make_service_with_responder(responder) -> GeocodingService:
     service = GeocodingService()
     service.client = _DummyClient(responder)
     service.google_maps_api_key = "test-key"
+    service.onemap_access_token = "test-onemap-token"
+    service.onemap_email = ""
+    service.onemap_password = ""
     service.offline_mode = False
     return service
 
@@ -119,9 +133,11 @@ async def test_geocode_returns_google_coordinates() -> None:
 
 @pytest.mark.asyncio
 async def test_geocode_lookup_prefers_onemap_for_singapore_addresses() -> None:
+    calls: list[str] = []
+
     def responder(url: str, params: dict[str, Any]) -> _FakeResponse:
         if "common/elastic/search" in url:
-            assert params["searchVal"] == "1 Nassim Rd, Singapore 258458"
+            calls.append(params["searchVal"])
             return _FakeResponse(
                 200,
                 {
@@ -155,6 +171,7 @@ async def test_geocode_lookup_prefers_onemap_for_singapore_addresses() -> None:
     service = _make_service_with_responder(responder)
     result = await service.geocode_lookup("1 Nassim Rd, Singapore 258458")
 
+    assert calls == ["1 Nassim Road Singapore 258458"]
     assert result is not None
     assert result.latitude == pytest.approx(1.3071)
     assert result.longitude == pytest.approx(103.8259)
@@ -164,6 +181,374 @@ async def test_geocode_lookup_prefers_onemap_for_singapore_addresses() -> None:
     assert result.address.postal_code == "258458"
     assert result.source.provider == "onemap_address_search"
     assert result.source.state == ExternalSourceState.LIVE
+
+
+@pytest.mark.asyncio
+async def test_geocode_lookup_uses_onemap_for_singapore_context_without_country() -> (
+    None
+):
+    calls: list[str] = []
+
+    def responder(url: str, params: dict[str, Any]) -> _FakeResponse:
+        if "common/elastic/search" in url:
+            calls.append(params["searchVal"])
+            return _FakeResponse(
+                200,
+                {
+                    "found": 1,
+                    "results": [
+                        {
+                            "SEARCHVAL": "10 MARINA BOULEVARD",
+                            "BLK_NO": "10",
+                            "ROAD_NAME": "MARINA BOULEVARD",
+                            "BUILDING": "MARINA BAY FINANCIAL CENTRE",
+                            "ADDRESS": "10 MARINA BOULEVARD SINGAPORE 018983",
+                            "POSTAL": "018983",
+                            "LATITUDE": "1.2797934",
+                            "LONGITUDE": "103.8538274",
+                        },
+                    ],
+                },
+            )
+        raise AssertionError("unexpected URL in test")
+
+    service = _make_service_with_responder(responder)
+    result = await service.geocode_lookup(
+        "10 marina boulevard",
+        jurisdiction_code="SG",
+    )
+
+    assert calls == ["10 marina boulevard"]
+    assert result is not None
+    assert result.formatted_address == "10 MARINA BOULEVARD SINGAPORE 018983"
+    assert result.address.street_name == "MARINA BOULEVARD"
+    assert result.source.provider == "onemap_address_search"
+
+
+@pytest.mark.asyncio
+async def test_geocode_lookup_uses_onemap_no_comma_singapore_retry() -> None:
+    calls: list[str] = []
+
+    def responder(url: str, params: dict[str, Any]) -> _FakeResponse:
+        if "common/elastic/search" in url:
+            search_value = params["searchVal"]
+            calls.append(search_value)
+            if search_value == "28 Soon Lee Road":
+                return _FakeResponse(200, {"found": 0, "results": []})
+            if search_value == "28 Soon Lee Road Singapore":
+                return _FakeResponse(
+                    200,
+                    {
+                        "found": 1,
+                        "results": [
+                            {
+                                "SEARCHVAL": "28 SOON LEE ROAD",
+                                "BLK_NO": "28",
+                                "ROAD_NAME": "SOON LEE ROAD",
+                                "BUILDING": "NIL",
+                                "ADDRESS": "28 SOON LEE ROAD SINGAPORE 628083",
+                                "POSTAL": "628083",
+                                "LATITUDE": "1.330785973343241",
+                                "LONGITUDE": "103.6982752065997",
+                            },
+                        ],
+                    },
+                )
+        raise AssertionError("unexpected URL in test")
+
+    service = _make_service_with_responder(responder)
+    result = await service.geocode_lookup("28 Soon Lee Rd", jurisdiction_code="SG")
+
+    assert calls == ["28 Soon Lee Road", "28 Soon Lee Road Singapore"]
+    assert result is not None
+    assert result.formatted_address == "28 SOON LEE ROAD SINGAPORE 628083"
+    assert result.latitude == pytest.approx(1.330785973343241)
+
+
+@pytest.mark.asyncio
+async def test_geocode_lookup_interpolates_missing_singapore_street_number() -> None:
+    calls: list[str] = []
+
+    def responder(url: str, params: dict[str, Any]) -> _FakeResponse:
+        if "common/elastic/search" in url:
+            search_value = params["searchVal"]
+            calls.append(search_value)
+            if search_value in {
+                "25 Soon Lee Road",
+                "25 Soon Lee Road Singapore",
+                "25 Soon Lee Rd",
+                "25 Soon Lee Rd Singapore",
+                "24 Soon Lee Road Singapore",
+            }:
+                return _FakeResponse(200, {"found": 0, "results": []})
+            if search_value == "26 Soon Lee Road Singapore":
+                return _FakeResponse(
+                    200,
+                    {
+                        "found": 1,
+                        "results": [
+                            {
+                                "SEARCHVAL": "26 SOON LEE ROAD",
+                                "BLK_NO": "26",
+                                "ROAD_NAME": "SOON LEE ROAD",
+                                "BUILDING": "NIL",
+                                "ADDRESS": "26 SOON LEE ROAD SINGAPORE 628086",
+                                "POSTAL": "628086",
+                                "LATITUDE": "1.32953109420068",
+                                "LONGITUDE": "103.6983092614985",
+                            },
+                        ],
+                    },
+                )
+            if search_value in {
+                "23 Soon Lee Road Singapore",
+                "27 Soon Lee Road Singapore",
+            }:
+                return _FakeResponse(200, {"found": 0, "results": []})
+            if search_value == "22 Soon Lee Road Singapore":
+                return _FakeResponse(
+                    200,
+                    {
+                        "found": 1,
+                        "results": [
+                            {
+                                "SEARCHVAL": "22 SOON LEE ROAD",
+                                "BLK_NO": "22",
+                                "ROAD_NAME": "SOON LEE ROAD",
+                                "BUILDING": "NIL",
+                                "ADDRESS": "22 SOON LEE ROAD SINGAPORE 628082",
+                                "POSTAL": "628082",
+                                "LATITUDE": "1.3280",
+                                "LONGITUDE": "103.6980",
+                            },
+                        ],
+                    },
+                )
+        raise AssertionError("unexpected URL in test")
+
+    service = _make_service_with_responder(responder)
+    result = await service.geocode_lookup("25 Soon Lee Rd", jurisdiction_code="SG")
+
+    assert result is not None
+    assert result.source.provider == "onemap_street_interpolation"
+    assert result.source.synthetic is True
+    assert result.formatted_address == "25 SOON LEE ROAD SINGAPORE"
+    assert result.address.block_number == "25"
+    assert result.address.street_name == "SOON LEE ROAD"
+    assert result.latitude == pytest.approx(1.32914832065051)
+    assert "22 Soon Lee Road Singapore" in calls
+    assert "26 Soon Lee Road Singapore" in calls
+
+
+@pytest.mark.asyncio
+async def test_geocode_lookup_does_not_interpolate_without_bracketing_points() -> None:
+    calls: list[str] = []
+
+    def responder(url: str, params: dict[str, Any]) -> _FakeResponse:
+        if "common/elastic/search" in url:
+            search_value = params["searchVal"]
+            calls.append(search_value)
+            if search_value == "26 Soon Lee Road Singapore":
+                return _FakeResponse(
+                    200,
+                    {
+                        "found": 1,
+                        "results": [
+                            {
+                                "SEARCHVAL": "26 SOON LEE ROAD",
+                                "BLK_NO": "26",
+                                "ROAD_NAME": "SOON LEE ROAD",
+                                "BUILDING": "NIL",
+                                "ADDRESS": "26 SOON LEE ROAD SINGAPORE 628086",
+                                "POSTAL": "628086",
+                                "LATITUDE": "1.32953109420068",
+                                "LONGITUDE": "103.6983092614985",
+                            },
+                        ],
+                    },
+                )
+            return _FakeResponse(200, {"found": 0, "results": []})
+        raise AssertionError("unexpected URL in test")
+
+    service = _make_service_with_responder(responder)
+    result = await service.geocode_lookup("25 Soon Lee Rd", jurisdiction_code="SG")
+
+    assert result is None
+    assert "26 Soon Lee Road Singapore" in calls
+    assert "17 Soon Lee Road Singapore" in calls
+
+
+@pytest.mark.asyncio
+async def test_geocode_lookup_retries_onemap_with_abbreviation_expansion() -> None:
+    calls: list[str] = []
+
+    def responder(url: str, params: dict[str, Any]) -> _FakeResponse:
+        if "common/elastic/search" in url:
+            search_value = params["searchVal"]
+            calls.append(search_value)
+            if search_value in {
+                "1 Nassim Road",
+                "1 Nassim Road Singapore",
+                "1 Nassim Rd",
+            }:
+                return _FakeResponse(200, {"found": 0, "results": []})
+            if search_value == "1 Nassim Rd Singapore":
+                return _FakeResponse(
+                    200,
+                    {
+                        "found": 1,
+                        "results": [
+                            {
+                                "SEARCHVAL": "1 NASSIM ROAD",
+                                "BLK_NO": "1",
+                                "ROAD_NAME": "NASSIM ROAD",
+                                "BUILDING": "NIL",
+                                "ADDRESS": "1 NASSIM ROAD SINGAPORE 258458",
+                                "POSTAL": "258458",
+                                "LATITUDE": "1.3071",
+                                "LONGITUDE": "103.8259",
+                            },
+                        ],
+                    },
+                )
+        raise AssertionError("unexpected URL in test")
+
+    service = _make_service_with_responder(responder)
+    result = await service.geocode_lookup(
+        "1 Nassim Rd",
+        jurisdiction_code="SG",
+    )
+
+    assert calls == [
+        "1 Nassim Road",
+        "1 Nassim Road Singapore",
+        "1 Nassim Rd",
+        "1 Nassim Rd Singapore",
+    ]
+    assert result is not None
+    assert result.address.postal_code == "258458"
+
+
+@pytest.mark.asyncio
+async def test_geocode_lookup_requires_onemap_token_for_singapore_context() -> None:
+    service = _make_service_with_responder(
+        lambda *_: (_ for _ in ()).throw(AssertionError("OneMap should not be called"))
+    )
+    service.onemap_access_token = ""
+
+    with pytest.raises(RuntimeError, match="ONEMAP_ACCESS_TOKEN or ONEMAP_EMAIL"):
+        await service.geocode_lookup("25 Soon Lee Rd", jurisdiction_code="SG")
+
+
+@pytest.mark.asyncio
+async def test_geocode_lookup_mints_onemap_token_from_server_credentials() -> None:
+    calls: list[tuple[str, str]] = []
+
+    def responder(method: str, url: str, payload: dict[str, Any]) -> _FakeResponse:
+        calls.append((method, url))
+        if method == "POST" and "auth/post/getToken" in url:
+            assert payload == {"email": "capture@example.com", "password": "secret"}
+            return _FakeResponse(
+                200,
+                {"access_token": "minted-token", "expires_in": 3600},
+            )
+        if method == "GET" and "common/elastic/search" in url:
+            return _FakeResponse(
+                200,
+                {
+                    "found": 1,
+                    "results": [
+                        {
+                            "SEARCHVAL": "25 SOON LEE ROAD",
+                            "BLK_NO": "25",
+                            "ROAD_NAME": "SOON LEE ROAD",
+                            "BUILDING": "NIL",
+                            "ADDRESS": "25 SOON LEE ROAD SINGAPORE 628083",
+                            "POSTAL": "628083",
+                            "LATITUDE": "1.3282813",
+                            "LONGITUDE": "103.6984406",
+                        },
+                    ],
+                },
+            )
+        raise AssertionError("unexpected URL in test")
+
+    service = _make_service_with_responder(responder)
+    service.onemap_access_token = ""
+    service.onemap_email = "capture@example.com"
+    service.onemap_password = "secret"
+
+    result = await service.geocode_lookup("25 Soon Lee Rd", jurisdiction_code="SG")
+
+    assert result is not None
+    assert result.address.postal_code == "628083"
+    assert service._onemap_access_token_cache == "minted-token"
+    assert calls[0][0] == "POST"
+    assert calls[1][0] == "GET"
+
+
+@pytest.mark.asyncio
+async def test_geocode_lookup_propagates_onemap_token_failure() -> None:
+    calls: list[tuple[str, str]] = []
+
+    def responder(method: str, url: str, payload: dict[str, Any]) -> _FakeResponse:
+        calls.append((method, url))
+        if method == "POST" and "auth/post/getToken" in url:
+            return _FakeResponse(400, {"error": "Invalid OneMap credentials"})
+        raise AssertionError("address search should not run after auth failure")
+
+    service = _make_service_with_responder(responder)
+    service.onemap_access_token = ""
+    service.onemap_email = "capture@example.com"
+    service.onemap_password = "secret"
+
+    with pytest.raises(
+        OneMapAuthError,
+        match=r"OneMap token request failed \(400\): Invalid OneMap credentials",
+    ):
+        await service.geocode_lookup("10 Marina Boulevard", jurisdiction_code="SG")
+
+    assert calls == [("POST", "https://www.onemap.gov.sg/api/auth/post/getToken")]
+
+
+@pytest.mark.asyncio
+async def test_geocode_lookup_reuses_cached_onemap_token() -> None:
+    post_calls = 0
+
+    def responder(method: str, url: str, payload: dict[str, Any]) -> _FakeResponse:
+        nonlocal post_calls
+        if method == "POST" and "auth/post/getToken" in url:
+            post_calls += 1
+            return _FakeResponse(200, {"access_token": "minted-token"})
+        if method == "GET" and "common/elastic/search" in url:
+            return _FakeResponse(
+                200,
+                {
+                    "found": 1,
+                    "results": [
+                        {
+                            "SEARCHVAL": "1 NASSIM ROAD",
+                            "BLK_NO": "1",
+                            "ROAD_NAME": "NASSIM ROAD",
+                            "BUILDING": "NIL",
+                            "ADDRESS": "1 NASSIM ROAD SINGAPORE 258458",
+                            "POSTAL": "258458",
+                            "LATITUDE": "1.3071",
+                            "LONGITUDE": "103.8259",
+                        },
+                    ],
+                },
+            )
+        raise AssertionError("unexpected URL in test")
+
+    service = _make_service_with_responder(responder)
+    service.onemap_access_token = ""
+    service.onemap_email = "capture@example.com"
+    service.onemap_password = "secret"
+
+    assert await service.geocode_lookup("1 Nassim Rd", jurisdiction_code="SG")
+    assert await service.geocode_lookup("1 Nassim Rd", jurisdiction_code="SG")
+    assert post_calls == 1
 
 
 @pytest.mark.asyncio
@@ -337,6 +722,42 @@ def test_onemap_amenities_metadata_reports_live_when_client_ready() -> None:
 
     assert metadata.provider == "onemap"
     assert metadata.state == ExternalSourceState.LIVE
+    assert metadata.synthetic is False
+
+
+def test_onemap_address_metadata_reports_unavailable_without_token_or_credentials() -> (
+    None
+):
+    service = GeocodingService()
+    service.offline_mode = False
+    service.client = _DummyClient(lambda *_: _FakeResponse(200, {}))
+    service.onemap_access_token = ""
+    service.onemap_email = ""
+    service.onemap_password = ""
+
+    metadata = service.get_onemap_address_metadata()
+
+    assert metadata.provider == "onemap_address_search"
+    assert metadata.state == ExternalSourceState.UNAVAILABLE
+    assert metadata.configured is False
+    assert metadata.reason == (
+        "ONEMAP_ACCESS_TOKEN or ONEMAP_EMAIL/ONEMAP_PASSWORD not configured"
+    )
+
+
+def test_onemap_address_metadata_reports_live_with_server_credentials() -> None:
+    service = GeocodingService()
+    service.offline_mode = False
+    service.client = _DummyClient(lambda *_: _FakeResponse(200, {}))
+    service.onemap_access_token = ""
+    service.onemap_email = "capture@example.com"
+    service.onemap_password = "secret"
+
+    metadata = service.get_onemap_address_metadata()
+
+    assert metadata.provider == "onemap_address_search"
+    assert metadata.state == ExternalSourceState.LIVE
+    assert metadata.configured is True
     assert metadata.synthetic is False
 
 

--- a/backend/tests/test_api/test_developer_site_acquisition.py
+++ b/backend/tests/test_api/test_developer_site_acquisition.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
 from uuid import UUID, uuid4
@@ -1246,6 +1247,64 @@ async def test_developer_log_property_prefers_onemap_submitted_address_coordinat
     assert payload["address"]["full_address"] == "25 Soon Lee Rd, Singapore 628083"
     assert payload["address"]["postal_code"] == "628083"
     assert payload["geocoding_source"]["provider"] == "onemap_address_search"
+
+
+@pytest.mark.asyncio
+async def test_resolve_submitted_sg_address_lookup_passes_jurisdiction_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+    lookup = GeocodeLookupResult(
+        latitude=1.3282813,
+        longitude=103.6984406,
+        formatted_address="25 SOON LEE ROAD SINGAPORE 628083",
+        address=Address(
+            full_address="25 SOON LEE ROAD SINGAPORE 628083",
+            street_name="SOON LEE ROAD",
+            block_number="25",
+            postal_code="628083",
+            district="D22 - Boon Lay, Jurong, Tuas",
+        ),
+        source=ExternalSourceMetadata(
+            provider="onemap_address_search",
+            state=ExternalSourceState.LIVE,
+            configured=True,
+            synthetic=False,
+        ),
+    )
+
+    class StubGeocoder:
+        async def geocode_lookup(
+            self,
+            address: str,
+            *,
+            jurisdiction_code: str | None = None,
+        ) -> GeocodeLookupResult:
+            calls.append(
+                {
+                    "address": address,
+                    "jurisdiction_code": jurisdiction_code,
+                },
+            )
+            return lookup
+
+    monkeypatch.setattr(
+        developers_api,
+        "_developer_geocoding",
+        SimpleNamespace(instance=StubGeocoder()),
+    )
+
+    result = await developers_api._resolve_submitted_sg_address_lookup(
+        SimpleNamespace(submitted_address="25 Soon Lee Rd", jurisdiction_code="SG"),
+    )
+
+    assert result is lookup
+    assert calls == [
+        {
+            "address": "25 Soon Lee Rd",
+            "jurisdiction_code": "SG",
+        },
+    ]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_core/test_config.py
+++ b/backend/tests/test_core/test_config.py
@@ -37,3 +37,27 @@ def test_finance_sensitivity_max_sync_bands_env_override(monkeypatch):
 
     settings = _fresh_settings(monkeypatch, "9")
     assert settings.FINANCE_SENSITIVITY_MAX_SYNC_BANDS == 9
+
+
+def test_local_dotenv_loader_preserves_secret_special_characters(
+    monkeypatch,
+    tmp_path,
+):
+    """Local env files should load secrets literally, without shell expansion."""
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ONEMAP_EMAIL", raising=False)
+    monkeypatch.setenv("ONEMAP_PASSWORD", "shell-expanded")
+    (tmp_path / ".env").write_text(
+        "ONEMAP_EMAIL=base@example.com\nONEMAP_PASSWORD=base\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".env.local").write_text(
+        "ONEMAP_EMAIL=capture@example.com\nONEMAP_PASSWORD=pa$$word#literal\n",
+        encoding="utf-8",
+    )
+
+    importlib.reload(config_module)
+
+    assert config_module.settings.ONEMAP_EMAIL == "capture@example.com"
+    assert config_module.settings.ONEMAP_PASSWORD == "pa$$word#literal"

--- a/backend/tests/test_flows/test_watch_fetch_flow.py
+++ b/backend/tests/test_flows/test_watch_fetch_flow.py
@@ -359,6 +359,34 @@ async def test_watch_fetch_deduplicates_identical_payloads(
 
 
 @pytest.mark.asyncio
+async def test_run_flow_seeds_offline_sources_for_ci_smoke(
+    async_session_factory,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """The offline CLI smoke should not depend on broad seed-data side effects."""
+
+    storage = ReferenceStorage(base_path=tmp_path, bucket="")
+    monkeypatch.setattr(watch_fetch_module, "AsyncSessionLocal", async_session_factory)
+
+    summary = await watch_fetch_module._run_flow(
+        storage=storage,
+        fetcher=watch_fetch_module.OfflineReferenceFetcher(),
+        seed_offline_sources=True,
+    )
+
+    assert summary["document_count"] >= 1
+    assert summary["source_count"] >= 1
+    assert summary["inserted_unique"] >= 1
+
+    async with async_session_factory() as session:
+        sources = (await session.execute(select(RefSource))).scalars().all()
+        assert {source.authority for source in sources}.issuperset(
+            {"URA", "BCA", "SCDF", "PUB"}
+        )
+
+
+@pytest.mark.asyncio
 async def test_watch_fetch_persists_seeded_html_and_pdf_sources(
     async_session_factory, tmp_path
 ) -> None:

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -87,6 +87,8 @@ For production deployment, you should:
 | `S3_ACCESS_KEY` | Object storage access | From your S3/MinIO provider |
 | `S3_SECRET_KEY` | Object storage access | From your S3/MinIO provider |
 | `FIRST_SUPERUSER_PASSWORD` | Initial admin account | Strong password (16+ chars) |
+| `ONEMAP_EMAIL` | Singapore OneMap service account for backend geocoding | Dedicated company-controlled OneMap account |
+| `ONEMAP_PASSWORD` | Singapore OneMap service account password | Strong password stored only in secrets manager |
 
 ### Best Practices
 
@@ -105,6 +107,15 @@ For production deployment, you should:
    - AWS Secrets Manager
    - HashiCorp Vault
    - Kubernetes Secrets
+
+5. **Use service accounts for external providers**
+   - Singapore OneMap production deployments should use a dedicated account
+     such as `capture-onemap@yourcompany.com`, not a personal developer email.
+   - The backend may use `ONEMAP_EMAIL` and `ONEMAP_PASSWORD` to mint short-lived
+     OneMap access tokens; do not send those credentials or tokens to the
+     frontend.
+   - `ONEMAP_ACCESS_TOKEN` is allowed only as a local/debug override because
+     OneMap tokens expire and do not auto-renew.
 
 ---
 

--- a/docs/jurisdictions/sg.md
+++ b/docs/jurisdictions/sg.md
@@ -15,17 +15,23 @@ Owner: Codex (implementation), PM (data/API keys)
 
 **Option 1: OneMap Theme API (Programmatic Access)**
 
-The OneMap Theme API requires authentication via API token:
+The OneMap Theme API requires authentication. For production, configure the
+backend with server-side OneMap account credentials so it can mint and cache
+short-lived tokens without exposing them to the frontend:
 
-1. **Obtain ONEMAP_TOKEN:**
+1. **Configure OneMap credentials or token:**
    - Register for OneMap API access at https://www.onemap.gov.sg/
-   - Generate an API token from your account dashboard
-   - Export token: `export ONEMAP_TOKEN="your_token_here"`
+   - Preferred: add `ONEMAP_EMAIL="account@example.com"` and
+     `ONEMAP_PASSWORD="account-password"` to deployment secrets or ignored
+     `.env.local`
+   - Optional local override: add `ONEMAP_ACCESS_TOKEN="your_token_here"` to
+     `.env.local`
+   - Shell-only runs can still export `ONEMAP_ACCESS_TOKEN`
 
 2. **Fetch the dataset:**
    ```bash
    # Get theme info (returns GeoJSON download link)
-   curl -H "Authorization: $ONEMAP_TOKEN" \
+   curl -H "Authorization: Bearer $ONEMAP_ACCESS_TOKEN" \
      "https://www.onemap.gov.sg/api/public/themeservice/getThemeInfo?themeName=land_lot_boundary" \
      > data/sg/parcels/theme_info.json
 

--- a/docs/runbooks/production-deployment.md
+++ b/docs/runbooks/production-deployment.md
@@ -25,8 +25,26 @@ This runbook provides step-by-step instructions for deploying optimal_build to p
 
 - [ ] AWS/Cloud credentials valid
 - [ ] Secrets updated in Secrets Manager
+- [ ] Singapore OneMap service account configured if Capture SG is enabled
 - [ ] SSL certificates valid (check expiry)
 - [ ] Database backup completed
+
+### Singapore OneMap Credentials
+
+Capture's Singapore address resolver uses OneMap server-side. For any
+third-party or paying-customer deployment, do not use a personal developer
+account and do not ask end users to provide OneMap credentials.
+
+- [ ] Create a dedicated company-controlled OneMap account, for example
+  `capture-onemap@yourcompany.com`.
+- [ ] Store `ONEMAP_EMAIL` and `ONEMAP_PASSWORD` in the production secrets
+  manager.
+- [ ] Do not expose OneMap credentials or access tokens to frontend code.
+- [ ] Treat `ONEMAP_ACCESS_TOKEN` as a temporary local/debug override only.
+- [ ] Confirm the backend can re-authenticate automatically when OneMap's
+  3-day token expires.
+- [ ] Rotate the OneMap account password under the same process as other
+  external-provider credentials.
 
 ### Communication
 
@@ -148,7 +166,14 @@ curl -sf https://optimal-build.example.com/api/v1/test | jq
    - Verify results are returned
    - Check response time < 2s
 
-3. **Monitoring Check**
+3. **Capture SG Test**
+   - Run Capture for a known Singapore address, such as `1 Nassim Rd,
+     Singapore`
+   - Verify the UI shows backend/OneMap-derived analysis coordinates
+   - Verify zoning is resolved from the SG parcel/zoning pipeline
+   - Verify no OneMap token or password appears in browser responses or logs
+
+4. **Monitoring Check**
    - Open Grafana dashboard
    - Verify metrics are flowing
    - Check for error spikes
@@ -158,6 +183,7 @@ curl -sf https://optimal-build.example.com/api/v1/test | jq
 - [ ] Health endpoint returns 200
 - [ ] Login flow works
 - [ ] Core API endpoints respond
+- [ ] Capture SG address geocoding works if Singapore is enabled
 - [ ] No new errors in Sentry
 - [ ] No error spikes in Grafana
 - [ ] SSL certificate valid

--- a/frontend/src/api/geocoding.test.ts
+++ b/frontend/src/api/geocoding.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { forwardGeocodeAddress } from './geocoding'
+
+describe('forwardGeocodeAddress', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('surfaces API problem detail for unavailable Singapore geocoding', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          title: 'Service Unavailable',
+          status: 503,
+          detail: 'ONEMAP_ACCESS_TOKEN not configured',
+        }),
+        { status: 503 },
+      ),
+    )
+
+    await expect(
+      forwardGeocodeAddress('1 Nassim Rd', { jurisdictionCode: 'SG' }),
+    ).rejects.toThrow('ONEMAP_ACCESS_TOKEN not configured')
+  })
+})

--- a/frontend/src/api/geocoding.ts
+++ b/frontend/src/api/geocoding.ts
@@ -11,15 +11,22 @@ export interface GeocodeResult {
   source?: ExternalSourceMetadata | null
 }
 
+export interface ForwardGeocodeOptions {
+  jurisdictionCode?: string | null
+}
+
 export async function forwardGeocodeAddress(
   address: string,
+  options: ForwardGeocodeOptions = {},
 ): Promise<GeocodeResult> {
-  const encoded = encodeURIComponent(address)
-  const url = buildUrl(`/api/v1/geocoding/forward?address=${encoded}`)
+  const params = new URLSearchParams({ address })
+  if (options.jurisdictionCode) {
+    params.set('jurisdictionCode', options.jurisdictionCode)
+  }
+  const url = buildUrl(`/api/v1/geocoding/forward?${params.toString()}`)
   const response = await fetch(url)
   if (!response.ok) {
-    const detail = await response.text()
-    throw new Error(detail || `Geocoding failed with status ${response.status}`)
+    throw new Error(await geocodingErrorMessage(response, 'Geocoding failed'))
   }
   const payload = (await response.json()) as {
     latitude?: number
@@ -50,9 +57,8 @@ export async function reverseGeocodeCoords(
   )
   const response = await fetch(url)
   if (!response.ok) {
-    const detail = await response.text()
     throw new Error(
-      detail || `Reverse geocoding failed with status ${response.status}`,
+      await geocodingErrorMessage(response, 'Reverse geocoding failed'),
     )
   }
   const payload = (await response.json()) as {
@@ -75,4 +81,26 @@ export async function reverseGeocodeCoords(
     formattedAddress: formatted,
     source: mapExternalSourceMetadata(payload.source),
   }
+}
+
+async function geocodingErrorMessage(
+  response: Response,
+  fallback: string,
+): Promise<string> {
+  const body = await response.text()
+  if (body) {
+    try {
+      const payload = JSON.parse(body) as { detail?: unknown; title?: unknown }
+      if (typeof payload.detail === 'string' && payload.detail.trim()) {
+        return payload.detail
+      }
+      if (typeof payload.title === 'string' && payload.title.trim()) {
+        return payload.title
+      }
+    } catch {
+      return body
+    }
+    return body
+  }
+  return `${fallback} with status ${response.status}`
 }

--- a/frontend/src/app/pages/capture/UnifiedCapturePage.test.tsx
+++ b/frontend/src/app/pages/capture/UnifiedCapturePage.test.tsx
@@ -36,6 +36,8 @@ describe('UnifiedCapturePage', () => {
     return {
       latitude: '1.3',
       longitude: '103.85',
+      analysisLatitude: '',
+      analysisLongitude: '',
       address: '',
       currentGfaSqm: '',
       currentGfaSource: '',
@@ -59,6 +61,7 @@ describe('UnifiedCapturePage', () => {
       geocodeError: null,
       isGeocoding: false,
       coordinateSourceLabel: null,
+      mapCoordinateSourceLabel: null,
       mapContainerRef: { current: null },
       addressInputRef: { current: null },
       mapError: null,
@@ -141,16 +144,56 @@ describe('UnifiedCapturePage', () => {
       buildCaptureHookValue({
         latitude: '1.3065566',
         longitude: '103.8262787',
+        analysisLatitude: '1.3065566',
+        analysisLongitude: '103.8262787',
         coordinateSourceLabel: 'OneMap address search (Singapore)',
+        mapCoordinateSourceLabel: 'OneMap address search (Singapore)',
       }),
     )
 
     render(<UnifiedCapturePage />)
 
-    expect(screen.getByText(/Coordinate source:/i)).toBeInTheDocument()
+    expect(screen.getByText(/Used for zoning:/i)).toBeInTheDocument()
     expect(
       screen.getByText('OneMap address search (Singapore)'),
     ).toBeInTheDocument()
+  })
+
+  it('separates analysis coordinates from the map preview', () => {
+    mockUseDeveloperMode.mockReturnValue({
+      isDeveloperMode: true,
+      toggleDeveloperMode: mockToggleDeveloperMode,
+    })
+
+    mockUseUnifiedCapture.mockReturnValue(
+      buildCaptureHookValue({
+        latitude: '1.3065566',
+        longitude: '103.8262787',
+        analysisLatitude: '',
+        analysisLongitude: '',
+        coordinateSourceLabel: null,
+        mapCoordinateSourceLabel: 'Google Places autocomplete',
+      }),
+    )
+
+    render(<UnifiedCapturePage />)
+
+    expect(screen.getByLabelText('Lat')).toHaveValue('')
+    expect(screen.getByLabelText('Lng')).toHaveValue('')
+    expect(screen.getByLabelText('Lat')).toHaveAttribute(
+      'placeholder',
+      'Pending',
+    )
+    expect(screen.getByLabelText('Lng')).toHaveAttribute(
+      'placeholder',
+      'Pending',
+    )
+    expect(screen.getByText(/Used for zoning:/i)).toHaveTextContent(
+      'Not resolved yet',
+    )
+    expect(screen.getByText(/Map preview:/i)).toHaveTextContent(
+      '1.3065566, 103.8262787 · Google Places autocomplete',
+    )
   })
 
   it('renders the developer workspace when developer mode has results', async () => {

--- a/frontend/src/app/pages/capture/UnifiedCapturePage.tsx
+++ b/frontend/src/app/pages/capture/UnifiedCapturePage.tsx
@@ -39,6 +39,8 @@ export function UnifiedCapturePage() {
   const {
     latitude,
     longitude,
+    analysisLatitude,
+    analysisLongitude,
     address,
     selectedScenarios,
     setAddress,
@@ -54,6 +56,7 @@ export function UnifiedCapturePage() {
     geocodeError,
     isGeocoding,
     coordinateSourceLabel,
+    mapCoordinateSourceLabel,
     mapContainerRef,
     addressInputRef,
     mapError,
@@ -185,7 +188,9 @@ export function UnifiedCapturePage() {
                   <p className="gps-error-text">{geocodeError}</p>
                 )}
 
-                {/* Coords — compact row */}
+                <p className="gps-form__coordinate-heading">
+                  Analysis coordinates
+                </p>
                 <div className="gps-form__coords-row">
                   <div className="gps-form__coord">
                     <label
@@ -198,8 +203,8 @@ export function UnifiedCapturePage() {
                       id="capture-lat"
                       type="text"
                       className="gps-input-ghost gps-input-ghost--sm"
-                      placeholder="-36.8485"
-                      value={latitude}
+                      placeholder="Pending"
+                      value={analysisLatitude}
                       readOnly
                       inputMode="decimal"
                     />
@@ -215,17 +220,26 @@ export function UnifiedCapturePage() {
                       id="capture-lng"
                       type="text"
                       className="gps-input-ghost gps-input-ghost--sm"
-                      placeholder="174.7633"
-                      value={longitude}
+                      placeholder="Pending"
+                      value={analysisLongitude}
                       readOnly
                       inputMode="decimal"
                     />
                   </div>
                 </div>
-                {(latitude || longitude || coordinateSourceLabel) && (
+                <p className="gps-form__coordinate-source">
+                  Used for zoning:{' '}
+                  <span>{coordinateSourceLabel ?? 'Not resolved yet'}</span>
+                </p>
+                {(latitude || longitude || mapCoordinateSourceLabel) && (
                   <p className="gps-form__coordinate-source">
-                    Coordinate source:{' '}
-                    <span>{coordinateSourceLabel ?? 'Not resolved yet'}</span>
+                    Map preview:{' '}
+                    <span>
+                      {latitude && longitude ? `${latitude}, ${longitude}` : ''}
+                      {mapCoordinateSourceLabel
+                        ? `${latitude && longitude ? ' · ' : ''}${mapCoordinateSourceLabel}`
+                        : ''}
+                    </span>
                   </p>
                 )}
               </fieldset>

--- a/frontend/src/app/pages/capture/hooks/__tests__/useUnifiedCapture.test.tsx
+++ b/frontend/src/app/pages/capture/hooks/__tests__/useUnifiedCapture.test.tsx
@@ -14,6 +14,10 @@ const mockMarkerConstructor = vi.fn()
 const mockMarkerAddListener = vi.fn()
 const mockMarkerSetPosition = vi.fn()
 const mockMarkerSetMap = vi.fn()
+const mockAutocompleteConstructor = vi.fn()
+const mockAutocompleteAddListener = vi.fn()
+let mockAutocompletePlace: Record<string, unknown> | null = null
+let mockAutocompletePlaceChanged: (() => void) | null = null
 
 const installGoogleMapsMocks = () => {
   Object.defineProperty(window, 'google', {
@@ -48,6 +52,22 @@ const installGoogleMapsMocks = () => {
           getPosition() {
             return { lat: () => 1.3, lng: () => 103.85 }
           }
+        },
+        places: {
+          Autocomplete: class {
+            constructor(...args: unknown[]) {
+              mockAutocompleteConstructor(...args)
+            }
+            addListener(eventName: string, callback: () => void) {
+              mockAutocompleteAddListener(eventName, callback)
+              if (eventName === 'place_changed') {
+                mockAutocompletePlaceChanged = callback
+              }
+            }
+            getPlace() {
+              return mockAutocompletePlace ?? {}
+            }
+          },
         },
       },
     },
@@ -87,7 +107,12 @@ function renderHookHarness(
 
   function Harness() {
     ref.current = useUnifiedCapture({ isDeveloperMode, ...options })
-    return <div ref={ref.current.mapContainerRef} />
+    return (
+      <>
+        <input ref={ref.current.addressInputRef} aria-label="Address" />
+        <div ref={ref.current.mapContainerRef} />
+      </>
+    )
   }
 
   render(<Harness />)
@@ -102,6 +127,8 @@ describe('useUnifiedCapture', () => {
     cleanup()
     vi.useRealTimers()
     vi.resetAllMocks()
+    mockAutocompletePlace = null
+    mockAutocompletePlaceChanged = null
     sessionStorage.clear()
     document.body.classList.remove('capture-results-active')
     delete (window as { google?: unknown }).google
@@ -155,11 +182,46 @@ describe('useUnifiedCapture', () => {
       vi.advanceTimersByTime(800)
     })
 
-    expect(mockForwardGeocodeAddress).toHaveBeenCalledWith('123 Main St')
-    expect(hookRef.current!.latitude).toBe('1.2345')
-    expect(hookRef.current!.longitude).toBe('103.9876')
+    expect(mockForwardGeocodeAddress).toHaveBeenCalledWith('123 Main St', {
+      jurisdictionCode: 'SG',
+    })
+    expect(hookRef.current!.latitude).toBe('1.234500')
+    expect(hookRef.current!.longitude).toBe('103.987600')
+    expect(hookRef.current!.analysisLatitude).toBe('1.234500')
+    expect(hookRef.current!.analysisLongitude).toBe('103.987600')
     expect(hookRef.current!.coordinateSourceLabel).toBe(
       'OneMap address search (Singapore)',
+    )
+  })
+
+  it('labels interpolated Singapore coordinates separately from exact OneMap hits', async () => {
+    vi.useFakeTimers()
+    mockForwardGeocodeAddress.mockResolvedValue({
+      latitude: 1.3291483,
+      longitude: 103.6982319,
+      formattedAddress: '25 SOON LEE ROAD SINGAPORE',
+      source: {
+        provider: 'onemap_street_interpolation',
+        state: 'live',
+        configured: true,
+        synthetic: true,
+        reason: 'Exact address was not returned by OneMap',
+      },
+    })
+
+    const hookRef = renderHookHarness(true, { googleMapsApiKey: '' })
+
+    await act(async () => {
+      hookRef.current!.setAddress('25 Soon Lee Rd')
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(800)
+    })
+
+    expect(hookRef.current!.analysisLatitude).toBe('1.329148')
+    expect(hookRef.current!.analysisLongitude).toBe('103.698232')
+    expect(hookRef.current!.coordinateSourceLabel).toBe(
+      'Approximate OneMap street interpolation (Singapore)',
     )
   })
 
@@ -177,6 +239,85 @@ describe('useUnifiedCapture', () => {
     })
 
     expect(hookRef.current!.geocodeError).toBe('Geocode down')
+  })
+
+  it('clears stale analysis coordinates when Singapore geocoding fails', async () => {
+    vi.useFakeTimers()
+    mockForwardGeocodeAddress
+      .mockResolvedValueOnce({
+        latitude: 1.2345,
+        longitude: 103.9876,
+        formattedAddress: '123 MAIN ST SINGAPORE 123456',
+        source: {
+          provider: 'onemap_address_search',
+          state: 'live',
+          configured: true,
+          synthetic: false,
+        },
+      })
+      .mockRejectedValueOnce(
+        new Error(
+          'OneMap token request failed (400): Invalid OneMap credentials',
+        ),
+      )
+
+    const hookRef = renderHookHarness(true, { googleMapsApiKey: '' })
+
+    await act(async () => {
+      hookRef.current!.setAddress('123 Main St Singapore')
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(800)
+      await Promise.resolve()
+    })
+
+    expect(hookRef.current!.analysisLatitude).toBe('1.234500')
+    expect(hookRef.current!.analysisLongitude).toBe('103.987600')
+
+    await act(async () => {
+      hookRef.current!.setAddress('10 Marina Boulevard singapore')
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(800)
+      await Promise.resolve()
+    })
+
+    expect(hookRef.current!.geocodeError).toBe(
+      'OneMap token request failed (400): Invalid OneMap credentials',
+    )
+    expect(hookRef.current!.latitude).toBe('')
+    expect(hookRef.current!.longitude).toBe('')
+    expect(hookRef.current!.analysisLatitude).toBe('')
+    expect(hookRef.current!.analysisLongitude).toBe('')
+    expect(hookRef.current!.coordinateSourceLabel).toBeNull()
+    expect(hookRef.current!.mapCoordinateSourceLabel).toBeNull()
+  })
+
+  it('uses the backend geocoding failure as the scan error', async () => {
+    vi.useFakeTimers()
+    mockForwardGeocodeAddress.mockRejectedValue(
+      new Error('ONEMAP_ACCESS_TOKEN not configured'),
+    )
+    const hookRef = renderHookHarness(true, { googleMapsApiKey: '' })
+
+    await act(async () => {
+      hookRef.current!.setAddress('1 Nassim Rd')
+    })
+
+    await act(async () => {
+      const event = {
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>
+      const promise = hookRef.current!.handleCapture(event)
+      await Promise.resolve()
+      await vi.runAllTimersAsync()
+      await promise
+    })
+
+    expect(hookRef.current!.captureError).toBe(
+      'ONEMAP_ACCESS_TOKEN not configured',
+    )
+    expect(mockCapturePropertyForDevelopment).not.toHaveBeenCalled()
   })
 
   it('runs the developer capture flow and persists the capture', async () => {
@@ -335,8 +476,10 @@ describe('useUnifiedCapture', () => {
       await Promise.resolve()
     })
 
-    expect(hookRef.current!.latitude).toBe('1.3286413')
+    expect(hookRef.current!.latitude).toBe('1.328641')
     expect(hookRef.current!.longitude).toBe('103.698443')
+    expect(hookRef.current!.analysisLatitude).toBe('1.328641')
+    expect(hookRef.current!.analysisLongitude).toBe('103.698443')
 
     await act(async () => {
       const event = {
@@ -352,6 +495,142 @@ describe('useUnifiedCapture', () => {
     expect(hookRef.current!.captureError).toContain(
       'Geocoding resolved "25 Soon Lee Rd, Singapore 628083" to "20 Soon Lee Rd, Singapore 628086"',
     )
+  })
+
+  it('re-resolves partial Singapore addresses before capture even after auto-geocode', async () => {
+    vi.useFakeTimers()
+    mockForwardGeocodeAddress.mockResolvedValue({
+      latitude: 1.3282813,
+      longitude: 103.6984406,
+      formattedAddress: '20 Soon Lee Rd, Singapore 628086',
+      source: {
+        provider: 'onemap_address_search',
+        state: 'live',
+        configured: true,
+        synthetic: false,
+      },
+    })
+
+    const hookRef = renderHookHarness(true, { googleMapsApiKey: '' })
+
+    await act(async () => {
+      hookRef.current!.setAddress('25 Soon Lee Rd')
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(800)
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      const event = {
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>
+      const promise = hookRef.current!.handleCapture(event)
+      await Promise.resolve()
+      await vi.runAllTimersAsync()
+      await promise
+    })
+
+    expect(mockForwardGeocodeAddress).toHaveBeenCalledTimes(2)
+    expect(mockForwardGeocodeAddress).toHaveBeenLastCalledWith(
+      '25 Soon Lee Rd',
+      { jurisdictionCode: 'SG' },
+    )
+    expect(mockCapturePropertyForDevelopment).not.toHaveBeenCalled()
+    expect(hookRef.current!.captureError).toContain(
+      'Geocoding resolved "25 Soon Lee Rd" to "20 Soon Lee Rd, Singapore 628086"',
+    )
+  })
+
+  it('re-resolves Singapore Google Places selections through backend geocoding before capture', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-06T10:00:00.000Z'))
+    installGoogleMapsMocks()
+
+    mockForwardGeocodeAddress.mockResolvedValue({
+      latitude: 1.3071,
+      longitude: 103.8259,
+      formattedAddress: '1 NASSIM ROAD SINGAPORE 258458',
+      source: {
+        provider: 'onemap_address_search',
+        state: 'live',
+        configured: true,
+        synthetic: false,
+      },
+    })
+    mockCapturePropertyForDevelopment.mockResolvedValue({
+      propertyId: 'prop-nassim',
+      currencySymbol: 'S$',
+      address: { fullAddress: '1 NASSIM ROAD SINGAPORE 258458' },
+      quickAnalysis: { generatedAt: '2026-01-06T09:58:00Z', scenarios: [] },
+      previewJob: null,
+    })
+
+    const hookRef = renderHookHarness(true, { googleMapsApiKey: 'test-key' })
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(mockAutocompleteConstructor).toHaveBeenCalled()
+
+    mockAutocompletePlace = {
+      formatted_address: '1 Nassim Rd, Singapore 258458',
+      place_id: 'google-place-1',
+      name: '1 Nassim Road',
+      types: ['street_address'],
+      geometry: {
+        location: {
+          lat: () => 1.3065566,
+          lng: () => 103.8262787,
+        },
+      },
+    }
+
+    await act(async () => {
+      mockAutocompletePlaceChanged?.()
+    })
+
+    expect(hookRef.current!.latitude).toBe('1.306557')
+    expect(hookRef.current!.longitude).toBe('103.826279')
+    expect(hookRef.current!.analysisLatitude).toBe('')
+    expect(hookRef.current!.analysisLongitude).toBe('')
+    expect(hookRef.current!.coordinateSourceLabel).toBe(null)
+    expect(hookRef.current!.mapCoordinateSourceLabel).toBe(
+      'Google Places autocomplete',
+    )
+
+    await act(async () => {
+      const event = {
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>
+      const promise = hookRef.current!.handleCapture(event)
+      await Promise.resolve()
+      await vi.runAllTimersAsync()
+      await promise
+    })
+
+    expect(mockForwardGeocodeAddress).toHaveBeenCalledWith(
+      '1 Nassim Rd, Singapore 258458',
+      { jurisdictionCode: 'SG' },
+    )
+    expect(mockCapturePropertyForDevelopment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        latitude: 1.3071,
+        longitude: 103.8259,
+        submittedAddress: '1 Nassim Rd, Singapore 258458',
+        placeId: 'google-place-1',
+        placeName: '1 Nassim Road',
+        placeTypes: ['street_address'],
+      }),
+      expect.any(AbortSignal),
+    )
+    expect(hookRef.current!.coordinateSourceLabel).toBe(
+      'OneMap address search (Singapore)',
+    )
+    expect(hookRef.current!.analysisLatitude).toBe('1.307100')
+    expect(hookRef.current!.analysisLongitude).toBe('103.825900')
   })
 
   it('omits developmentScenarios when no scenarios are selected (developer flow)', async () => {
@@ -410,6 +689,8 @@ describe('useUnifiedCapture', () => {
 
     expect(hookRef.current!.latitude).toBe('')
     expect(hookRef.current!.longitude).toBe('')
+    expect(hookRef.current!.analysisLatitude).toBe('')
+    expect(hookRef.current!.analysisLongitude).toBe('')
     expect(hookRef.current!.address).toBe('')
     expect(hookRef.current!.currentGfaSqm).toBe('')
     expect(hookRef.current!.currentGfaSource).toBe('')

--- a/frontend/src/app/pages/capture/hooks/useUnifiedCapture.ts
+++ b/frontend/src/app/pages/capture/hooks/useUnifiedCapture.ts
@@ -36,6 +36,15 @@ function leadingStreetNumber(value: string): string | null {
   return match?.[1]?.toLowerCase() ?? null
 }
 
+function looksLikeSingaporeAddress(value: string): boolean {
+  const trimmed = value.trim()
+  return /\bsingapore\b/i.test(trimmed) || /\b\d{6}\b/.test(trimmed)
+}
+
+function formatCoordinate(value: number): string {
+  return Number.isFinite(value) ? value.toFixed(6) : ''
+}
+
 function hasConflictingResolvedStreetNumber(
   submittedAddress: string,
   resolvedAddress: string | null | undefined,
@@ -148,6 +157,8 @@ function coordinateSourceLabelFor(
   switch (source.provider) {
     case 'onemap_address_search':
       return 'OneMap address search (Singapore)'
+    case 'onemap_street_interpolation':
+      return 'Approximate OneMap street interpolation (Singapore)'
     case 'google_maps':
       return fallbackLabel ?? 'Google geocoding'
     default:
@@ -169,6 +180,8 @@ export interface UseUnifiedCaptureReturn {
   // Form state
   latitude: string
   longitude: string
+  analysisLatitude: string
+  analysisLongitude: string
   address: string
   currentGfaSqm: string
   currentGfaSource: string
@@ -202,6 +215,7 @@ export interface UseUnifiedCaptureReturn {
   geocodeError: string | null
   isGeocoding: boolean
   coordinateSourceLabel: string | null
+  mapCoordinateSourceLabel: string | null
 
   // Map
   mapContainerRef: React.RefObject<HTMLDivElement>
@@ -223,10 +237,14 @@ export function useUnifiedCapture({
   projectId,
   googleMapsApiKey,
 }: UseUnifiedCaptureOptions): UseUnifiedCaptureReturn {
-  // Form state — start empty; geolocation fills in the user's position
+  // Form state — latitude/longitude is the map preview position; analysis
+  // coordinates are backend-resolved and are the only coordinates used for
+  // zoning lookup once available.
   const [latitude, setLatitude] = useState<string>('')
   const [longitude, setLongitude] = useState<string>('')
-  const [address, setAddress] = useState<string>('')
+  const [analysisLatitude, setAnalysisLatitude] = useState<string>('')
+  const [analysisLongitude, setAnalysisLongitude] = useState<string>('')
+  const [address, setAddressState] = useState<string>('')
   const [currentGfaSqm, setCurrentGfaSqm] = useState<string>('')
   const [currentGfaSource, setCurrentGfaSource] = useState<string>('')
   const [jurisdictionCode, setJurisdictionCode] = useState<string>('')
@@ -268,10 +286,39 @@ export function useUnifiedCapture({
   const [coordinateSourceLabel, setCoordinateSourceLabel] = useState<
     string | null
   >(null)
+  const [mapCoordinateSourceLabel, setMapCoordinateSourceLabel] = useState<
+    string | null
+  >(null)
   // Track the address that was last geocoded to avoid redundant calls
   const lastGeocodedAddressRef = useRef<string>('')
   const lastResolvedGeocodeAddressRef = useRef<string>('')
+  const lastGeocodeErrorRef = useRef<string | null>(null)
   const selectedPlaceMetadataRef = useRef<SelectedPlaceMetadata | null>(null)
+
+  const clearAnalysisCoordinates = useCallback(() => {
+    setAnalysisLatitude('')
+    setAnalysisLongitude('')
+    setCoordinateSourceLabel(null)
+  }, [])
+
+  const clearAddressResolvedCoordinates = useCallback(() => {
+    clearAnalysisCoordinates()
+    if (mapCoordinateSourceLabel !== 'Browser location') {
+      setLatitude('')
+      setLongitude('')
+      setMapCoordinateSourceLabel(null)
+    }
+  }, [clearAnalysisCoordinates, mapCoordinateSourceLabel])
+
+  const setAddress = useCallback(
+    (value: string) => {
+      setAddressState(value)
+      if (value.trim() !== lastGeocodedAddressRef.current) {
+        clearAddressResolvedCoordinates()
+      }
+    },
+    [clearAddressResolvedCoordinates],
+  )
 
   // Map
   const [mapError, setMapError] = useState<string | null>(null)
@@ -322,7 +369,7 @@ export function useUnifiedCapture({
       // Only set if user hasn't already typed something
       setLatitude((prev) => (prev === '' ? pos.latitude.toFixed(6) : prev))
       setLongitude((prev) => (prev === '' ? pos.longitude.toFixed(6) : prev))
-      setCoordinateSourceLabel((prev) => prev ?? 'Browser location')
+      setMapCoordinateSourceLabel((prev) => prev ?? 'Browser location')
 
       // Center map if already initialized
       if (mapInstanceRef.current) {
@@ -357,18 +404,28 @@ export function useUnifiedCapture({
     } | null> => {
       const targetAddress = addressToGeocode ?? address
       if (!targetAddress.trim()) {
-        setGeocodeError('Please enter an address to geocode.')
+        const message = 'Please enter an address to geocode.'
+        lastGeocodeErrorRef.current = message
+        setGeocodeError(message)
         return null
       }
       try {
+        lastGeocodeErrorRef.current = null
         setGeocodeError(null)
         setIsGeocoding(true)
-        const result = await forwardGeocodeAddress(targetAddress.trim())
-        setLatitude(result.latitude.toString())
-        setLongitude(result.longitude.toString())
-        setCoordinateSourceLabel(
-          coordinateSourceLabelFor(result.source, 'Backend geocoder'),
+        const result = await forwardGeocodeAddress(targetAddress.trim(), {
+          jurisdictionCode: jurisdictionCode || 'SG',
+        })
+        const sourceLabel = coordinateSourceLabelFor(
+          result.source,
+          'Backend geocoder',
         )
+        setLatitude(formatCoordinate(result.latitude))
+        setLongitude(formatCoordinate(result.longitude))
+        setMapCoordinateSourceLabel(sourceLabel)
+        setAnalysisLatitude(formatCoordinate(result.latitude))
+        setAnalysisLongitude(formatCoordinate(result.longitude))
+        setCoordinateSourceLabel(sourceLabel)
         lastGeocodedAddressRef.current = targetAddress.trim()
         lastResolvedGeocodeAddressRef.current = result.formattedAddress
         selectedPlaceMetadataRef.current = null
@@ -387,15 +444,27 @@ export function useUnifiedCapture({
         }
       } catch (error) {
         console.error('Forward geocode failed', error)
-        setGeocodeError(
-          error instanceof Error ? error.message : 'Unable to geocode address.',
-        )
+        const message =
+          error instanceof Error ? error.message : 'Unable to geocode address.'
+        lastGeocodeErrorRef.current = message
+        setGeocodeError(message)
+        if (
+          jurisdictionCode.toUpperCase() === 'SG' ||
+          looksLikeSingaporeAddress(targetAddress)
+        ) {
+          clearAddressResolvedCoordinates()
+        }
         return null
       } finally {
         setIsGeocoding(false)
       }
     },
-    [address, updateMarkerPosition],
+    [
+      address,
+      clearAddressResolvedCoordinates,
+      jurisdictionCode,
+      updateMarkerPosition,
+    ],
   )
 
   // Auto-geocode when address changes (debounced)
@@ -468,12 +537,15 @@ export function useUnifiedCapture({
     }
     if (storedResult) {
       setSiteAcquisitionResult(storedResult)
-      setLatitude(storedResult.coordinates.latitude.toString())
-      setLongitude(storedResult.coordinates.longitude.toString())
+      setLatitude(formatCoordinate(storedResult.coordinates.latitude))
+      setLongitude(formatCoordinate(storedResult.coordinates.longitude))
+      setAnalysisLatitude(formatCoordinate(storedResult.coordinates.latitude))
+      setAnalysisLongitude(formatCoordinate(storedResult.coordinates.longitude))
       setCoordinateSourceLabel('Saved capture coordinates')
+      setMapCoordinateSourceLabel('Saved capture coordinates')
       setJurisdictionCode(storedResult.jurisdictionCode ?? 'SG')
       if (storedResult.address?.fullAddress) {
-        setAddress(storedResult.address.fullAddress)
+        setAddressState(storedResult.address.fullAddress)
       }
     }
     hasHydratedRef.current = true
@@ -649,17 +721,18 @@ export function useUnifiedCapture({
           typeof position.lng === 'function' ? position.lng() : position.lng
         setLatitude(Number(lat).toFixed(6))
         setLongitude(Number(lng).toFixed(6))
-        setCoordinateSourceLabel('Google Maps pin')
+        setMapCoordinateSourceLabel('Google Maps pin')
+        clearAnalysisCoordinates()
         reverseGeocodeCoords(Number(lat), Number(lng))
           .then((result) => {
             if (mounted && result?.formattedAddress) {
-              setCoordinateSourceLabel(
+              setMapCoordinateSourceLabel(
                 coordinateSourceLabelFor(
                   result.source,
                   'Google Maps reverse geocoding',
                 ),
               )
-              setAddress(result.formattedAddress)
+              setAddressState(result.formattedAddress)
               lastGeocodedAddressRef.current = result.formattedAddress
               lastResolvedGeocodeAddressRef.current = result.formattedAddress
             }
@@ -683,18 +756,19 @@ export function useUnifiedCapture({
         const lng = event.latLng.lng()
         setLatitude(lat.toFixed(6))
         setLongitude(lng.toFixed(6))
-        setCoordinateSourceLabel('Google Maps pin')
+        setMapCoordinateSourceLabel('Google Maps pin')
+        clearAnalysisCoordinates()
         setMarkerPosition(lat, lng)
         reverseGeocodeCoords(lat, lng)
           .then((result) => {
             if (mounted && result?.formattedAddress) {
-              setCoordinateSourceLabel(
+              setMapCoordinateSourceLabel(
                 coordinateSourceLabelFor(
                   result.source,
                   'Google Maps reverse geocoding',
                 ),
               )
-              setAddress(result.formattedAddress)
+              setAddressState(result.formattedAddress)
               lastGeocodedAddressRef.current = result.formattedAddress
               lastResolvedGeocodeAddressRef.current = result.formattedAddress
             }
@@ -741,7 +815,7 @@ export function useUnifiedCapture({
     autocomplete.addListener('place_changed', () => {
       const place = autocomplete.getPlace()
       if (place.formatted_address) {
-        setAddress(place.formatted_address)
+        setAddressState(place.formatted_address)
         lastGeocodedAddressRef.current = place.formatted_address
         lastResolvedGeocodeAddressRef.current = place.formatted_address
         selectedPlaceMetadataRef.current = {
@@ -756,7 +830,8 @@ export function useUnifiedCapture({
         const lng = place.geometry.location.lng()
         setLatitude(lat.toFixed(6))
         setLongitude(lng.toFixed(6))
-        setCoordinateSourceLabel('Google Places autocomplete')
+        setMapCoordinateSourceLabel('Google Places autocomplete')
+        clearAnalysisCoordinates()
         if (mapInstanceRef.current) {
           mapInstanceRef.current.setCenter({ lat, lng })
           updateMarkerPosition(lat, lng)
@@ -790,14 +865,16 @@ export function useUnifiedCapture({
         // If address is provided and hasn't been geocoded yet, geocode it first
         // This ensures the coordinates match the entered address
         const trimmedAddress = address.trim()
-        let finalLat = Number(latitude)
-        let finalLon = Number(longitude)
+        let finalLat = Number(analysisLatitude || latitude)
+        let finalLon = Number(analysisLongitude || longitude)
         const selectedPlaceMetadata =
           selectedPlaceMetadataRef.current?.formattedAddress === trimmedAddress
             ? selectedPlaceMetadataRef.current
             : null
+        const activeJurisdictionCode = jurisdictionCode || 'SG'
 
         if (
+          activeJurisdictionCode.toUpperCase() !== 'SG' &&
           trimmedAddress &&
           trimmedAddress === lastGeocodedAddressRef.current &&
           hasConflictingResolvedStreetNumber(
@@ -813,15 +890,22 @@ export function useUnifiedCapture({
           return
         }
 
-        if (
+        const shouldResolveThroughBackend =
           trimmedAddress &&
-          trimmedAddress !== lastGeocodedAddressRef.current
-        ) {
+          (trimmedAddress !== lastGeocodedAddressRef.current ||
+            activeJurisdictionCode.toUpperCase() === 'SG' ||
+            looksLikeSingaporeAddress(trimmedAddress) ||
+            mapCoordinateSourceLabel === 'Google Places autocomplete')
+
+        if (shouldResolveThroughBackend) {
           // Address has changed since last geocode - geocode it now
+          // Singapore captures must use the backend resolver because it prefers
+          // OneMap coordinates for parcel-to-zoning lookup.
           const geocodeResult = await handleForwardGeocode(trimmedAddress)
           if (!geocodeResult) {
             setCaptureError(
-              'Unable to geocode the address. Please check the address and try again.',
+              lastGeocodeErrorRef.current ||
+                'Unable to geocode the address. Please check the address and try again.',
             )
             setIsCapturing(false)
             setIsScanning(false)
@@ -1016,6 +1100,8 @@ export function useUnifiedCapture({
     [
       latitude,
       longitude,
+      analysisLatitude,
+      analysisLongitude,
       address,
       currentGfaSqm,
       currentGfaSource,
@@ -1023,6 +1109,7 @@ export function useUnifiedCapture({
       selectedScenarios,
       isDeveloperMode,
       handleForwardGeocode,
+      mapCoordinateSourceLabel,
     ],
   )
 
@@ -1053,9 +1140,11 @@ export function useUnifiedCapture({
     setCaptureError(null)
     setGeocodeError(null)
     setTargetAcquired(null)
+    clearAnalysisCoordinates()
+    setMapCoordinateSourceLabel(null)
 
     // Reset form — clear fields, re-geolocate
-    setAddress('')
+    setAddressState('')
     setCurrentGfaSqm('')
     setCurrentGfaSource('')
     setSelectedScenarios([])
@@ -1074,6 +1163,7 @@ export function useUnifiedCapture({
       if (pos) {
         setLatitude(pos.latitude.toFixed(6))
         setLongitude(pos.longitude.toFixed(6))
+        setMapCoordinateSourceLabel('Browser location')
         if (mapInstanceRef.current) {
           mapInstanceRef.current.setCenter({
             lat: pos.latitude,
@@ -1084,9 +1174,10 @@ export function useUnifiedCapture({
       } else {
         setLatitude('')
         setLongitude('')
+        setMapCoordinateSourceLabel(null)
       }
     })
-  }, [updateMarkerPosition])
+  }, [clearAnalysisCoordinates, updateMarkerPosition])
 
   // Compute hasResults
   const hasResults = isDeveloperMode
@@ -1105,6 +1196,8 @@ export function useUnifiedCapture({
     // Form state
     latitude,
     longitude,
+    analysisLatitude,
+    analysisLongitude,
     address,
     currentGfaSqm,
     currentGfaSource,
@@ -1138,6 +1231,7 @@ export function useUnifiedCapture({
     geocodeError,
     isGeocoding,
     coordinateSourceLabel,
+    mapCoordinateSourceLabel,
 
     // Map
     mapContainerRef,

--- a/frontend/src/styles/gps-capture/core.css
+++ b/frontend/src/styles/gps-capture/core.css
@@ -219,6 +219,16 @@
 
 /* ── Coords (compact row) ── */
 
+.gps-form__coordinate-heading {
+    margin: var(--ob-space-050) 0 calc(var(--ob-space-025) * -1);
+    color: var(--ob-color-text-muted);
+    font-size: var(--ob-font-size-2xs);
+    font-weight: var(--ob-font-weight-semibold);
+    letter-spacing: 0.04em;
+    line-height: var(--ob-line-height-snug);
+    text-transform: uppercase;
+}
+
 .gps-form__coords-row {
     display: flex;
     gap: var(--ob-space-100);

--- a/infra/backup/backup.sh
+++ b/infra/backup/backup.sh
@@ -40,7 +40,6 @@ RETENTION_MONTHLY="${RETENTION_MONTHLY:-12}"
 
 # Timestamp formats
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-DATE=$(date +%Y%m%d)
 WEEK=$(date +%Y_W%V)
 MONTH=$(date +%Y%m)
 
@@ -94,7 +93,8 @@ backup_full() {
         --verbose \
         2>&1 | gzip > "${backup_file}"
 
-    local backup_size=$(du -h "${backup_file}" | cut -f1)
+    local backup_size
+    backup_size=$(du -h "${backup_file}" | cut -f1)
     log "Full backup completed: ${backup_file} (${backup_size})"
 
     # Create weekly backup on Sundays
@@ -131,7 +131,8 @@ backup_custom() {
         -f "${backup_file}" \
         2>&1
 
-    local backup_size=$(du -h "${backup_file}" | cut -f1)
+    local backup_size
+    backup_size=$(du -h "${backup_file}" | cut -f1)
     log "Custom backup completed: ${backup_file} (${backup_size})"
 
     echo "${backup_file}"
@@ -161,7 +162,8 @@ backup_schema() {
 # Upload to S3
 upload_to_s3() {
     local file_path="$1"
-    local filename=$(basename "${file_path}")
+    local filename
+    filename=$(basename "${file_path}")
     local s3_key="${S3_PREFIX}/${filename}"
 
     if [[ -z "${S3_BUCKET}" ]]; then

--- a/infra/backup/restore.sh
+++ b/infra/backup/restore.sh
@@ -37,7 +37,7 @@ S3_PREFIX="${S3_PREFIX:-backups/postgresql}"
 
 # Temporary directory for downloads
 TEMP_DIR=$(mktemp -d)
-trap "rm -rf ${TEMP_DIR}" EXIT
+trap 'rm -rf "${TEMP_DIR}"' EXIT
 
 # Logging
 log() {
@@ -90,7 +90,8 @@ list_s3_backups() {
 # Download from S3
 download_from_s3() {
     local s3_key="$1"
-    local filename=$(basename "${s3_key}")
+    local filename
+    filename=$(basename "${s3_key}")
     local local_path="${TEMP_DIR}/${filename}"
 
     if [[ -z "${S3_BUCKET}" ]]; then
@@ -220,7 +221,8 @@ do_restore() {
         error "Backup file not found: ${backup_file}"
     fi
 
-    local file_size=$(du -h "${backup_file}" | cut -f1)
+    local file_size
+    file_size=$(du -h "${backup_file}" | cut -f1)
     log "Backup file: ${backup_file} (${file_size})"
 
     # Confirm restoration
@@ -244,7 +246,8 @@ do_restore() {
 verify_restore() {
     log "Verifying restored database..."
 
-    local table_count=$(psql \
+    local table_count
+    table_count=$(psql \
         -h "${POSTGRES_HOST}" \
         -p "${POSTGRES_PORT}" \
         -U "${POSTGRES_USER}" \
@@ -260,7 +263,8 @@ verify_restore() {
         -U "${POSTGRES_USER}" \
         -d "${POSTGRES_DB}" \
         -tAc "SELECT 1 FROM information_schema.tables WHERE table_name = 'alembic_version'" | grep -q 1; then
-        local migration_version=$(psql \
+        local migration_version
+        migration_version=$(psql \
             -h "${POSTGRES_HOST}" \
             -p "${POSTGRES_PORT}" \
             -U "${POSTGRES_USER}" \
@@ -327,7 +331,8 @@ main() {
             fi
             check_requirements
             verify_connection
-            local backup_file=$(download_from_s3 "$1")
+            local backup_file
+            backup_file=$(download_from_s3 "$1")
             do_restore "${backup_file}"
             verify_restore
             ;;

--- a/infra/secrets/README.md
+++ b/infra/secrets/README.md
@@ -75,11 +75,30 @@ This directory contains configuration and utilities for managing secrets in prod
 
 Both AWS Secrets Manager and Vault support automatic secret rotation. Configure rotation policies according to your security requirements.
 
+### External Provider Service Accounts
+
+Use dedicated company-controlled service accounts for external data providers.
+Do not use a personal employee account for production integrations.
+
+For Singapore OneMap:
+
+- Register a dedicated OneMap account, for example
+  `capture-onemap@yourcompany.com`.
+- Store `ONEMAP_EMAIL` and `ONEMAP_PASSWORD` in the production secret manager.
+- Let the backend mint and cache OneMap access tokens. OneMap tokens are
+  short-lived and should not be treated as permanent deployment secrets.
+- Keep `ONEMAP_ACCESS_TOKEN` for local debugging or emergency override only.
+- Never expose OneMap credentials or tokens to frontend bundles, browser
+  responses, analytics, or logs.
+- Rotate the OneMap password when operator access changes, after suspected
+  exposure, and on the regular external-provider rotation schedule.
+
 ### Recommended Rotation Periods
 
 | Secret Type | Rotation Period |
 |-------------|-----------------|
 | Database passwords | 30 days |
 | API keys | 90 days |
+| External provider service-account passwords | 90 days |
 | JWT secrets | 180 days |
 | SSL certificates | Before expiry |


### PR DESCRIPTION
## Summary
- route Singapore Capture analysis through backend OneMap geocoding
- show the actual analysis coordinates and source used for zoning
- support server-side OneMap token minting from deployment secrets
- add conservative same-street interpolation for missing OneMap address points
- document OneMap credential handling and add regression coverage

## Validation
- .venv/bin/pytest -q backend/tests/services/test_geocoding_service.py
- npx vitest run src/app/pages/capture/hooks/__tests__/useUnifiedCapture.test.tsx src/app/pages/capture/UnifiedCapturePage.test.tsx
- pre-commit hooks during commit